### PR TITLE
修复PFC在3.12以下版本报错

### DIFF
--- a/src/plugins/PFC/action_planner.py
+++ b/src/plugins/PFC/action_planner.py
@@ -232,7 +232,8 @@ class ActionPlanner:
         prompt = f"""{persona_text}。现在你在参与一场QQ聊天，请根据以下【所有信息】审慎决策下一步行动，可以发言，可以等待，可以倾听，可以调取知识：
 
 【当前对话目标】
-{goals_str if goals_str.strip() else "- 目前没有明确对话目标，请考虑设定一个。\n"}
+{goals_str if goals_str.strip() else "- 目前没有明确对话目标，请考虑设定一个。"}
+
 
 【最近行动历史概要】
 {action_history_summary}
@@ -241,7 +242,8 @@ class ActionPlanner:
 【时间和超时提示】
 {time_since_last_bot_message_info}{timeout_context}
 【最近的对话记录】(包括你已成功发送的消息 和 新收到的消息)
-{chat_history_text if chat_history_text.strip() else "还没有聊天记录。\n"}
+{chat_history_text if chat_history_text.strip() else "还没有聊天记录。"}
+
 --- 行动决策指南 ---
 1.  **仔细分析【上一次行动的详细情况和结果】**。如果上次行动是 direct_reply 且因“内容与你上一条发言完全相同”或“高度相似”而被取消(status: recall)，那么【绝对不要】立即再次规划 direct_reply。在这种特定情况下，你应该优先考虑 wait (等待用户的新回应) 或 rethink_goal (如果对话似乎因此卡住了)。
 2.  结合【当前对话目标】和【最近的对话记录】来判断是否需要回应、回应什么。如果【最近的对话记录】中有新的用户消息，通常需要 direct_reply。如果上次行动成功，或者上次失败的原因不是重复，可以根据对话内容考虑 direct_reply。

--- a/src/plugins/chat/bot.py
+++ b/src/plugins/chat/bot.py
@@ -82,7 +82,7 @@ class ChatBot:
                 logger.debug(f"用户{userinfo.user_id}被禁止回复")
                 return
 
-            if groupinfo.group_id not in global_config.talk_allowed_groups:
+            if groupinfo != None and groupinfo.group_id not in global_config.talk_allowed_groups:
                 logger.debug(f"群{groupinfo.group_id}被禁止回复")
                 return
 


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
 - python 3.12 以下不支持在 f-string 中添加反斜杠，这里把反斜杠删掉了。
 - 私聊信息没有 group_info，增加判断 group_info 是否为空防止私聊爆炸。
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复了低于 3.12 的 Python 版本的兼容性问题，并为聊天处理中的群组信息添加了安全检查

Bug 修复:
- 通过删除反斜杠，解决了低于 3.12 的 Python 版本的 f-string 兼容性问题
- 为 `group_info` 添加了空值检查，以防止在私信期间发生错误

增强功能:
- 通过添加群组信息验证，改进了聊天消息处理中的错误处理

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix compatibility issues with Python versions below 3.12 and add safety checks for group information in chat processing

Bug Fixes:
- Resolved f-string compatibility issue for Python versions below 3.12 by removing backslashes
- Added a null check for group_info to prevent errors during private messaging

Enhancements:
- Improved error handling in chat message processing by adding group information validation

</details>