### PR TITLE
fix: Linux安装脚本适配最新的协议检查机制

### DIFF
--- a/run_debian12.sh
+++ b/run_debian12.sh
@@ -188,10 +188,10 @@ update_config() {
 
 check_eula() {
     # 首先计算当前EULA的MD5值
-    current_md5=$(md5sum ${INSTALL_DIR}/repo/EULA.md | awk '{print $1}')
+    current_md5=$(md5sum "${INSTALL_DIR}/repo/EULA.md" | awk '{print $1}')
 
     # 首先计算当前隐私条款文件的哈希值
-    current_md5_privacy=$(md5sum ${INSTALL_DIR}/repo/PRIVACY.md | awk '{print $1}')
+    current_md5_privacy=$(md5sum "${INSTALL_DIR}/repo/PRIVACY.md" | awk '{print $1}')
 
     # 检查eula.confirmed文件是否存在
     if [[ -f ${INSTALL_DIR}/repo/eula.confirmed ]]; then
@@ -393,10 +393,10 @@ run_installation() {
     echo -e "${GREEN}同意协议...${RESET}"
 
     # 首先计算当前EULA的MD5值
-    current_md5=$(md5sum repo/EULA.md | awk '{print $1}')
+    current_md5=$(md5sum "repo/EULA.md" | awk '{print $1}')
 
     # 首先计算当前隐私条款文件的哈希值
-    current_md5_privacy=$(md5sum repo/PRIVACY.md | awk '{print $1}')
+    current_md5_privacy=$(md5sum "repo/PRIVACY.md" | awk '{print $1}')
 
     echo $current_md5 > repo/eula.confirmed
     echo $current_md5_privacy > repo/privacy.confirmed

--- a/run_debian12.sh
+++ b/run_debian12.sh
@@ -186,6 +186,42 @@ update_config() {
     fi
 }
 
+check_eula() {
+    # 首先计算当前EULA的MD5值
+    current_md5=$(md5sum ${INSTALL_DIR}/repo/EULA.md | awk '{print $1}')
+
+    # 首先计算当前隐私条款文件的哈希值
+    current_md5_privacy=$(md5sum ${INSTALL_DIR}/repo/PRIVACY.md | awk '{print $1}')
+
+    # 检查eula.confirmed文件是否存在
+    if [[ -f repo/elua.confirmed ]]; then
+        # 如果存在则检查其中包含的md5与current_md5是否一致
+        confirmed_md5=$(cat ${INSTALL_DIR}/repo/elua.confirmed)
+    else
+        confirmed_md5=""
+    fi
+
+    # 检查privacy.confirmed文件是否存在
+    if [[ -f repo/privacy ]]; then
+        # 如果存在则检查其中包含的md5与current_md5是否一致
+        confirmed_md5_privacy=$(cat ${INSTALL_DIR}/repo/privacy.confirmed)
+    else
+        confirmed_md5_privacy=""
+    fi
+
+    # 如果EULA或隐私条款有更新，提示用户重新确认
+    if [[ $current_md5 != $confirmed_md5 || $current_md5_privacy != $confirmed_md5_privacy ]]; then
+        whiptail --title "📜 使用协议更新" --yesno "检测到麦麦Bot EULA或隐私条款已更新。\nhttps://github.com/SengokuCola/MaiMBot/blob/main/EULA.md\nhttps://github.com/SengokuCola/MaiMBot/blob/main/PRIVACY.md\n\n您是否同意上述协议？ \n\n " 12 70
+        if [[ $? -eq 0 ]]; then
+            echo $current_md5 > ${INSTALL_DIR}/repo/elua.confirmed
+            echo $current_md5_privacy > ${INSTALL_DIR}/repo/privacy.confirmed
+        else
+            exit 1
+        fi
+    fi
+
+}
+
 # ----------- 主安装流程 -----------
 run_installation() {
     # 1/6: 检测是否安装 whiptail
@@ -195,7 +231,7 @@ run_installation() {
     fi
 
     # 协议确认
-    if ! (whiptail --title "ℹ️ [1/6] 使用协议" --yes-button "我同意" --no-button "我拒绝" --yesno "使用麦麦Bot及此脚本前请先阅读ELUA协议\nhttps://github.com/SengokuCola/MaiMBot/blob/main/EULA.md\n\n您是否同意此协议？" 12 70); then
+    if ! (whiptail --title "ℹ️ [1/6] 使用协议" --yes-button "我同意" --no-button "我拒绝" --yesno "使用麦麦Bot及此脚本前请先阅读ELUA协议及隐私协议\nhttps://github.com/SengokuCola/MaiMBot/blob/main/EULA.md\nhttps://github.com/SengokuCola/MaiMBot/blob/main/PRIVACY.md\n\n您是否同意上述协议？" 12 70); then
         exit 1
     fi
 
@@ -355,7 +391,15 @@ run_installation() {
     pip install -r repo/requirements.txt
 
     echo -e "${GREEN}同意协议...${RESET}"
-    touch repo/elua.confirmed
+
+    # 首先计算当前EULA的MD5值
+    current_md5=$(md5sum repo/EULA.md | awk '{print $1}')
+
+    # 首先计算当前隐私条款文件的哈希值
+    current_md5_privacy=$(md5sum repo/PRIVACY.md | awk '{print $1}')
+
+    echo $current_md5 > repo/elua.confirmed
+    echo $current_md5_privacy > repo/privacy.confirmed
 
     echo -e "${GREEN}创建系统服务...${RESET}"
     cat > /etc/systemd/system/${SERVICE_NAME}.service <<EOF
@@ -408,9 +452,10 @@ EOF
     exit 1
 }
 
-# 如果已安装显示菜单
+# 如果已安装显示菜单，并检查协议是否更新
 if check_installed; then
     load_install_info
+    check_eula
     show_menu
 else
     run_installation

--- a/run_debian12.sh
+++ b/run_debian12.sh
@@ -161,8 +161,8 @@ switch_branch() {
 
     sed -i "s/^BRANCH=.*/BRANCH=${new_branch}/" /etc/maimbot_install.conf
     BRANCH="${new_branch}"
+    check_eula
     systemctl restart ${SERVICE_NAME}
-    touch "${INSTALL_DIR}/repo/elua.confirmed"
     whiptail --msgbox "✅ 已切换到分支 ${new_branch} 并重启服务！" 10 60
 }
 
@@ -194,9 +194,9 @@ check_eula() {
     current_md5_privacy=$(md5sum ${INSTALL_DIR}/repo/PRIVACY.md | awk '{print $1}')
 
     # 检查eula.confirmed文件是否存在
-    if [[ -f ${INSTALL_DIR}/repo/elua.confirmed ]]; then
+    if [[ -f ${INSTALL_DIR}/repo/eula.confirmed ]]; then
         # 如果存在则检查其中包含的md5与current_md5是否一致
-        confirmed_md5=$(cat ${INSTALL_DIR}/repo/elua.confirmed)
+        confirmed_md5=$(cat ${INSTALL_DIR}/repo/eula.confirmed)
     else
         confirmed_md5=""
     fi
@@ -213,7 +213,7 @@ check_eula() {
     if [[ $current_md5 != $confirmed_md5 || $current_md5_privacy != $confirmed_md5_privacy ]]; then
         whiptail --title "📜 使用协议更新" --yesno "检测到麦麦Bot EULA或隐私条款已更新。\nhttps://github.com/SengokuCola/MaiMBot/blob/main/EULA.md\nhttps://github.com/SengokuCola/MaiMBot/blob/main/PRIVACY.md\n\n您是否同意上述协议？ \n\n " 12 70
         if [[ $? -eq 0 ]]; then
-            echo $current_md5 > ${INSTALL_DIR}/repo/elua.confirmed
+            echo $current_md5 > ${INSTALL_DIR}/repo/eula.confirmed
             echo $current_md5_privacy > ${INSTALL_DIR}/repo/privacy.confirmed
         else
             exit 1
@@ -231,7 +231,7 @@ run_installation() {
     fi
 
     # 协议确认
-    if ! (whiptail --title "ℹ️ [1/6] 使用协议" --yes-button "我同意" --no-button "我拒绝" --yesno "使用麦麦Bot及此脚本前请先阅读ELUA协议及隐私协议\nhttps://github.com/SengokuCola/MaiMBot/blob/main/EULA.md\nhttps://github.com/SengokuCola/MaiMBot/blob/main/PRIVACY.md\n\n您是否同意上述协议？" 12 70); then
+    if ! (whiptail --title "ℹ️ [1/6] 使用协议" --yes-button "我同意" --no-button "我拒绝" --yesno "使用麦麦Bot及此脚本前请先阅读EULA协议及隐私协议\nhttps://github.com/SengokuCola/MaiMBot/blob/main/EULA.md\nhttps://github.com/SengokuCola/MaiMBot/blob/main/PRIVACY.md\n\n您是否同意上述协议？" 12 70); then
         exit 1
     fi
 
@@ -398,7 +398,7 @@ run_installation() {
     # 首先计算当前隐私条款文件的哈希值
     current_md5_privacy=$(md5sum repo/PRIVACY.md | awk '{print $1}')
 
-    echo $current_md5 > repo/elua.confirmed
+    echo $current_md5 > repo/eula.confirmed
     echo $current_md5_privacy > repo/privacy.confirmed
 
     echo -e "${GREEN}创建系统服务...${RESET}"

--- a/run_debian12.sh
+++ b/run_debian12.sh
@@ -194,7 +194,7 @@ check_eula() {
     current_md5_privacy=$(md5sum ${INSTALL_DIR}/repo/PRIVACY.md | awk '{print $1}')
 
     # 检查eula.confirmed文件是否存在
-    if [[ -f repo/elua.confirmed ]]; then
+    if [[ -f ${INSTALL_DIR}/repo/elua.confirmed ]]; then
         # 如果存在则检查其中包含的md5与current_md5是否一致
         confirmed_md5=$(cat ${INSTALL_DIR}/repo/elua.confirmed)
     else
@@ -202,7 +202,7 @@ check_eula() {
     fi
 
     # 检查privacy.confirmed文件是否存在
-    if [[ -f repo/privacy ]]; then
+    if [[ -f ${INSTALL_DIR}/repo/privacy.confirmed ]]; then
         # 如果存在则检查其中包含的md5与current_md5是否一致
         confirmed_md5_privacy=$(cat ${INSTALL_DIR}/repo/privacy.confirmed)
     else


### PR DESCRIPTION
<!-- 提交前必读 -->
- 🔴**当前项目处于重构阶段（2025.3.14-）**
- ✅ 接受：与main直接相关的Bug修复：提交到main-fix分支
- ⚠️ 冻结：所有新功能开发和非紧急重构

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
- 适配最新的协议检查方法
- 安装后运行时检查协议是否更新
7. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
![image](https://github.com/user-attachments/assets/3571a1e1-94f2-4040-9043-c4ba31834ac9)

- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修改了安装脚本，通过比较当前版本和已确认版本的 MD5 哈希值来检查 EULA（最终用户许可协议）和隐私政策的更新。如果检测到更改，脚本现在会提示用户重新接受协议。

杂项：
- 更新安装脚本以检查 EULA 和隐私政策的更新。
- 如果检测到更改，提示用户重新接受协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adapts the installation script to check for updates to the EULA and privacy policy by comparing MD5 hashes of the current and confirmed versions. The script now prompts users to re-accept the agreement if changes are detected.

Chores:
- Updates the installation script to check for EULA and privacy policy updates.
- Prompts users to re-accept the agreement if changes are detected.

</details>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修改了 Linux 安装脚本，通过比较当前版本和已确认版本的 MD5 哈希值来检查 EULA（最终用户许可协议）和隐私政策的更新。如果检测到更改，脚本现在会提示用户重新接受协议。

杂项：
- 更新安装脚本以检查 EULA 和隐私政策的更新。
- 如果检测到更改，提示用户重新接受协议。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adapts the Linux installation script to check for updates to the EULA and privacy policy by comparing MD5 hashes of the current and confirmed versions. The script now prompts users to re-accept the agreement if changes are detected.

Chores:
- Updates the installation script to check for EULA and privacy policy updates.
- Prompts users to re-accept the agreement if changes are detected.

</details>