### PR TITLE
PFC 修复人设获取

### DIFF
--- a/src/plugins/PFC/action_planner.py
+++ b/src/plugins/PFC/action_planner.py
@@ -93,8 +93,7 @@ class ActionPlanner:
             max_tokens=1500,
             request_type="action_planning",
         )
-        self.personality_info = Individuality.get_instance().get_prompt(type="personality", x_person=2, level=3)
-        self.identity_detail_info = Individuality.get_instance().get_prompt(type="identity", x_person=2, level=2)
+        self.personality_info = Individuality.get_instance().get_prompt(x_person=2, level=3)
         self.name = global_config.BOT_NICKNAME
         self.private_name = private_name
         self.chat_observer = ChatObserver.get_instance(stream_id, private_name)
@@ -244,21 +243,7 @@ class ActionPlanner:
             chat_history_text = "处理聊天记录时出错。\n"
 
         # 构建 Persona 文本 (persona_text)
-        # (这部分逻辑不变)
-        identity_details_only = self.identity_detail_info
-        identity_addon = ""
-        if isinstance(identity_details_only, str):
-            pronouns = ["你", "我", "他"]
-            for p in pronouns:
-                if identity_details_only.startswith(p):
-                    identity_details_only = identity_details_only[len(p) :]
-                    break
-            if identity_details_only.endswith("。"):
-                identity_details_only = identity_details_only[:-1]
-            cleaned_details = identity_details_only.strip(",， ")
-            if cleaned_details:
-                identity_addon = f"并且{cleaned_details}"
-        persona_text = f"你的名字是{self.name}，{self.personality_info}{identity_addon}。"
+        persona_text = f"你的名字是{self.name}，{self.personality_info}。"
 
         # 构建行动历史和上一次行动结果 (action_history_summary, last_action_context)
         # (这部分逻辑不变)

--- a/src/plugins/PFC/conversation.py
+++ b/src/plugins/PFC/conversation.py
@@ -374,7 +374,7 @@ class Conversation:
                     f"[私聊][{self.private_name}]经过 {reply_attempt_count} 次尝试，追问回复决定打回动作决策。打回原因: {check_reason}"
                 )
                 conversation_info.done_action[action_index].update(
-                    {"status": "recall", "final_reason": f"追问尝试{reply_attempt_count}次后失败: {check_reason}"}
+                    {"status": "recall", "final_reason": f"追问尝试{reply_attempt_count}次后打回: {check_reason}"}
                 )
 
             else:
@@ -383,7 +383,7 @@ class Conversation:
                     f"[私聊][{self.private_name}]经过 {reply_attempt_count} 次尝试，未能生成合适的追问回复。最终原因: {check_reason}"
                 )
                 conversation_info.done_action[action_index].update(
-                    {"status": "recall", "final_reason": f"追问尝试{reply_attempt_count}次后打回: {check_reason}"}
+                    {"status": "recall", "final_reason": f"追问尝试{reply_attempt_count}次后失败: {check_reason}"}
                 )
                 # 重置状态: 追问失败，下次用初始 prompt
                 self.conversation_info.last_successful_reply_action = None

--- a/src/plugins/PFC/pfc.py
+++ b/src/plugins/PFC/pfc.py
@@ -23,8 +23,7 @@ class GoalAnalyzer:
             model=global_config.llm_normal, temperature=0.7, max_tokens=1000, request_type="conversation_goal"
         )
 
-        self.personality_info = Individuality.get_instance().get_prompt(type="personality", x_person=2, level=3)
-        self.identity_detail_info = Individuality.get_instance().get_prompt(type="identity", x_person=2, level=2)
+        self.personality_info = Individuality.get_instance().get_prompt(x_person=2, level=3)
         self.name = global_config.BOT_NICKNAME
         self.nick_name = global_config.BOT_ALIAS_NAMES
         self.private_name = private_name
@@ -79,21 +78,7 @@ class GoalAnalyzer:
 
             # await observation_info.clear_unprocessed_messages()
 
