### PR TITLE
支持统计数据输出，预留27017端口映射

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,10 @@ services:
 #      - PRIVACY_AGREE=42dddb3cbe2b784b45a2781407b298a1 # 同意EULA
 #    ports:
 #      - "8000:8000"
+#      - "27017:27017"
     volumes:
       - ./docker-config/mmc/.env:/MaiMBot/.env # 持久化env配置文件
+      - ./docker-config/mmc/maibot_statistics.html:/MaiMBot/maibot_statistics.html #统计数据输出
       - ./docker-config/mmc:/MaiMBot/config # 持久化bot配置文件
       - ./data/MaiMBot:/MaiMBot/data # NapCat 和 NoneBot 共享此卷，否则发送图片会有问题
     restart: always


### PR DESCRIPTION
# 支持统计数据输出

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:可能需要预留统计文件
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

启用统计数据输出，通过将统计文件挂载到容器中并在 docker-compose 中暴露端口 27017。

新功能：
- 添加卷挂载，用于将统计数据导出到 maibot_statistics.html
- 保留 Docker 端口映射，用于 MongoDB 的 27017 端口

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable statistical data output by mounting the statistics file into the container and exposing port 27017 in docker-compose

New Features:
- Add volume mount for exporting statistics data to maibot_statistics.html
- Reserve Docker port mapping for MongoDB on port 27017

</details>