### PR TITLE
feat:增加PFC主动对话功能

### DIFF
--- a/src/plugins/PFC/conversation.py
+++ b/src/plugins/PFC/conversation.py
@@ -9,7 +9,7 @@ from src.plugins.utils.chat_message_builder import build_readable_messages, get_
 from typing import Dict, Any, Optional
 from ..chat.message import Message
 from .pfc_types import ConversationState
-from .pfc import ChatObserver, GoalAnalyzer
+from .pfc import ChatObserver, GoalAnalyzer, IdleConversationStarter
 from .message_sender import DirectMessageSender
 from src.common.logger_manager import get_logger
 from .action_planner import ActionPlanner
@@ -58,6 +58,7 @@ class Conversation:
             self.knowledge_fetcher = KnowledgeFetcher(self.private_name)
             self.waiter = Waiter(self.stream_id, self.private_name)
             self.direct_sender = DirectMessageSender(self.private_name)
+            self.idle_conversation_starter = IdleConversationStarter(self.stream_id, self.private_name)
 
             # 获取聊天流信息
             self.chat_stream = chat_manager.get_stream(self.stream_id)
@@ -116,6 +117,9 @@ class Conversation:
                 # 让 ChatObserver 从加载的最后一条消息之后开始同步
                 self.chat_observer.last_message_time = self.observation_info.last_message_time
                 self.chat_observer.last_message_read = last_msg  # 更新 observer 的最后读取记录
+
+                # 初始化空闲对话检测器的最后消息时间
+                self.idle_conversation_starter.update_last_message_time(self.observation_info.last_message_time)
             else:
                 logger.info(f"[私聊][{self.private_name}]没有找到初始聊天记录。")
 
@@ -124,6 +128,11 @@ class Conversation:
             # 出错也要继续，只是没有历史记录而已
         # 组件准备完成，启动该论对话
         self.should_continue = True
+
+        # 启动空闲对话检测器
+        self.idle_conversation_starter.start()
+        logger.info(f"[私聊][{self.private_name}]空闲对话检测器已启动")
+
         asyncio.create_task(self.start())
 
     async def start(self):
@@ -140,6 +149,10 @@ class Conversation:
         while self.should_continue:
             # 忽略逻辑
             if self.ignore_until_timestamp and time.time() < self.ignore_until_timestamp:
+                # 暂停空闲对话检测器，避免在忽略期间触发
+                if hasattr(self, 'idle_conversation_starter') and self.idle_conversation_starter._running:
+                    self.idle_conversation_starter.stop()
+                    logger.debug(f"[私聊][{self.private_name}]对话被暂时忽略，暂停空闲对话检测")
                 await asyncio.sleep(30)
                 continue
             elif self.ignore_until_timestamp and time.time() >= self.ignore_until_timestamp:
@@ -147,6 +160,12 @@ class Conversation:
                 self.ignore_until_timestamp = None
                 self.should_continue = False
                 continue
+            else:
+                # 确保空闲对话检测器在正常对话时是启动的
+                if hasattr(self, 'idle_conversation_starter') and not self.idle_conversation_starter._running:
+                    self.idle_conversation_starter.start()
+                    logger.debug(f"[私聊][{self.private_name}]恢复空闲对话检测")
+
             try:
                 # --- 在规划前记录当前新消息数量 ---
                 initial_new_message_count = 0
@@ -371,6 +390,9 @@ class Conversation:
                 self.conversation_info.last_successful_reply_action = "send_new_message"
                 action_successful = True  # 标记动作成功
 
+                # 更新最后消息时间，重置空闲检测计时器
+                self.idle_conversation_starter.update_last_message_time()
+
             elif need_replan:
                 # 打回动作决策
                 logger.warning(
@@ -474,6 +496,9 @@ class Conversation:
                 # 更新状态: 标记上次成功是 direct_reply
                 self.conversation_info.last_successful_reply_action = "direct_reply"
                 action_successful = True  # 标记动作成功
+
+                # 更新最后消息时间，重置空闲检测计时器
+                self.idle_conversation_starter.update_last_message_time()
 
             elif need_replan:
                 # 打回动作决策
@@ -699,3 +724,15 @@ class Conversation:
             )
         except Exception as e:
             logger.error(f"[私聊][{self.private_name}]发送超时消息失败: {str(e)}")
