### PR TITLE
修复PFC私聊发送消息失败

### DIFF
--- a/src/plugins/PFC/pfc.py
+++ b/src/plugins/PFC/pfc.py
@@ -821,7 +821,7 @@ class DirectMessageSender:
             if not end_point:
                 raise ValueError(f"未找到平台：{chat_stream.platform} 的url配置")
                 
-            await global_api.send_message(end_point, message_json)
+            await global_api.send_message_REST(end_point, message_json)
             
             # 存储消息
             await self.storage.store_message(message, message.chat_stream)


### PR DESCRIPTION
<!-- 提交前必读 -->
- 🔴**当前项目处于重构阶段（2025.3.14-）**
- ✅ 接受：与main直接相关的Bug修复：提交到main-fix分支
- ⚠️ 冻结：所有新功能开发和非紧急重构

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [x] 本次更新是否经过测试
4. - [x] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复:
- 修改 PFC 插件中的消息发送机制，使用 `send_message_REST` 代替 `send_message`，以解决私聊消息发送失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Modify the message sending mechanism in PFC plugin to use send_message_REST instead of send_message to resolve private chat message sending failures

</details>