### PR TITLE
ci(docker): 更新 Docker镜像构建和推送配置

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Clone maim_message (refactor branch only)
+      - name: Clone maim_message
         run: git clone https://github.com/MaiM-with-u/maim_message maim_message
 
       - name: Set up Docker Buildx
@@ -44,7 +44,7 @@ jobs:
             echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot:classical,${{ secrets.DOCKERHUB_USERNAME }}/maimbot:classical-$(date -u +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref }}" == "refs/heads/dev" ]; then
             echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot:dev,${{ secrets.DOCKERHUB_USERNAME }}/maimbot:dev-$(date -u +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref }}" == "refs/heads/knowledge" ]; then 
+          elif [ "${{ github.ref }}" == "refs/heads/new_knowledge" ]; then 
             echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot:knowledge,${{ secrets.DOCKERHUB_USERNAME }}/maimbot:knowledge-$(date -u +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - main
-      - main-fix
-      - refactor  # 新增 refactor 分支触发
+      - classical
+      - dev
+      - new_knowledge
     tags:
       - 'v*'
   workflow_dispatch:
@@ -21,7 +22,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Clone maim_message (refactor branch only)
-        if: github.ref == 'refs/heads/refactor'  # 仅 refactor 分支执行
         run: git clone https://github.com/MaiM-with-u/maim_message maim_message
 
       - name: Set up Docker Buildx
@@ -39,11 +39,13 @@ jobs:
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
             echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot:${{ github.ref_name }},${{ secrets.DOCKERHUB_USERNAME }}/maimbot:latest" >> $GITHUB_OUTPUT
           elif [ "${{ github.ref }}" == "refs/heads/main" ]; then
-            echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot:main,${{ secrets.DOCKERHUB_USERNAME }}/maimbot:latest" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref }}" == "refs/heads/main-fix" ]; then
-            echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot:main-fix" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref }}" == "refs/heads/refactor" ]; then  # 新增 refactor 分支处理
-            echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot:refactor,${{ secrets.DOCKERHUB_USERNAME }}/maimbot:refactor$(date -u +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
+            echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot:main,${{ secrets.DOCKERHUB_USERNAME }}/maimbot:main-$(date -u +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref }}" == "refs/heads/classical" ]; then
+            echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot:classical,${{ secrets.DOCKERHUB_USERNAME }}/maimbot:classical-$(date -u +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref }}" == "refs/heads/dev" ]; then
+            echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot:dev,${{ secrets.DOCKERHUB_USERNAME }}/maimbot:dev-$(date -u +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
+          elif [ "${{ github.ref }}" == "refs/heads/knowledge" ]; then 
+            echo "tags=${{ secrets.DOCKERHUB_USERNAME }}/maimbot:knowledge,${{ secrets.DOCKERHUB_USERNAME }}/maimbot:knowledge-$(date -u +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and Push Docker Image


### PR DESCRIPTION
- 移除仅在 refactor 分支执行的 maim_message 克隆步骤
- 更新分支标签配置:  - main 分支构建 main 和 main-时间戳 标签  - 新增 classical、dev 和 knowledge 分支的构建配置
- 删除 main-fix 和 refactor 分支的特殊处理逻辑

<!-- 提交前必读 -->
- 🔴**当前项目处于重构阶段（2025.3.14-）**
- ✅ 接受：与main直接相关的Bug修复：提交到main-fix分支
- ⚠️ 冻结：所有新功能开发和非紧急重构

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [ ] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [ ] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新 Docker 镜像构建和推送配置，以支持多个分支

CI:
- 修改 GitHub Actions 工作流程，以支持为多个分支（包括 main、classical、dev 和 knowledge 分支）构建 Docker 镜像
- 移除针对 refactor 和 main-fix 分支的特定分支条件逻辑
- 更新 Docker 镜像标签策略，为不同的分支添加基于时间戳的标签

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Docker image build and push configuration for multiple branches

CI:
- Modify GitHub Actions workflow to support building Docker images for multiple branches including main, classical, dev, and knowledge branches
- Remove branch-specific conditional logic for refactor and main-fix branches
- Update Docker image tagging strategy to include timestamp-based tags for different branches

</details>