+
+    async def stop(self):
+        """停止对话处理"""
+        logger.info(f"[私聊][{self.private_name}]停止对话 {self.stream_id}")
+        self.should_continue = False
+
+        # 停止空闲对话检测器
+        if hasattr(self, 'idle_conversation_starter'):
+            self.idle_conversation_starter.stop()
+
+        if hasattr(self, 'chat_observer'):
+            self.chat_observer.stop()

--- a/src/plugins/PFC/pfc.py
+++ b/src/plugins/PFC/pfc.py
@@ -8,6 +8,13 @@ from src.individuality.individuality import Individuality
 from .conversation_info import ConversationInfo
 from .observation_info import ObservationInfo
 from src.plugins.utils.chat_message_builder import build_readable_messages
+import asyncio
+import time
+import random
+from .message_sender import DirectMessageSender
+from ..chat.chat_stream import ChatStream
+from maim_message import UserInfo
+from src.config.config import global_config
 from rich.traceback import install
 
 install(extra_lines=3)
@@ -37,6 +44,228 @@ def _calculate_similarity(goal1: str, goal2: str) -> float:
     total = len(words1.union(words2))
     return overlap / total if total > 0 else 0
 
+
+class IdleConversationStarter:
+    """长时间无对话主动发起对话的组件"""
+
+    def __init__(self, stream_id: str, private_name: str):
+        self.stream_id = stream_id
+        self.private_name = private_name
+        self.chat_observer = ChatObserver.get_instance(stream_id, private_name)
+        self.message_sender = DirectMessageSender(private_name)
+
+        # LLM请求对象，用于生成主动对话内容
+        self.llm = LLMRequest(
+            model=global_config.llm_normal, temperature=0.8, max_tokens=500, request_type="idle_conversation_starter"
+        )
+
+        # 个性化信息
+        self.personality_info = Individuality.get_instance().get_prompt(x_person=2, level=3)
+        self.name = global_config.BOT_NICKNAME
+        self.nick_name = global_config.BOT_ALIAS_NAMES
+
+        # 从配置文件读取配置参数，或使用默认值
+        self.enabled = getattr(global_config, 'idle_conversation', {}).get('enable_idle_conversation', True)
+        self.idle_check_interval = getattr(global_config, 'idle_conversation', {}).get('idle_check_interval', 10)
+        self.min_idle_time = getattr(global_config, 'idle_conversation', {}).get('min_idle_time', 60)
+        self.max_idle_time = getattr(global_config, 'idle_conversation', {}).get('max_idle_time', 120)
+
+        # 计算实际触发阈值（在min和max之间随机）
+        self.actual_idle_threshold = random.randint(self.min_idle_time, self.max_idle_time)
+
+        # 工作状态
+        self.last_message_time = time.time()
+        self._running = False
+        self._task = None
+
+    def start(self):
+        """启动空闲对话检测"""
+        # 如果功能被禁用，则不启动
+        if not self.enabled:
+            logger.info(f"[私聊][{self.private_name}]主动发起对话功能已禁用")
+            return
+
+        if self._running:
+            return
+
+        self._running = True
+        self._task = asyncio.create_task(self._check_idle_loop())
+        logger.info(f"[私聊][{self.private_name}]启动空闲对话检测，阈值设置为{self.actual_idle_threshold}秒")
+
+    def stop(self):
+        """停止空闲对话检测"""
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            self._task = None
+        logger.info(f"[私聊][{self.private_name}]停止空闲对话检测")
+
+    def update_last_message_time(self, message_time=None):
+        """更新最后一条消息的时间"""
+        self.last_message_time = message_time or time.time()
+        # 重新随机化下一次触发的时间阈值
+        self.actual_idle_threshold = random.randint(self.min_idle_time, self.max_idle_time)
+        logger.debug(
+            f"[私聊][{self.private_name}]更新最后消息时间: {self.last_message_time}，新阈值: {self.actual_idle_threshold}秒")
+
+    def reload_config(self):
+        """重新加载配置"""
+        # 从配置文件重新读取参数
+        self.enabled = getattr(global_config, 'idle_conversation', {}).get('enable_idle_conversation', True)
+        self.idle_check_interval = getattr(global_config, 'idle_conversation', {}).get('idle_check_interval', 10)
+        self.min_idle_time = getattr(global_config, 'idle_conversation', {}).get('min_idle_time', 7200)
+        self.max_idle_time = getattr(global_config, 'idle_conversation', {}).get('max_idle_time', 18000)
+        logger.debug(
+            f"[私聊][{self.private_name}]重新加载主动对话配置: 启用={self.enabled}, 检查间隔={self.idle_check_interval}秒, 最短间隔={self.min_idle_time}秒, 最长间隔={self.max_idle_time}秒")
+
+    async def _check_idle_loop(self):
+        """检查空闲状态的循环"""
+        try:
+            config_reload_counter = 0
+            config_reload_interval = 100  # 每100次检查重新加载一次配置
+
+            while self._running:
+                # 定期重新加载配置
+                config_reload_counter += 1
+                if config_reload_counter >= config_reload_interval:
+                    self.reload_config()
+                    config_reload_counter = 0
+
+                # 检查是否启用了主动对话功能
+                if not self.enabled:
+                    # 如果禁用了功能，就等待一段时间后再次检查配置
+                    await asyncio.sleep(self.idle_check_interval)
+                    continue
+
+                current_time = time.time()
+                idle_time = current_time - self.last_message_time
+
+                if idle_time >= self.actual_idle_threshold:
+                    logger.info(f"[私聊][{self.private_name}]检测到长时间({idle_time:.0f}秒)无对话，尝试主动发起聊天")
+                    await self._initiate_conversation()
+                    # 更新时间，避免连续触发
+                    self.update_last_message_time()
+
+                # 等待下一次检查
+                await asyncio.sleep(self.idle_check_interval)
+
+        except asyncio.CancelledError:
+            logger.debug(f"[私聊][{self.private_name}]空闲对话检测任务被取消")
+        except Exception as e:
+            logger.error(f"[私聊][{self.private_name}]空闲对话检测出错: {str(e)}")
+
+    async def _initiate_conversation(self):
+        """生成并发送主动对话内容"""
+        try:
+            # 获取聊天历史记录，用于生成更合适的开场白
+            messages = self.chat_observer.get_cached_messages(limit=12)  # 获取最近12条消息
+            chat_history_text = await build_readable_messages(
+                messages,
+                replace_bot_name=True,
+                merge_messages=False,
+                timestamp_mode="relative",
+                read_mark=0.0,
+            )
+
+            # 构建提示词
+            prompt = f"""{self.personality_info}。你的名字是{self.name}。
+            你正在与用户{self.private_name}进行QQ私聊，
+            但已经有一段时间没有对话了。
+            你想要主动发起一个友好的对话，可以说说自己在做的事情或者询问对方在做什么。
+            请基于以下之前的对话历史，生成一条自然、友好、符合你个性的主动对话消息。
+            这条消息应该能够引起用户的兴趣，重新开始对话。
+            最近的对话历史（可能已经过去了很久）：
+            {chat_history_text}
+            请直接输出一条消息，不要有任何额外的解释或引导文字。消息要简短自然，就像是在日常聊天中的开场白。
+            消息内容尽量简短，不要超过20个字，不要添加任何表情符号。
+            """
+
+            # 生成对话内容
+            content, _ = await self.llm.generate_response_async(prompt)
+
+            # 清理和格式化内容
+            content = content.strip()
+            # 移除可能的引号和多余格式
+            content = content.strip('"\'')
+
+            if content:
+                # 通过PFCManager创建或获取一个新的对话实例
+                # 使用局部导入避免循环依赖
+                from .pfc_manager import PFCManager
+                from src.plugins.chat.chat_stream import chat_manager
+
+                # 获取当前实例
+                pfc_manager = PFCManager.get_instance()
+
+                # 结束当前对话实例（如果存在）
+                current_conversation = await pfc_manager.get_conversation(self.stream_id)
+                if current_conversation:
+                    logger.info(f"[私聊][{self.private_name}]结束当前对话实例，准备创建新实例")
+                    await current_conversation.stop()
+                    await pfc_manager.remove_conversation(self.stream_id)
+
+                # 创建新的对话实例
+                logger.info(f"[私聊][{self.private_name}]创建新的对话实例以发送主动消息")
+                new_conversation = await pfc_manager.get_or_create_conversation(self.stream_id, self.private_name)
+
+                # 确保新对话实例已初始化完成
+                if new_conversation and hasattr(new_conversation, 'should_continue'):
+                    # 等待一小段时间，确保初始化完成
+                    retry_count = 0
+                    max_retries = 10  # 增加最大重试次数
+                    while not new_conversation.should_continue and retry_count < max_retries:
+                        await asyncio.sleep(0.5)  # 减少等待时间，0.5秒
+                        retry_count += 1
+                        logger.debug(
+                            f"[私聊][{self.private_name}]等待新对话实例初始化完成: 尝试 {retry_count}/{max_retries}")
+
+                    if not new_conversation.should_continue:
+                        logger.warning(f"[私聊][{self.private_name}]新对话实例初始化可能未完成，但仍将尝试发送消息")
+
+                # 首先尝试使用新对话实例的聊天流
+                chat_stream = None
+                if new_conversation and hasattr(new_conversation, 'chat_stream') and new_conversation.chat_stream:
+                    logger.info(f"[私聊][{self.private_name}]使用新对话实例的聊天流发送消息")
+                    chat_stream = new_conversation.chat_stream
+
+                # 如果新对话实例没有可用的聊天流，则尝试从chat_manager获取
+                if not chat_stream:
+                    logger.info(f"[私聊][{self.private_name}]尝试从chat_manager获取聊天流")
+                    chat_stream = chat_manager.get_stream(self.stream_id)
+
+                # 如果仍然没有获取到聊天流，则创建一个新的
+                if not chat_stream:
+                    logger.warning(f"[私聊][{self.private_name}]无法获取聊天流，创建新的聊天流")
+                    # 创建用户信息对象
+                    user_info = UserInfo(
+                        user_id=global_config.BOT_QQ,
+                        user_nickname=global_config.BOT_NICKNAME,
+                        platform="qq"
+                    )
+                    # 创建聊天流
+                    chat_stream = ChatStream(self.stream_id, "qq", user_info)
+
+                # 发送消息
+                await self.message_sender.send_message(
+                    chat_stream=chat_stream,
+                    content=content,
+                    reply_to_message=None
+                )
+
+                # 更新空闲会话启动器的最后消息时间
+                self.update_last_message_time()
+
+                # 如果新对话实例有一个聊天观察者，请触发更新
+                if new_conversation and hasattr(new_conversation, 'chat_observer'):
+                    logger.info(f"[私聊][{self.private_name}]触发聊天观察者更新")
+                    new_conversation.chat_observer.trigger_update()
+
+                logger.success(f"[私聊][{self.private_name}]成功主动发起对话: {content}")
+            else:
+                logger.error(f"[私聊][{self.private_name}]生成的主动对话内容为空")
+
+        except Exception as e:
+            logger.error(f"[私聊][{self.private_name}]主动发起对话失败: {str(e)}")
 
 class GoalAnalyzer:
     """对话目标分析器"""

