### PR TITLE
feat: 新增maim_message配置，支持wss，tcp模式，支持token

### DIFF
--- a/src/common/message/api.py
+++ b/src/common/message/api.py
@@ -3,25 +3,53 @@ import os
 import importlib.metadata
 from maim_message import MessageServer
 from src.common.logger_manager import get_logger
+from src.config.config import global_config
 
 
 # 检查maim_message版本
 try:
     maim_message_version = importlib.metadata.version("maim_message")
-    version_compatible = [int(x) for x in maim_message_version.split(".")] >= [0, 3, 0]
+    version_compatible = [int(x) for x in maim_message_version.split(".")] >= [0, 3, 3]
 except (importlib.metadata.PackageNotFoundError, ValueError):
     version_compatible = False
 
-# 根据版本决定是否使用自定义logger
+# 读取配置项
+maim_message_config = global_config.maim_message
+
+# 设置基本参数
 kwargs = {
     "host": os.environ["HOST"],
     "port": int(os.environ["PORT"]),
     "app": global_server.get_app(),
 }
 
-# 只有在版本 >= 0.3.0 时才使用自定义logger
+# 只有在版本 >= 0.3.0 时才使用高级特性
 if version_compatible:
+    # 添加自定义logger
     maim_message_logger = get_logger("maim_message")
     kwargs["custom_logger"] = maim_message_logger
 
+    # 添加token认证
+    if maim_message_config.auth_token:
+        if len(maim_message_config.auth_token) > 0:
+            kwargs["enable_token"] = True
+
+    if maim_message_config.use_custom:
+        # 添加WSS模式支持
+        del kwargs["app"]
+        kwargs["host"] = maim_message_config.host
+        kwargs["port"] = maim_message_config.port
+        kwargs["mode"] = maim_message_config.mode
+        if maim_message_config.use_wss:
+            if maim_message_config.cert_file:
+                kwargs["ssl_certfile"] = maim_message_config.cert_file
+            if maim_message_config.key_file:
+                kwargs["ssl_keyfile"] = maim_message_config.key_file
+        kwargs["enable_custom_uvicorn_logger"] = False
+
+
 global_api = MessageServer(**kwargs)
+
+if version_compatible and maim_message_config.auth_token:
+    for token in maim_message_config.auth_token:
+        global_api.add_valid_token(token)

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -31,6 +31,7 @@ from src.config.official_configs import (
     ModelConfig,
     FocusChatProcessorConfig,
     MessageReceiveConfig,
+    MaimMessageConfig,
 )
 
 install(extra_lines=3)
@@ -157,6 +158,7 @@ class Config(ConfigBase):
     telemetry: TelemetryConfig
     experimental: ExperimentalConfig
     model: ModelConfig
+    maim_message: MaimMessageConfig
 
 
 def load_config(config_path: str) -> Config:

--- a/src/config/official_configs.py
+++ b/src/config/official_configs.py
@@ -356,6 +356,35 @@ class ExperimentalConfig(ConfigBase):
 
 
 @dataclass
+class MaimMessageConfig(ConfigBase):
+    """maim_message配置类"""
+
+    use_custom: bool = False
+    """是否使用自定义的maim_message配置"""
+
+    host: str = "127.0.0.1"
+    """主机地址"""
+
+    port: int = 8090
+    """"端口号"""
+
+    mode: str = "ws"
+    """连接模式，支持ws和tcp"""
+
+    use_wss: bool = False
+    """是否使用WSS安全连接"""
+
+    cert_file: str = ""
+    """SSL证书文件路径，仅在use_wss=True时有效"""
+
+    key_file: str = ""
+    """SSL密钥文件路径，仅在use_wss=True时有效"""
+
+    auth_token: list[str] = field(default_factory=lambda: [])
+    """认证令牌，用于API验证，为空则不启用验证"""
+
+
+@dataclass
 class ModelConfig(ConfigBase):
     """模型配置类"""
 

--- a/src/config/official_configs.py
+++ b/src/config/official_configs.py
@@ -368,7 +368,7 @@ class MaimMessageConfig(ConfigBase):
     port: int = 8090
     """"端口号"""
 
-    mode: str = "ws"
+    mode: Literal["ws", "tcp"] = "ws"
     """连接模式，支持ws和tcp"""
 
     use_wss: bool = False

--- a/src/config/official_configs.py
+++ b/src/config/official_configs.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 from src.config.config_base import ConfigBase
 

--- a/template/bot_config_template.toml
+++ b/template/bot_config_template.toml
@@ -169,6 +169,18 @@ max_length = 256 # 回复允许的最大长度
 max_sentence_num = 4 # 回复允许的最大句子数
 enable_kaomoji_protection = false # 是否启用颜文字保护
 
+[maim_message]
+auth_token = [] # 认证令牌，用于API验证，为空则不启用验证
+# 以下项目若要使用需要打开use_custom，并单独配置maim_message的服务器
+use_custom = false # 是否启用自定义的maim_message服务器，注意这需要设置新的端口，不能与.env重复
+host="127.0.0.1"
+port=8090
+mode="ws" # 支持ws和tcp两种模式
+use_wss = false # 是否使用WSS安全连接，只支持ws模式
+cert_file = "" # SSL证书文件路径，仅在use_wss=true时有效
+key_file = "" # SSL密钥文件路径，仅在use_wss=true时有效
+
+
 [telemetry] #发送统计信息，主要是看全球有多少只麦麦
 enable = true
 
@@ -293,3 +305,4 @@ name = "Qwen/Qwen2.5-32B-Instruct"
 provider = "SILICONFLOW"
 pri_in = 1.26
 pri_out = 1.26
+


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [ ] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

引入可配置的 `maim_message` 支持，通过添加专用配置选项、自定义服务器模式（ws/tcp）、安全 WSS 连接和基于令牌的身份验证。

新功能：
- 添加 `MaimMessageConfig` 类以集中管理 `maim_message` 设置（自定义主机/端口/模式、WSS 证书、身份验证令牌）。
- 在 `bot_config_template.toml` 中公开 `[maim_message]` 部分，用于用户定义的服务器和安全参数。

增强功能：
- 修改消息 API 以使用新配置，在默认服务器和自定义服务器之间切换，并启用令牌验证。
- 在激活高级功能之前，将所需的 `maim_message` 版本阈值从 0.3.0 升级到 0.3.3。
- 在启动时自动向消息服务器注册配置的身份验证令牌。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce configurable maim_message support by adding dedicated configuration options, custom server modes (ws/tcp), secure WSS connections, and token-based authentication.

New Features:
- Add MaimMessageConfig class to centralize maim_message settings (custom host/port/mode, WSS certificates, auth tokens).
- Expose [maim_message] section in bot_config_template.toml for user-defined server and security parameters.

Enhancements:
- Modify message API to consume new configuration, switch between default and custom servers, and enable token validation.
- Upgrade required maim_message version threshold from 0.3.0 to 0.3.3 before activating advanced features.
- Automatically register configured auth tokens with the message server on startup.

</details>