### PR TITLE
vol(docker-compose): 调整数据卷挂载路径并增加配置文件持久化

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,10 @@ services:
     ports:
       - "18002:18002"
     volumes:
-      - ./docker-config/adapters/plugins:/adapters/src/plugins # 持久化adapters
+      - ./docker-config/adapters/config.py:/adapters/src/plugins/nonebot_plugin_maibot_adapters/config.py # 持久化adapters配置文件
       - ./docker-config/adapters/.env:/adapters/.env # 持久化adapters配置文件
       - ./data/qq:/app/.config/QQ # 持久化QQ本体并同步qq表情和图片到adapters
+      - ./data/MaiMBot:/adapters/data
     restart: always
     depends_on:
       - mongodb
@@ -61,7 +62,7 @@ services:
     volumes:
       - ./docker-config/napcat:/app/napcat/config # 持久化napcat配置文件
       - ./data/qq:/app/.config/QQ # 持久化QQ本体并同步qq表情和图片到adapters
-      - ./data/MaiMBot:/MaiMBot/data # NapCat 和 NoneBot 共享此卷，否则发送图片会有问题
+      - ./data/MaiMBot:/adapters/data # NapCat 和 NoneBot 共享此卷，否则发送图片会有问题
     container_name: maim-bot-napcat
     restart: always
     image: mlikiowa/napcat-docker:latest


### PR DESCRIPTION
-增加 adapters 配置文件持久化挂载
- 修改 MaiMBot 数据挂载路径以适配 NapCat 和 NoneBot 共享
- 更新 NapCat 容器的数据卷挂载路径

<!-- 提交前必读 -->
- 🔴**当前项目处于重构阶段（2025.3.14-）**
- ✅ 接受：与main直接相关的Bug修复：提交到main-fix分支
- ⚠️ 冻结：所有新功能开发和非紧急重构

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [ ] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [ ] 本次更新是否经过测试
4. - [ ] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

调整 Docker 卷挂载路径并改进 MaiMBot 项目的配置文件持久性

增强功能：
- 更新数据卷配置，以提高文件持久性和跨容器兼容性

部署：
- 修改 Docker 卷挂载路径，以确保 NapCat 和 NoneBot 容器之间的数据一致共享

杂务：
- 在 docker-compose.yml 中标准化数据和配置文件挂载路径

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust Docker volume mounting paths and improve configuration file persistence for MaiMBot project

Enhancements:
- Update data volume configurations to improve file persistence and cross-container compatibility

Deployment:
- Modify Docker volume mounting paths to ensure consistent data sharing between NapCat and NoneBot containers

Chores:
- Standardize data and configuration file mounting paths in docker-compose.yml

</details>