### PR TITLE
修复接收部分卡片消息错误的bug

### DIFF
--- a/src/plugins/chat/message.py
+++ b/src/plugins/chat/message.py
@@ -79,7 +79,10 @@ class MessageRecv(Message):
 
         if message_segment.get("data", "") == "[json]":
             # 提取json消息中的展示信息
-            pattern = r"\[CQ:json,data=(?P<json_data>.+?)\]"
+            pattern = re.compile(
+                r"\[CQ:json,data=(?P<json_data>.+?)\]",
+                re.DOTALL
+            )
             match = re.search(pattern, message_dict.get("raw_message", ""))
             raw_json = html.unescape(match.group("json_data"))
             try:


### PR DESCRIPTION
<!-- 提交前必读 -->
- 🔴**当前项目处于重构阶段（2025.3.14-）**
- ✅ 接受：与main直接相关的Bug修复：提交到main-fix分支
- ⚠️ 冻结：所有新功能开发和非紧急重构

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
修复接收部分卡片消息（小程序）错误的bug。
# 其他信息
- **关联 Issue**：https://github.com/MaiM-with-u/MaiBot/issues/614
- **截图/GIF**：
- **附加信息**: 
该bug由接收卡片消息时，在`src/plugins/chat/message.py:83`中，由于iOS端发送的消息`raw_message`中含有换行符，导致`re.search`无法正常工作而导致。加入`re.DOTALL`可以避免这一问题。

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 修复了当原始消息包含换行符时，JSON 卡片消息的正则表达式匹配问题，通过添加 `re.DOTALL` 标志解决。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve issue with regex matching for JSON card messages when raw message contains newline characters by adding re.DOTALL flag

</details>