--- a/src/plugins/PFC/pfc_manager.py
+++ b/src/plugins/PFC/pfc_manager.py
@@ -62,7 +62,12 @@ class PFCManager:
             if instance.should_continue:
                 logger.debug(f"[私聊][{private_name}]使用现有会话实例: {stream_id}")
                 return instance
-        # else: 实例存在但不应继续
+            else:
+                # 清理旧实例资源
+                await self._cleanup_conversation(instance)
+                del self._instances[stream_id]
+
+        # 创建新实例
         try:
             # 创建新实例
             logger.info(f"[私聊][{private_name}]创建新的对话实例: {stream_id}")
@@ -103,6 +108,25 @@ class PFCManager:
             logger.error(f"[私聊][{private_name}]{traceback.format_exc()}")
             # 清理失败的初始化
 
+    async def _cleanup_conversation(self, conversation: Conversation):
+        """清理会话实例的资源
+
+        Args:
+            conversation: 要清理的会话实例
+        """
+        try:
+            # 调用conversation的停止方法，确保所有组件都被正确关闭
+            if hasattr(conversation, 'stop') and callable(conversation.stop):
+                await conversation.stop()
+
+            # 特别确保空闲对话检测器被关闭
+            if hasattr(conversation, 'idle_conversation_starter'):
+                conversation.idle_conversation_starter.stop()
+
+            logger.info(f"[私聊][{conversation.private_name}]会话实例 {conversation.stream_id} 资源已清理")
+        except Exception as e:
+            logger.error(f"[私聊][{conversation.private_name}]清理会话实例资源失败: {e}")
+
     async def get_conversation(self, stream_id: str) -> Optional[Conversation]:
         """获取已存在的会话实例
 
@@ -113,3 +137,19 @@ class PFCManager:
             Optional[Conversation]: 会话实例，不存在则返回None
         """
         return self._instances.get(stream_id)
