### PR TITLE
增加一个意愿降低时被@或被提及也能必定回复的功能

### DIFF
--- a/src/plugins/chat/bot.py
+++ b/src/plugins/chat/bot.py
@@ -135,15 +135,23 @@ class ChatBot:
 
         await self.storage.store_message(message, chat, topic[0] if topic else None)
 
-        is_mentioned = is_mentioned_bot_in_message(message)
-        reply_probability = await willing_manager.change_reply_willing_received(
-            chat_stream=chat,
-            is_mentioned_bot=is_mentioned,
-            config=global_config,
-            is_emoji=message.is_emoji,
-            interested_rate=interested_rate,
-            sender_id=str(message.message_info.user_info.user_id),
-        )
+        if ( f"[CQ:at,qq={global_config.BOT_QQ},name=" in message_cq.raw_message ) and global_config.at_bot_inevitable_reply:
+            reply_probability = 1
+            logger.info(f"被@，回复概率设置为100%")
+        else:
+            is_mentioned = is_mentioned_bot_in_message(message)
+            if is_mentioned and global_config.metioned_bot_inevitable_reply:
+                reply_probability = 1
+                logger.info(f"被提及，回复概率设置为100%")
+            else:
+                reply_probability = await willing_manager.change_reply_willing_received(
+                    chat_stream=chat,
+                    is_mentioned_bot=is_mentioned,
+                    config=global_config,
+                    is_emoji=message.is_emoji,
+                    interested_rate=interested_rate,
+                    sender_id=str(message.message_info.user_info.user_id),
+                )
         
         if global_config.enable_think_flow:
             current_willing_old = willing_manager.get_willing(chat_stream=chat)

--- a/src/plugins/chat/config.py
+++ b/src/plugins/chat/config.py
@@ -58,7 +58,9 @@ class BotConfig:
     response_interested_rate_amplifier: float = 1.0  # 回复兴趣度放大系数
     down_frequency_rate: float = 3  # 降低回复频率的群组回复意愿降低系数
     emoji_response_penalty: float = 0.0  # 表情包回复惩罚
-    
+    metioned_bot_inevitable_reply: bool = False  # 提及 bot 必然回复
+    at_bot_inevitable_reply: bool = False  # @bot 必然回复
+
     # response
     MODEL_R1_PROBABILITY: float = 0.8  # R1模型概率
     MODEL_V3_PROBABILITY: float = 0.1  # V3模型概率
@@ -261,6 +263,10 @@ class BotConfig:
                 config.down_frequency_rate = willing_config.get("down_frequency_rate", config.down_frequency_rate)
                 config.emoji_response_penalty = willing_config.get(
                     "emoji_response_penalty", config.emoji_response_penalty)
+                config.metioned_bot_inevitable_reply = willing_config.get(
+                    "metioned_bot_inevitable_reply", config.metioned_bot_inevitable_reply)
+                config.at_bot_inevitable_reply = willing_config.get(
+                    "at_bot_inevitable_reply", config.at_bot_inevitable_reply)
                 
         def model(parent: dict):
             # 加载模型配置

--- a/template/bot_config_template.toml
+++ b/template/bot_config_template.toml
@@ -68,6 +68,8 @@ response_willing_amplifier = 1 # 麦麦回复意愿放大系数，一般为1
 response_interested_rate_amplifier = 1 # 麦麦回复兴趣度放大系数,听到记忆里的内容时放大系数
 down_frequency_rate = 3 # 降低回复频率的群组回复意愿降低系数 除法
 emoji_response_penalty = 0.1 # 表情包回复惩罚系数，设为0为不回复单个表情包，减少单独回复表情包的概率
+metioned_bot_inevitable_reply = false # 提及 bot 必然回复
+at_bot_inevitable_reply = false # @bot 必然回复
 
 [response]
 model_r1_probability = 0.8 # 麦麦回答时选择主要回复模型1 模型的概率


### PR DESCRIPTION
<!-- 提交前必读 -->
- 🔴**当前项目处于重构阶段（2025.3.14-）**
- ✅ 接受：与main直接相关的Bug修复：提交到main-fix分支
- ⚠️ 冻结：所有新功能开发和非紧急重构

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
配置文件增加`at_bot_inevitable_reply`和`metioned_bot_inevitable_reply`项，用于开关是否被@/提及必然回复，不考虑回复意愿。
7. 请简要说明本次更新的内容和目的：
增加一个意愿降低时被@或被提及也能必定回复的功能
# 其他信息
- **关联 Issue**：Close #579 
- **截图/GIF**：
- **附加信息**:
