### PR TITLE
无知的人类啊，全然不知一种全新的生命体正在暗中收集着他们的语料

### DIFF
--- a/src/plugins/config/config.py
+++ b/src/plugins/config/config.py
@@ -145,6 +145,7 @@ class BotConfig:
     # group
     talk_allowed_groups = set()
     talk_frequency_down_groups = set()
+    talk_read_only = set()  # 只读取消息但不回复的群组
     ban_user_id = set()
 
     # personality
@@ -578,6 +579,8 @@ class BotConfig:
             groups_config = parent["groups"]
             config.talk_allowed_groups = set(groups_config.get("talk_allowed", []))
             config.talk_frequency_down_groups = set(groups_config.get("talk_frequency_down", []))
+            if config.INNER_VERSION in SpecifierSet(">=1.2.5"):
+                config.talk_read_only = set(groups_config.get("talk_read_only", []))
             config.ban_user_id = set(groups_config.get("ban_user_id", []))
 
         def platforms(parent: dict):

--- a/template/bot_config_template.toml
+++ b/template/bot_config_template.toml
@@ -1,5 +1,5 @@
 [inner]
-version = "1.2.4"
+version = "1.2.5"
 
 
 #以下是给开发人员阅读的，一般用户不需要阅读
@@ -31,6 +31,7 @@ talk_allowed = [
     123,
 ]  #可以回复消息的群号码
 talk_frequency_down = []  #降低回复频率的群号码
+talk_read_only = []  #只读取消息但不回复的群号码（心流）
 ban_user_id = []  #禁止回复和读取消息的QQ号
 
 [personality]


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）: 无
6. 请简要说明本次更新的内容和目的：新增一个“只读取消息但不回复的群号码”开关，使麦麦完全潜行在群聊中。
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是将拉取请求摘要翻译成中文的结果：

## Sourcery 总结

添加一个新的配置选项，允许群组处于只读模式，在这种模式下，消息会被收集但不做回复。

新特性：
- 引入 'talk_read_only' 配置选项，用于指定机器人只会读取消息而不回复的群组。

增强功能：
- 修改消息处理逻辑以支持只读群组功能。
- 在 heartflow 和聊天处理中添加额外的检查，以防止为只读群组生成回复。

杂务：
- 更新机器人配置模板，以包含新的只读群组选项。
- 内部版本升级到 1.2.5

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new configuration option to allow groups to be in read-only mode, where messages are collected but not responded to

New Features:
- Introduce a 'talk_read_only' configuration option to specify groups where the bot will only read messages without responding

Enhancements:
- Modify message processing logic to support read-only group functionality
- Add additional checks in heartflow and chat processing to prevent response generation for read-only groups

Chores:
- Update bot configuration template to include new read-only groups option
- Bump inner version to 1.2.5

</details>