+
+    async def remove_conversation(self, stream_id: str):
+        """移除会话实例
+
+        Args:
+            stream_id: 聊天流ID
+        """
+        if stream_id in self._instances:
+            try:
+                # 清理资源
+                await self._cleanup_conversation(self._instances[stream_id])
+                # 删除实例引用
+                del self._instances[stream_id]
+                logger.info(f"会话实例 {stream_id} 已从管理器中移除")
+            except Exception as e:
+                logger.error(f"移除会话实例 {stream_id} 失败: {e}")

--- a/template/bot_config_template.toml
+++ b/template/bot_config_template.toml
@@ -291,6 +291,11 @@ provider = "SILICONFLOW"
 pri_in = 2
 pri_out = 8
 
+[idle_conversation]
+enable_idle_conversation = true
+idle_check_interval = 600  # 检查间隔，10分钟检查一次
+min_idle_time = 7200      # 最短无活动时间，2小时 (7200秒)建议拉高
+max_idle_time = 18000     # 最长无活动时间，5小时 (18000秒)
 
 #以下模型暂时没有使用！！
 #以下模型暂时没有使用！！


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [ ] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [ ] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

为私聊互动添加空闲对话启动器功能，允许机器人在长时间没有消息交换时主动发起对话。

新功能：
- 为私聊实现空闲对话启动机制
- 为空闲对话检测添加可配置参数
- 创建动态机制来生成和发送主动消息

增强功能：
- 通过空闲对话检测改进对话管理
- 为对话启动时机添加灵活的配置
- 增强机器人在私聊中保持参与度的能力

杂项：
- 更新 conversation 和 manager 类以支持空闲对话功能
- 为空闲对话设置添加配置模板

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an idle conversation starter feature for private chat interactions, allowing the bot to proactively initiate conversations when no messages have been exchanged for an extended period.

New Features:
- Implement an idle conversation starter mechanism for private chats
- Add configurable parameters for idle conversation detection
- Create a dynamic mechanism to generate and send proactive messages

Enhancements:
- Improve conversation management with idle conversation detection
- Add flexible configuration for conversation initiation timing
- Enhance bot's ability to maintain engagement in private chats

Chores:
- Update conversation and manager classes to support idle conversation feature
- Add configuration template for idle conversation settings

</details>