### PR TITLE
修复在群聊中提示词不会包含和当前消息发送人的relationship的问题

### DIFF
--- a/src/chat/normal_chat/normal_prompt.py
+++ b/src/chat/normal_chat/normal_prompt.py
@@ -104,10 +104,9 @@ class PromptBuilder:
                 (chat_stream.user_info.platform, chat_stream.user_info.user_id) if chat_stream.user_info else None,
                 limit=global_config.normal_chat.max_context_size,
             )
-        elif chat_stream.user_info:
-            who_chat_in_group.append(
-                (chat_stream.user_info.platform, chat_stream.user_info.user_id, chat_stream.user_info.user_nickname)
-            )
+        who_chat_in_group.append(
+            (chat_stream.user_info.platform, chat_stream.user_info.user_id, chat_stream.user_info.user_nickname)
+        )
 
         relation_prompt = ""
         for person in who_chat_in_group:


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue** #1013 
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 修复群聊中当前消息发送者缺少关系提示的问题，通过始终将其 user_info 附加到参与者列表来解决。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix missing relationship prompt for the current message sender in group chats by always appending their user_info to the participant list.

</details>