-        identity_details_only = self.identity_detail_info
-        identity_addon = ""
-        if isinstance(identity_details_only, str):
-            pronouns = ["你", "我", "他"]
-            for p in pronouns:
-                if identity_details_only.startswith(p):
-                    identity_details_only = identity_details_only[len(p) :]
-                    break
-            if identity_details_only.endswith("。"):
-                identity_details_only = identity_details_only[:-1]
-            cleaned_details = identity_details_only.strip(",， ")
-            if cleaned_details:
-                identity_addon = f"并且{cleaned_details}"
-
-        persona_text = f"你的名字是{self.name}，{self.personality_info}{identity_addon}。"
+        persona_text = f"你的名字是{self.name}，{self.personality_info}。"
         # 构建action历史文本
         action_history_list = conversation_info.done_action
         action_history_text = "你之前做的事情是："
@@ -241,21 +226,8 @@ class GoalAnalyzer:
             timestamp_mode="relative",
             read_mark=0.0,
         )
-        identity_details_only = self.identity_detail_info
-        identity_addon = ""
-        if isinstance(identity_details_only, str):
-            pronouns = ["你", "我", "他"]
-            for p in pronouns:
-                if identity_details_only.startswith(p):
-                    identity_details_only = identity_details_only[len(p) :]
-                    break
-            if identity_details_only.endswith("。"):
-                identity_details_only = identity_details_only[:-1]
-            cleaned_details = identity_details_only.strip(",， ")
-            if cleaned_details:
-                identity_addon = f"并且{cleaned_details}"
 
-        persona_text = f"你的名字是{self.name}，{self.personality_info}{identity_addon}。"
+        persona_text = f"你的名字是{self.name}，{self.personality_info}。"
         # ===> Persona 文本构建结束 <===
 
         # --- 修改 Prompt 字符串，使用 persona_text ---

--- a/src/plugins/PFC/reply_generator.py
+++ b/src/plugins/PFC/reply_generator.py
@@ -68,8 +68,7 @@ class ReplyGenerator:
             max_tokens=300,
             request_type="reply_generation",
         )
-        self.personality_info = Individuality.get_instance().get_prompt(type="personality", x_person=2, level=3)
-        self.identity_detail_info = Individuality.get_instance().get_prompt(type="identity", x_person=2, level=2)
+        self.personality_info = Individuality.get_instance().get_prompt(x_person=2, level=3)
         self.name = global_config.BOT_NICKNAME
         self.private_name = private_name
         self.chat_observer = ChatObserver.get_instance(stream_id, private_name)
@@ -130,20 +129,7 @@ class ReplyGenerator:
             chat_history_text = "还没有聊天记录。"
 
         # 构建 Persona 文本 (persona_text)
-        identity_details_only = self.identity_detail_info
-        identity_addon = ""
-        if isinstance(identity_details_only, str):
-            pronouns = ["你", "我", "他"]
-            for p in pronouns:
-                if identity_details_only.startswith(p):
-                    identity_details_only = identity_details_only[len(p) :]
-                    break
-            if identity_details_only.endswith("。"):
-                identity_details_only = identity_details_only[:-1]
-            cleaned_details = identity_details_only.strip(",， ")
-            if cleaned_details:
-                identity_addon = f"并且{cleaned_details}"
-        persona_text = f"你的名字是{self.name}，{self.personality_info}{identity_addon}。"
+        persona_text = f"你的名字是{self.name}，{self.personality_info}。"
 
         # --- 选择 Prompt ---
         if action_type == "send_new_message":


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
 - 修复人设获取失败导致pfc被炸飞的问题
 - 顺带解决了个 typo
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是将pull request总结翻译成中文的结果：

## Sourcery 总结

修复 PFC 组件中的角色获取问题并更正一个拼写错误。

Bug 修复：
- 更正了跨 PFC 组件的角色获取的方法调用，使用 `Individuality.get_instance().get_prompt`。
- 修复了在多次回复尝试失败后，在对话处理中回忆操作时状态消息中的拼写错误。

增强功能：
- 移除未使用的身份细节逻辑，并简化 PFC、Action Planner 和 Reply Generator 中的角色文本构建。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix persona acquisition in PFC components and correct a typo.

Bug Fixes:
- Correct the method call to `Individuality.get_instance().get_prompt` for persona acquisition across PFC components.
- Fix a typo in the status message within conversation handling when recalling an action after multiple failed reply attempts.

Enhancements:
- Remove unused identity detail logic and simplify persona text construction in PFC, Action Planner, and Reply Generator.

</details>