### PR TITLE
试图修复PFC开始对话实例时载入聊天记录缺失的bug

### DIFF
--- a/src/plugins/PFC/conversation.py
+++ b/src/plugins/PFC/conversation.py
@@ -1,7 +1,8 @@
 import time
 import asyncio
 import datetime
-from .message_storage import MongoDBMessageStorage
+# from .message_storage import MongoDBMessageStorage
+from src.plugins.utils.chat_message_builder import get_raw_msg_before_timestamp_with_chat
 from ...config.config import global_config
 from typing import Dict, Any
 from ..chat.message import Message
@@ -75,13 +76,10 @@ class Conversation:
             raise
         try:
             logger.info(f"为 {self.stream_id} 加载初始聊天记录...")
-            storage = MongoDBMessageStorage()  # 创建存储实例
-            # 获取当前时间点之前最多 N 条消息 (比如 30 条)
-            # get_messages_before 返回的是按时间正序排列的列表
-            initial_messages = await storage.get_messages_before(
+            initial_messages = await get_raw_msg_before_timestamp_with_chat( #
                 chat_id=self.stream_id,
-                time_point=time.time(),
-                limit=30,  # 加载最近20条作为初始上下文，可以调整
+                timestamp=time.time(),
+                limit=30,  # 加载最近30条作为初始上下文，可以调整
             )
             if initial_messages:
                 # 将加载的消息填充到 ObservationInfo 的 chat_history


### PR DESCRIPTION
开始对话示例时出现神秘bug导致聊天记录缺失（只有对方的没有bot的），经过高人指点将提取聊天记录方式改用chat_message_builder中的函数而不是storage

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [ ] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复:
- 解决了一个在加载 PFC 会话的初始聊天记录时，消息丢失的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve an issue where messages were missing when loading the initial chat history for a PFC conversation.

</details>