### PR TITLE
让普通聊天模式下，提及 bot 必然回复的选项起作用

### DIFF
--- a/src/chat/normal_chat/normal_chat.py
+++ b/src/chat/normal_chat/normal_chat.py
@@ -252,7 +252,7 @@ class NormalChat:
             return
 
         timing_results = {}
-        reply_probability = 1.0 if is_mentioned else 0.0  # 如果被提及，基础概率为1，否则需要意愿判断
+        reply_probability = 1.0 if is_mentioned and global_config.normal_chat.mentioned_bot_inevitable_reply else 0.0  # 如果被提及，且开启了提及必回复，则基础概率为1，否则需要意愿判断
 
         # 意愿管理器：设置当前message信息
         willing_manager.setup(message, self.chat_stream, is_mentioned, interested_rate)


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**：我希望麦麦在群里微微潜水，但是实际上只要一提及必然回复，所以希望mentioned_bot_inevitable_reply = false能起作用，所以找到这个地方改了改。

好的，这是翻译成中文的 pull request 摘要：

## Sourcery 总结

Bug 修复：
- 修复了在普通聊天模式下计算提及消息的回复概率时，没有考虑 `mentioned_bot_inevitable_reply` 设置的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Honor the `mentioned_bot_inevitable_reply` setting when computing reply probability for mentioned messages in normal chat mode.

</details>