### PR TITLE
支持使用魔搭平台的生图 api，新增支持该返回 json 格式,新增一个配置参数，可以修改此参数实现生图风格化以及调用 lora

### DIFF
--- a/src/plugins/doubao_pic/actions/generate_pic_config.py
+++ b/src/plugins/doubao_pic/actions/generate_pic_config.py
@@ -10,6 +10,11 @@ default_model = "doubao-seedream-3-0-t2i-250415"
 # 默认图片尺寸
 default_size = "1024x1024"
 
+#魔搭
+#base_url = "https://api-inference.modelscope.cn/v1"#API的基础url
+#volcano_generate_api_key = "xxxxxxxxxxxxxxxxxxxxxx"#key与豆包一样有需要前缀，无需修改源代码
+#default_model = "cancel13/liaocao"#潦草lora图片生成模型
+
 
 # 是否默认开启水印
 default_watermark = true
@@ -20,6 +25,7 @@ default_seed = 42
 
 # 更多插件特定配置可以在此添加...
 # custom_parameter = "some_value"
+#custom_prompt = "liaocao,Cartoon"#自定义参数，可添加lora，或是其他自定义提示词，用来作为画图的风格，会添加在生成的提示词前面。
 """
 
 


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
- 新增一个判断逻辑，方便修改无法返回 url 的生图模型切换
- 支持使用魔搭平台的生图 api，新增支持该返回 json 格式
- 新增一个配置参数，可以修改此参数实现生图风格化以及调用 lora
- 增加少量注释，望大佬指教，自学新手
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
![Snipaste_2025-06-12_22-48-40](https://github.com/user-attachments/assets/3b0435a2-6ebf-4c7d-8793-b8d78656ebe0)
- **附加信息**:

## Sourcery 总结

增强图片生成操作，通过添加可自定义的提示词（prompts），扩展 API 兼容性以处理 Base64 和多种 JSON 格式（包括 ModelScope），优化直接 Base64 传输，并更新提示词要求和配置选项。

新特性：
- 允许用户指定 `custom_prompt` 以修改图像风格并结合 LoRA 模型
- 支持从 Base64 编码的响应中直接发送图像，无需单独下载

增强功能：
- 支持 ModelScope (魔搭) API 以及现有服务，并处理其 JSON 图像结构
- 优先使用 `b64_json` response_format 而不是 URL，并回退到旧版 URL 和 ‘images’ 字段
- 将 HTTP 下载超时时间从 30 秒增加到 60 秒，并统一图像检索中的错误处理

文档：
- 在 generate_pic_config 中记录新的 `custom_prompt` 配置和示例 magic 平台设置

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the picture generation action by adding customizable prompts, broadening API compatibility to handle Base64 and multiple JSON formats (including ModelScope), optimizing direct Base64 delivery, and updating prompt requirements and configuration options.

New Features:
- Allow users to specify a custom_prompt to modify image style and incorporate LoRA models
- Enable direct image sending from Base64-encoded responses without separate download

Enhancements:
- Support ModelScope (魔搭) API alongside existing service and handle its JSON image structure
- Prioritize b64_json response_format over URL and fall back to legacy URL and ‘images’ fields
- Increase HTTP download timeout from 30s to 60s and unify error handling in image retrieval

Documentation:
- Document new custom_prompt config and example magic platform settings in generate_pic_config

</details>