### PR TITLE
fix: 避免不必要的类型转换

### DIFF
--- a/src/chat/message_receive/storage.py
+++ b/src/chat/message_receive/storage.py
@@ -84,12 +84,11 @@ class MessageStorage:
             logger.exception("存储撤回消息失败")
 
     @staticmethod
-    async def remove_recalled_message(time: str) -> None:
+    async def remove_recalled_message(timestamp: float) -> None:
         """删除撤回消息"""
         try:
-            # Assuming input 'time' is a string timestamp that can be converted to float
-            current_time_float = float(time)
-            RecalledMessages.delete().where(RecalledMessages.time < (current_time_float - 300)).execute()
+            # timestamp is the current time get from time.time()
+            RecalledMessages.delete().where(RecalledMessages.time < (timestamp - 300)).execute()
         except Exception:
             logger.exception("删除撤回消息失败")
 


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [ ] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）: 无
6. 请简要说明本次更新的内容和目的：
原代码中调用remove_recalled_message函数的过程为将float类型的time.time()转为str类型的时间戳传入函数，再转变为float类型的时间进行运算，会造成不必要的计算代价，同时str和float的隐式类型转换可能会引入错误
现在改为直接使用float类型的时间戳，避免强制类型转换
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
修改前：
![image](https://github.com/user-attachments/assets/7c3c4db9-9ed2-4a69-99ec-673a898d081b)
修改后：
![image](https://github.com/user-attachments/assets/b3cb17df-4596-422f-8f27-c991fa9e5e73)
项目中唯一用法：
![image](https://github.com/user-attachments/assets/49ffd91e-23cd-4463-a7ff-14a44ffa6d9a)

- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

简化撤回消息删除流程，将 `remove_recalled_message` 切换为直接使用浮点时间戳，从而消除不必要的字符串到浮点数的转换。

Bug 修复：
- 删除删除撤回消息时隐式的字符串到浮点数转换，以避免计算开销和潜在的类型错误。

增强功能：
- 更新 `remove_recalled_message` 签名，使其接受浮点时间戳而不是字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify recalled message deletion by switching remove_recalled_message to use float timestamps directly, eliminating unnecessary string-to-float conversion.

Bug Fixes:
- Remove implicit string-to-float conversion when deleting recalled messages to avoid computation overhead and potential type errors.

Enhancements:
- Update remove_recalled_message signature to accept a float timestamp instead of a string.

</details>