### PR TITLE
端口应为8000

### DIFF
--- a/template/template.env
+++ b/template/template.env
@@ -1,5 +1,5 @@
 HOST=127.0.0.1
-PORT=8080
+PORT=8000
 
 # 插件配置
 PLUGINS=["src2.plugins.chat"]


### PR DESCRIPTION
<!-- 提交前必读 -->
- 🔴**当前项目处于重构阶段（2025.3.14-）**
- ✅ 接受：与main直接相关的Bug修复：提交到main-fix分支
- ⚠️ 冻结：所有新功能开发和非紧急重构

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
   8080应该留给nonebot用作websocket连接，默认的port应为8000
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

## Summary by Sourcery

增强功能：
- 更新环境模板中的默认端口，将端口 8080 改为 8000

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update the default port in the environment template to use port 8000 instead of 8080

</details>