### PR TITLE
fix(heartFC_Cycleinfo): 添加目录创建失败时的异常处理和备用方案

### DIFF
--- a/src/chat/focus_chat/heartFC_Cycleinfo.py
+++ b/src/chat/focus_chat/heartFC_Cycleinfo.py
@@ -97,13 +97,12 @@ class CycleDetail:
         """将循环信息写入文件"""
         # 如果目录不存在，则创建目录
         dir_name = os.path.dirname(file_path)
+        # 去除特殊字符，保留字母、数字、下划线、中划线和中文
+        dir_name = "".join(
+            char for char in dir_name if char.isalnum() or char in ["_", "-", "/"] or "\u4e00" <= char <= "\u9fff"
+        )
         if dir_name and not os.path.exists(dir_name):
-            try:
-                os.makedirs(dir_name, exist_ok=True)
-            except Exception as e:
-                print(f"创建目录 {dir_name} 失败: {e}")
-                print(f"日志将会写入到temp目录下")
-                file_path = os.path.join("temp", os.path.basename(file_path))
+            os.makedirs(dir_name, exist_ok=True)
         # 写入文件
         import json
 

--- a/src/chat/focus_chat/heartFC_Cycleinfo.py
+++ b/src/chat/focus_chat/heartFC_Cycleinfo.py
@@ -98,7 +98,12 @@ class CycleDetail:
         # 如果目录不存在，则创建目录
         dir_name = os.path.dirname(file_path)
         if dir_name and not os.path.exists(dir_name):
-            os.makedirs(dir_name, exist_ok=True)
+            try:
+                os.makedirs(dir_name, exist_ok=True)
+            except Exception as e:
+                print(f"创建目录 {dir_name} 失败: {e}")
+                print(f"日志将会写入到temp目录下")
+                file_path = os.path.join("temp", os.path.basename(file_path))
         # 写入文件
         import json
 

--- a/src/chat/focus_chat/heartFC_Cycleinfo.py
+++ b/src/chat/focus_chat/heartFC_Cycleinfo.py
@@ -95,17 +95,20 @@ class CycleDetail:
 
     def log_cycle_to_file(self, file_path: str):
         """将循环信息写入文件"""
-        # 如果目录不存在，则创建目录
+        # 如果目录不存在，则创建目
         dir_name = os.path.dirname(file_path)
         # 去除特殊字符，保留字母、数字、下划线、中划线和中文
         dir_name = "".join(
             char for char in dir_name if char.isalnum() or char in ["_", "-", "/"] or "\u4e00" <= char <= "\u9fff"
         )
+        print("dir_name:", dir_name)
         if dir_name and not os.path.exists(dir_name):
             os.makedirs(dir_name, exist_ok=True)
         # 写入文件
         import json
 
+        file_path = os.path.join(dir_name, os.path.basename(file_path))
+        print("file_path:", file_path)
         with open(file_path, "a", encoding="utf-8") as f:
             f.write(json.dumps(self.to_dict(), ensure_ascii=False) + "\n")
 


### PR DESCRIPTION
当目录创建失败时，捕获异常并打印错误信息，同时将日志文件写入到temp目录下作为备用方案

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

捕获并处理 `log_cycle_to_file` 中的目录创建失败情况，并回退到在临时目录中写入日志文件

Bug 修复:
- 在 `os.makedirs` 周围添加 try-catch 块，以报告和处理目录创建错误
- 如果原始目录创建失败，则回退到在 'temp' 目录中写入日志文件

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Catch and handle directory creation failures in log_cycle_to_file and fallback to writing log files in the temporary directory

Bug Fixes:
- Add try-catch around os.makedirs to report and handle directory creation errors
- Fallback to writing log files in the 'temp' directory if original directory creation fails

</details>