### PR TITLE
Fix:配置文件不存在的时候先创建目录，否则复制文件的时候报：FileNotFoundError

### DIFF
--- a/src/plugins/config/config.py
+++ b/src/plugins/config/config.py
@@ -43,6 +43,8 @@ def update_config():
     # 检查配置文件是否存在
     if not old_config_path.exists():
         logger.info("配置文件不存在，从模板创建新配置")
+        #创建文件夹
+        old_config_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy2(template_path, old_config_path)
         logger.info(f"已创建新配置文件，请填写后重新运行: {old_config_path}")
         # 如果是新创建的配置文件,直接返回


### PR DESCRIPTION
…指定的路径。

<!-- 提交前必读 -->
- 🔴**当前项目处于重构阶段（2025.3.14-）**
- ✅ 接受：与main直接相关的Bug修复：提交到main-fix分支
- ⚠️ 冻结：所有新功能开发和非紧急重构

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:配置文件不存在的时候先创建目录，否则复制文件的时候报错：FileNotFoundError: [WinError 3] 系统找不到指定的路径。
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复:
- 增加在复制配置文件之前的目录创建步骤，以处理配置目录不存在的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add directory creation step before copying configuration file to handle cases where the configuration directory does not exist

</details>