### PR TITLE
戳一戳处理优化

### DIFF
--- a/emoji_reviewer.py
+++ b/emoji_reviewer.py
@@ -24,8 +24,11 @@ except ImportError:
         os.makedirs(log_dir, exist_ok=True)
     # 配置控制台输出格式
     logger.remove()  # 移除默认的处理器
-    logger.add(sys.stderr, format="{time:MM-DD HH:mm} | emoji_reviewer | {message}")  # 添加控制台输出
-    logger.add("logs/emoji_reviewer/{time:YYYY-MM-DD}.log", rotation="00:00", format="{time:MM-DD HH:mm} | emoji_reviewer | {message}")
+    logger.add(sys.stderr,
+                format="{time:MM-DD HH:mm} | emoji_reviewer | {message}")  # 添加控制台输出
+    logger.add("logs/emoji_reviewer/{time:YYYY-MM-DD}.log",
+                rotation="00:00",
+                format="{time:MM-DD HH:mm} | emoji_reviewer | {message}")
     logger.warning("检测到src.common.logger并未导入，将使用默认loguru作为日志记录器")
     logger.warning("如果你是用的是低版本(0.5.13)麦麦，请忽略此警告")
 # 忽略 gradio 版本警告
@@ -43,8 +46,8 @@ if os.path.exists(bot_config_path):
         except tomli.TOMLDecodeError as e:
             logger.critical(f"配置文件bot_config.toml填写有误，请检查第{e.lineno}行第{e.colno}处：{e.msg}")
             exit(1)
-        except KeyError as e:
-            logger.critical(f"配置文件bot_config.toml缺少model.embedding设置，请补充后再编辑表情包")
+        except KeyError :
+            logger.critical("配置文件bot_config.toml缺少model.embedding设置，请补充后再编辑表情包")
             exit(1)
 else:
     logger.critical(f"没有找到配置文件{bot_config_path}")
@@ -106,7 +109,7 @@ async def get_embedding(text):
             return embedding
         else:
             return f"网络错误{response.status_code}"
-    except:
+    except:  # noqa: E722
         return None
 
 
@@ -170,7 +173,7 @@ def on_select(evt: gr.SelectData, *tag_values):
     if new_index is None:
         emoji_show = None
         targets = []
-        for current_value, tag in zip(tag_values, tags.keys()):
+        for current_value in zip(tag_values, tags.keys()):
             if current_value:
                 neglect_update += 1
                 targets.append(False)
@@ -224,7 +227,9 @@ async def save_desc(desc):
             yield ["正在构建embedding，请勿关闭页面...", gr.update(interactive=False), gr.update(interactive=False)]
             embedding = await get_embedding(desc)
             if embedding is None or isinstance(embedding, str):
-                yield [f"<span style='color: red;'>获取embeddings失败！{embedding}</span>", gr.update(interactive=True), gr.update(interactive=True)]
+                yield [f"<span style='color: red;'>获取embeddings失败！{embedding}</span>",
+                        gr.update(interactive=True), 
+                        gr.update(interactive=True)]
             else:
                 e_id = emoji_show["_id"]
                 update_dict = {"$set": {"embedding": embedding, "description": desc}}
@@ -239,7 +244,9 @@ async def save_desc(desc):
                 logger.info(f'Update description and embeddings: {e_id}(hash={hash})')
                 yield ["保存完成", gr.update(value=desc, interactive=True), gr.update(interactive=True)]
         except Exception as e:
-            yield [f"<span style='color: red;'>出现异常: {e}</span>", gr.update(interactive=True), gr.update(interactive=True)]
+            yield [f"<span style='color: red;'>出现异常: {e}</span>", 
+                   gr.update(interactive=True), 
+                   gr.update(interactive=True)]
 
     else:
         yield ["没有选中表情包", gr.update()]
@@ -343,7 +350,7 @@ with gr.Blocks(title="MaimBot表情包审查器") as app:
     gallery.select(fn=on_select, inputs=list(tag_boxes.values()), outputs=[gallery, description, *tag_boxes.values()])
     revert_btn.click(fn=revert_desc, inputs=None, outputs=description)
     save_btn.click(fn=save_desc, inputs=description, outputs=[description_label, description, save_btn])
