### PR TITLE
添加消息统计对远古版本格式的支持

### DIFF
--- a/src/plugins/utils/statistic.py
+++ b/src/plugins/utils/statistic.py
@@ -142,12 +142,23 @@ class LLMStatistics:
             group_info = chat_info.get("group_info") if chat_info else {}
             # print(f"group_info: {group_info}")
             group_name = None
+            group_id = None
             if group_info:
                 group_id = f"g{group_info.get('group_id')}"
-                group_name = group_info.get("group_name", f"群{group_info.get('group_id')}")
+                group_name = group_info.get("group_name", f"群{group_id}")
             if user_info and not group_name:
                 group_id = f"u{user_info['user_id']}"
                 group_name = user_info["user_nickname"]
+            # 添加对远古版本格式的支持，防止炸飞
+            if group_id is None:
+                if "group_id" in doc:
+                    group_id = f"g{doc.get('group_id')}"
+                    group_name = doc.get("group_name", f"群{group_id}")
+                elif "user_id" in doc:
+                    group_id = f"g{doc.get('user_id')}"
+                    group_name = doc.get("user_nickname", "")
+                else:
+                    continue
             if self.name_dict.get(group_id):
                 if message_time > self.name_dict.get(group_id)[1]:
                     self.name_dict[group_id] = [group_name, message_time]


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
    防止远古版本的消息格式炸飞消息统计
    另外每次都把所有消息遍历一遍是不是有点浪费（
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

## Summary by Sourcery

添加对处理旧版消息格式中的消息统计的支持，以防止处理失败

错误修复：
- 通过为旧版消息文档格式添加后备处理来提高消息统计收集的稳健性

增强功能：
- 增强消息组识别逻辑以处理消息元数据中的变化

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for handling message statistics in legacy message formats to prevent processing failures

Bug Fixes:
- Improve robustness of message statistics collection by adding fallback handling for older message document formats

Enhancements:
- Enhance message group identification logic to handle variations in message metadata

</details>