### PR TITLE
fix(think_flow_demo): 使用 global_config 替代 BotConfig，修复自定义人格读取问题

### DIFF
--- a/src/think_flow_demo/current_mind.py
+++ b/src/think_flow_demo/current_mind.py
@@ -2,7 +2,7 @@ from .outer_world import outer_world
 import asyncio
 from src.plugins.moods.moods import MoodManager
 from src.plugins.models.utils_model import LLM_request
-from src.plugins.chat.config import global_config, BotConfig
+from src.plugins.chat.config import global_config
 import re
 import time
 from src.plugins.schedule.schedule_generator import bot_schedule
@@ -37,7 +37,7 @@ class SubHeartflow:
         if not self.current_mind:
             self.current_mind = "你什么也没想"
             
-        self.personality_info = " ".join(BotConfig.PROMPT_PERSONALITY)
+        self.personality_info = " ".join(global_config.PROMPT_PERSONALITY)
     
     def assign_observe(self,stream_id):
         self.outer_world = outer_world.get_world_by_stream_id(stream_id)

--- a/src/think_flow_demo/heartflow.py
+++ b/src/think_flow_demo/heartflow.py
@@ -1,7 +1,7 @@
 from .current_mind import SubHeartflow
 from src.plugins.moods.moods import MoodManager
 from src.plugins.models.utils_model import LLM_request
-from src.plugins.chat.config import global_config, BotConfig
+from src.plugins.chat.config import global_config
 from src.plugins.schedule.schedule_generator import bot_schedule
 import asyncio
 from src.common.logger import get_module_logger, LogConfig, HEARTFLOW_STYLE_CONFIG # noqa: E402
@@ -46,7 +46,7 @@ class Heartflow:
         logger.info("麦麦大脑袋转起来了")
         self.current_state.update_current_state_info()
         
-        personality_info = " ".join(BotConfig.PROMPT_PERSONALITY)
+        personality_info = " ".join(global_config.PROMPT_PERSONALITY)
         current_thinking_info = self.current_mind
         mood_info = self.current_state.mood
         related_memory_info = 'memory'
@@ -91,7 +91,7 @@ class Heartflow:
         return await self.minds_summary(sub_minds)
     
     async def minds_summary(self,minds_str):
-        personality_info = " ".join(BotConfig.PROMPT_PERSONALITY)
+        personality_info = " ".join(global_config.PROMPT_PERSONALITY)
         mood_info = self.current_state.mood
         
         prompt = ""


### PR DESCRIPTION
<!-- 提交前必读 -->
- 🔴**当前项目处于重构阶段（2025.3.14-）**
- ✅ 接受：与main直接相关的Bug修复：提交到main-fix分支
- ⚠️ 冻结：所有新功能开发和非紧急重构

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #598 
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的pull request总结：

## Sourcery 总结

将 BotConfig 替换为 global_config 以进行个性化配置，从而修复自定义个性读取问题

Bug 修复：
- 通过从 BotConfig 切换到 global_config，解决了读取自定义个性化配置的问题

增强功能：
- 通过使用集中式全局配置，简化了个性化信息的检索

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace BotConfig with global_config for personality configuration to fix custom personality reading issues

Bug Fixes:
- Resolved the problem with reading custom personality configurations by switching from BotConfig to global_config

Enhancements:
- Simplified personality information retrieval by using a centralized global configuration

</details>