### PR TITLE
fix: 修复docker-image的tag问题

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,6 +9,8 @@ on:
     tags:
       - "v*.*.*"
       - "v*"
+      - "*.*.*"
+      - "*.*.*-*"
 
 jobs:
   build-amd64:
@@ -47,6 +49,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=tag
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
@@ -109,6 +112,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=tag
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
@@ -153,6 +157,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=tag
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复 CI 中的 Docker 镜像标签问题，通过扩展可识别的标签模式并在主分支上启用“latest”标签

CI：
- 扩展工作流触发器，以包含没有“v”前缀的语义版本标签和预发布标签
- 启用在主分支上构建 Docker 镜像时推送“latest”标签

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Docker image tagging in CI by broadening recognized tag patterns and enabling the ‘latest’ tag on the main branch

CI:
- Expand workflow triggers to include semantic version tags without a ‘v’ prefix and prerelease tags
- Enable pushing the ‘latest’ tag for Docker image builds on the main branch

</details>