### PR TITLE
修复PFC最大重试次数，使其重新启用

### DIFF
--- a/src/plugins/PFC/reply_checker.py
+++ b/src/plugins/PFC/reply_checker.py
@@ -15,11 +15,11 @@ class ReplyChecker:
 
     def __init__(self, stream_id: str):
         self.llm = LLMRequest(
-            model=global_config.llm_PFC_reply_checker, temperature=0.55, max_tokens=1000, request_type="reply_check"
+            model=global_config.llm_PFC_reply_checker, temperature=0.50, max_tokens=1000, request_type="reply_check"
         )
         self.name = global_config.BOT_NICKNAME
         self.chat_observer = ChatObserver.get_instance(stream_id)
-        self.max_retries = 2  # 最大重试次数
+        self.max_retries = 3  # 最大重试次数
 
     async def check(
         self, reply: str, goal: str, chat_history: List[Dict[str, Any]], retry_count: int = 0
@@ -76,8 +76,10 @@ class ReplyChecker:
                         False,
                     )
 
-        except Exception as self_check_err:
-            logger.error(f"检查自身重复发言时出错: {self_check_err}")
+        except Exception as e:
+            import traceback
+            logger.error(f"检查回复时出错: 类型={type(e)}, 值={e}")
+            logger.error(traceback.format_exc()) # 打印详细的回溯信息
 
         for msg in chat_history[-20:]:
             time_str = datetime.datetime.fromtimestamp(msg["time"]).strftime("%H:%M:%S")


### PR DESCRIPTION
修复checker的最大重试次数，使其重新启用（似乎在之前所有版本中从来没有启用过？）达到最大重试次数自动wait，并且加入了更详细的reply_checker报错日志

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：防止因为reply_checker报错陷入高频率无限重试而消耗token
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是将拉取请求摘要翻译成中文的结果：

## Sourcery 总结

通过为生成合适的回复实现强大的重试策略，改进 PFC 插件中的回复生成和检查机制。

新特性：
- 当达到最大回复尝试次数时，添加自动等待动作
- 在回复生成期间提供更全面的错误跟踪

Bug 修复：
- 修复回复生成过程，通过引入多次尝试机制来处理初始回复不合适的情况
- 增强回复检查过程中的错误处理和日志记录

增强功能：
- 为回复生成实现可配置的最大重试次数
- 为回复生成和检查尝试添加更详细的日志记录
- 当回复生成持续失败时，引入回退等待机制

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the reply generation and checking mechanism in the PFC plugin by implementing a robust retry strategy for generating suitable replies

New Features:
- Add automatic wait action when maximum reply attempts are exhausted
- Provide more comprehensive error tracking during reply generation

Bug Fixes:
- Fix the reply generation process to handle cases where initial replies are not suitable by introducing a multi-attempt mechanism
- Enhance error handling and logging in the reply checking process

Enhancements:
- Implement a configurable maximum retry count for reply generation
- Add more detailed logging for reply generation and checking attempts
- Introduce a fallback wait mechanism when reply generation consistently fails

</details>