-    for k, v in tag_boxes.items():
+    for  v in tag_boxes.items():
         v.change(fn=change_tag, inputs=list(tag_boxes.values()), outputs=description_label)
     app.load(
         fn=update_gallery,

--- a/src/plugins/chat/bot.py
+++ b/src/plugins/chat/bot.py
@@ -44,6 +44,9 @@ chat_config = LogConfig(
 # 配置主程序日志格式
 logger = get_module_logger("chat_bot", config=chat_config)
 
+#处理重复戳一戳使用的字典
+last_poke_times = {}  # 格式: {group_id: last_timestamp}
+
 
 class ChatBot:
     def __init__(self):
@@ -154,7 +157,7 @@ class ChatBot:
             )
             # 开始思考的时间点
             thinking_time_point = round(time.time(), 2)
-            # logger.debug(f"开始思考的时间点: {thinking_time_point}")
+            logger.info(f"开始思考的时间点: {thinking_time_point}")
             think_id = "mt" + str(thinking_time_point)
             thinking_message = MessageThinking(
                 message_id=think_id,
@@ -294,9 +297,26 @@ class ChatBot:
             if event.group_id:
                 if event.group_id not in global_config.talk_allowed_groups:
                     return
+                
+            #保证bot在一分钟之内只响应一次戳一戳，防止群体戳bot导致的（呆滞）刷屏
+                current_time = time.time()
+                # 检查群号是否在字典中
+                if event.group_id in last_poke_times:
+                    last_time = last_poke_times[event.group_id]
+                    # 如果时间差小于60秒，直接返回
+                    if current_time - last_time < 60:
+                        return
+                    # 否则更新时间
+                    last_poke_times[event.group_id] = current_time
+                else:
+                    # 群号不在字典中，添加记录
+                    last_poke_times[event.group_id] = current_time
+
+
+
 
             raw_message = f"[戳了戳]{global_config.BOT_NICKNAME}"  # 默认类型
-            if info := event.model_extra["raw_info"]:
+            if info := event.raw_info:
                 poke_type = info[2].get("txt", "戳了戳")  # 戳戳类型，例如“拍一拍”、“揉一揉”、“捏一捏”
                 custom_poke_message = info[4].get("txt", "")  # 自定义戳戳消息，若不存在会为空字符串
                 raw_message = f"[{poke_type}]{global_config.BOT_NICKNAME}{custom_poke_message}"
@@ -418,11 +438,12 @@ class ChatBot:
         # 用户屏蔽,不区分私聊/群聊
         if event.user_id in global_config.ban_user_id:
             return
-
+        
         if isinstance(event, GroupMessageEvent):
             if event.group_id:
                 if event.group_id not in global_config.talk_allowed_groups:
                     return
+
 
         # 获取合并转发消息的详细信息
         forward_info = await bot.get_forward_msg(message_id=event.message_id)
@@ -433,17 +454,17 @@ class ChatBot:
         for node in messages:
             # 提取发送者昵称
             nickname = node["sender"].get("nickname", "未知用户")
-
+            
             # 递归处理消息内容
-            message_content = await self.process_message_segments(node["message"], layer=0)
-
+            message_content = await self.process_message_segments(node["message"],layer=0)
+            
             # 拼接为【昵称】+ 内容
             processed_messages.append(f"【{nickname}】{message_content}")
 
         # 组合所有消息
         combined_message = "\n".join(processed_messages)
         combined_message = f"合并转发消息内容：\n{combined_message}"
-
+        
         # 构建用户信息（使用转发消息的发送者）
         user_info = UserInfo(
             user_id=event.user_id,
@@ -455,7 +476,11 @@ class ChatBot:
         # 构建群聊信息（如果是群聊）
         group_info = None
         if isinstance(event, GroupMessageEvent):
-            group_info = GroupInfo(group_id=event.group_id, group_name=None, platform="qq")
+            group_info = GroupInfo(
+                group_id=event.group_id,
+                group_name=None,
+                platform="qq"
+            )
 
         # 创建消息对象
         message_cq = MessageRecvCQ(
@@ -470,19 +495,19 @@ class ChatBot:
         # 进入标准消息处理流程
         await self.message_process(message_cq)
 
-    async def process_message_segments(self, segments: list, layer: int) -> str:
+    async def process_message_segments(self, segments: list,layer:int) -> str:
         """递归处理消息段"""
         parts = []
         for seg in segments:
-            part = await self.process_segment(seg, layer + 1)
+            part = await self.process_segment(seg,layer+1)
             parts.append(part)
         return "".join(parts)
 
-    async def process_segment(self, seg: dict, layer: int) -> str:
+    async def process_segment(self, seg: dict , layer:int) -> str:
         """处理单个消息段"""
         seg_type = seg["type"]
-        if layer > 3:
-            # 防止有那种100层转发消息炸飞麦麦
+        if layer > 3 :
+            #防止有那种100层转发消息炸飞麦麦
             return "【转发消息】"
         if seg_type == "text":
             return seg["data"]["text"]
@@ -499,14 +524,13 @@ class ChatBot:
             nested_messages.append("合并转发消息内容：")
             for node in nested_nodes:
                 nickname = node["sender"].get("nickname", "未知用户")
-                content = await self.process_message_segments(node["message"], layer=layer)
+                content = await self.process_message_segments(node["message"],layer=layer)
                 # nested_messages.append('-' * layer)
                 nested_messages.append(f"{'--' * layer}【{nickname}】{content}")
             # nested_messages.append(f"{'--' * layer}合并转发第【{layer}】层结束")
             return "\n".join(nested_messages)
         else:
             return f"[{seg_type}]"
-
-
+        
 # 创建全局ChatBot实例
 chat_bot = ChatBot()

--- a/src/plugins/chat/emoji_manager.py
+++ b/src/plugins/chat/emoji_manager.py
@@ -398,7 +398,9 @@ class EmojiManager:
                     # 修复拼写错误
                     if "discription" in emoji:
                         desc = emoji["discription"]
-                        db.emoji.update_one({"_id": emoji["_id"]}, {"$unset": {"discription": ""}, "$set": {"description": desc}})
+                        db.emoji.update_one({"_id": emoji["_id"]}, 
+                                            {"$unset": {"discription": ""}, 
+                                             "$set": {"description": desc}})
 
                 except Exception as item_error:
                     logger.error(f"[错误] 处理表情包记录时出错: {str(item_error)}")


### PR DESCRIPTION
保证bot在一分钟之内只响应一次戳一戳，防止群体戳bot导致的（呆滞）刷屏

<!-- 提交前必读 -->
- 🔴**当前项目处于重构阶段（2025.3.14-）**
- ✅ 接受：与main直接相关的Bug修复：提交到main-fix分支
- ⚠️ 冻结：所有新功能开发和非紧急重构

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
  保证bot在一分钟之内只响应一次戳一戳，防止群体戳bot导致的（呆滞）刷屏
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

为 poke 事件实施速率限制，以防止机器人泛滥。现在，机器人每分钟每个群组只会响应一次 poke 事件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement rate limiting for poke events to prevent bot flooding. The bot will now only respond to a poke event once per minute per group.

</details>