### PR TITLE
fix: 修复【更好的表情包发送系统】（迫真）导致的颜文字消失问题

### DIFF
--- a/src/plugins/chat/utils.py
+++ b/src/plugins/chat/utils.py
@@ -324,11 +324,16 @@ def random_remove_punctuation(text: str) -> str:
 
 
 def process_llm_response(text: str) -> List[str]:
+    # 先保护颜文字
+    protected_text, kaomoji_mapping = protect_kaomoji(text)
+    logger.debug(f"保护颜文字后的文本: {protected_text}")
     # 提取被 () 或 [] 包裹的内容
     pattern = re.compile(r"[\(\[].*?[\)\]]")
-    _extracted_contents = pattern.findall(text)
+    # _extracted_contents = pattern.findall(text)
+    _extracted_contents = pattern.findall(protected_text) # 在保护后的文本上查找
     # 去除 () 和 [] 及其包裹的内容
-    cleaned_text = pattern.sub("", text)
+    # cleaned_text = pattern.sub("", text)
+    cleaned_text = pattern.sub("", protected_text)
     logger.debug(f"{text}去除括号处理后的文本: {cleaned_text}")
 
     # 对清理后的文本进行进一步处理
@@ -368,6 +373,8 @@ def process_llm_response(text: str) -> List[str]:
         return [f"{global_config.BOT_NICKNAME}不知道哦"]
 
     # sentences.extend(extracted_contents)
+    # 在所有句子处理完毕后，对包含占位符的列表进行恢复
+    sentences = recover_kaomoji(sentences, kaomoji_mapping)
 
     return sentences
 


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
> 这个 PR 修复了由 Commit 96ae2b4 引发的颜文字破损与消失问题，调整了 `process_llm_response` 函数的处理顺序，确保颜文字保护在括号移除之前执行，并将颜文字恢复步骤移至末尾。更多详情见issue #763 

# 其他信息
- **关联 Issue**：Close #763 
- **截图/GIF**：
- **附加信息**:
