### PR TITLE
deploy_windows 中的序号问题

### DIFF
--- a/docs/manual_deploy_windows.md
+++ b/docs/manual_deploy_windows.md
@@ -75,22 +75,22 @@ conda activate maimbot
 pip install -r requirements.txt
 ```
 
-### 2️⃣ **然后你需要启动MongoDB数据库，来存储信息**
+### 3️⃣ **然后你需要启动MongoDB数据库，来存储信息**
 
 - 安装并启动MongoDB服务
 - 默认连接本地27017端口
 
-### 3️⃣ **配置NapCat，让麦麦bot与qq取得联系**
+### 4️⃣ **配置NapCat，让麦麦bot与qq取得联系**
 
 - 安装并登录NapCat（用你的qq小号）
 - 添加反向WS: `ws://127.0.0.1:8080/onebot/v11/ws`
 
-### 4️⃣ **配置文件设置，让麦麦Bot正常工作**
+### 5️⃣ **配置文件设置，让麦麦Bot正常工作**
 
 - 修改环境配置文件：`.env.prod`
 - 修改机器人配置文件：`bot_config.toml`
 
-### 5️⃣ **启动麦麦机器人**
+### 6️⃣ **启动麦麦机器人**
 
 - 打开命令行，cd到对应路径
 
@@ -104,7 +104,7 @@ nb run
 python bot.py
 ```
 
-### 6️⃣ **其他组件(可选)**
+### 7️⃣ **其他组件(可选)**
 
 - `run_thingking.bat`: 启动可视化推理界面（未完善）
 - 直接运行 knowledge.py生成知识库


### PR DESCRIPTION
- 🔴**当前项目处于重构阶段（2025.3.14-）**
- ✅ 接受：与 main 直接相关的 Bug 修复：提交到 main-fix 分支
- ⚠️ 冻结：所有新功能开发和非紧急重构

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加 group_id 字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息

> [!Note]
> 先前 windows 系统部署手册（`.\docs/manual_deploy_windows.md`）中有两个序号为 2️⃣ 的标题
> ```md
> ### 2️⃣ **创建Python虚拟环境来运行程序**
> ### 2️⃣ **然后你需要启动MongoDB数据库，来存储信息**
> ```

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复:
- 修正了 Windows 部署手册中的编号，以确保每个步骤都清晰排序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Corrects the numbering in the Windows deployment manual to ensure each step is clearly sequenced.

</details>