### PR TITLE
docker部署不再需要mongodb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
     volumes:
       - ./docker-config/adapters/config.toml:/adapters/config.toml
     restart: always
-    depends_on:
-      - mongodb
     networks:
       - maim_bot
   core:
@@ -32,23 +30,6 @@ services:
       - ./docker-config/mmc:/MaiMBot/config # 持久化bot配置文件
       - ./data/MaiMBot:/MaiMBot/data # NapCat 和 NoneBot 共享此卷，否则发送图片会有问题
     restart: always
-    depends_on:
-      - mongodb
-    networks:
-      - maim_bot
-  mongodb:
-    container_name: maim-bot-mongo
-    environment:
-      - TZ=Asia/Shanghai
-#      - MONGO_INITDB_ROOT_USERNAME=your_username # 此处配置mongo用户
-#      - MONGO_INITDB_ROOT_PASSWORD=your_password # 此处配置mongo密码
-#    ports:
-#      - "27017:27017"
-    restart: always
-    volumes:
-      - mongodb:/data/db #  持久化mongodb数据
-      - mongodbCONFIG:/data/configdb # 持久化mongodb配置文件
-    image: mongo:latest
     networks:
       - maim_bot
   napcat:
@@ -70,6 +51,3 @@ services:
 networks:
   maim_bot:
     driver: bridge
-volumes:
-  mongodb:
-  mongodbCONFIG:


### PR DESCRIPTION
不再需要mongodb

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:删除了mongodb，使docker部署更精简
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

# 注意：**版本更新后将不再支持mongodb数据库迁移**

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

增强功能：
- 从 Docker Compose 配置中移除 MongoDB 服务、依赖项和卷，以简化容器设置

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Remove MongoDB service, dependencies, and volumes from Docker Compose configuration to simplify container setup

</details>