### PR TITLE
flake: add scipy to dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,10 +18,11 @@
       devShells.default = pkgs.mkShell {
         name = "python-venv";
         venvDir = "./.venv";
-        buildInputs = [
-          pythonPackages.python
-          pythonPackages.venvShellHook
-          pythonPackages.numpy
+        buildInputs = with pythonPackages; [
+          python
+          venvShellHook
+          scipy
+          numpy
         ];
 
         postVenvCreation = ''


### PR DESCRIPTION
scipy relies on libstdc++.so and cannot be used directly with venv in nix environment. adding it to buildInputs solves this issue.

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [ ] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 本次更新 **包含破坏性变更**（如数据库结构变更、配置文件修改等）
3. - [ ] 本次更新是否经过测试
4. - [ ] 请**不要**在数据库中添加group_id字段，这会影响本项目对其他平台的兼容
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在 Nix 开发环境中添加 scipy 到项目依赖

新特性：
- 在项目的 Python 开发环境中包含了 scipy 包

增强：
- 更新了构建输入，以解决 Nix 环境中 scipy 的库兼容性问题

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add scipy to project dependencies in the Nix development environment

New Features:
- Included scipy package in the project's Python development environment

Enhancements:
- Updated build inputs to resolve library compatibility issues with scipy in a Nix environment

</details>