### PR TITLE
feat: 更新LLMRequest类以支持自定义参数，更新payload键值添加逻辑，兼容不支持某些键值的api

### DIFF
--- a/src/llm_models/utils_model.py
+++ b/src/llm_models/utils_model.py
@@ -122,14 +122,16 @@ class LLMRequest:
         self.model_name: str = model["name"]
         self.params = kwargs
 
-        self.enable_thinking = model.get("enable_thinking", False)
+        self.enable_thinking = model.get("enable_thinking", None)
         self.temp = model.get("temp", 0.7)
-        self.thinking_budget = model.get("thinking_budget", 4096)
+        self.thinking_budget = model.get("thinking_budget", None)
         self.stream = model.get("stream", False)
         self.pri_in = model.get("pri_in", 0)
         self.pri_out = model.get("pri_out", 0)
         self.max_tokens = model.get("max_tokens", global_config.model.model_max_output_length)
         # print(f"max_tokens: {self.max_tokens}")
+        self.custom_params = model.get("custom_params", "{}")
+        self.custom_params = json.loads(self.custom_params)
 
         # 获取数据库实例
         self._init_database()
@@ -246,28 +248,6 @@ class LLMRequest:
             payload = await self._build_payload(prompt, image_base64, image_format)
         elif payload is None:
             payload = await self._build_payload(prompt)
-
-        if stream_mode:
-            payload["stream"] = stream_mode
-
-        if self.temp != 0.7:
-            payload["temperature"] = self.temp
-
-        # 添加enable_thinking参数（如果不是默认值False）
-        if not self.enable_thinking:
-            payload["enable_thinking"] = False
-
-        if self.thinking_budget != 4096:
-            payload["thinking_budget"] = self.thinking_budget
-
-        if self.max_tokens:
-            payload["max_tokens"] = self.max_tokens
-
-        # if "max_tokens" not in payload and "max_completion_tokens" not in payload:
-        # payload["max_tokens"] = global_config.model.model_max_output_length
-        # 如果 payload 中依然存在 max_tokens 且需要转换，在这里进行再次检查
-        if self.model_name.lower() in self.MODELS_NEEDING_TRANSFORMATION and "max_tokens" in payload:
-            payload["max_completion_tokens"] = payload.pop("max_tokens")
 
         return {
             "policy": policy,
@@ -668,18 +648,16 @@ class LLMRequest:
         if self.temp != 0.7:
             payload["temperature"] = self.temp
 
-        # 添加enable_thinking参数（如果不是默认值False）
-        if not self.enable_thinking:
-            payload["enable_thinking"] = False
+        # 仅当配置文件中存在参数时，添加对应参数
+        if self.enable_thinking is not None:
+            payload["enable_thinking"] = self.enable_thinking
 
-        if self.thinking_budget != 4096:
+        if self.thinking_budget is not None:
             payload["thinking_budget"] = self.thinking_budget
 
         if self.max_tokens:
             payload["max_tokens"] = self.max_tokens
 
-        # if "max_tokens" not in payload and "max_completion_tokens" not in payload:
-        # payload["max_tokens"] = global_config.model.model_max_output_length
         # 如果 payload 中依然存在 max_tokens 且需要转换，在这里进行再次检查
         if self.model_name.lower() in self.MODELS_NEEDING_TRANSFORMATION and "max_tokens" in payload:
             payload["max_completion_tokens"] = payload.pop("max_tokens")

--- a/src/llm_models/utils_model.py
+++ b/src/llm_models/utils_model.py
@@ -130,8 +130,13 @@ class LLMRequest:
         self.pri_out = model.get("pri_out", 0)
         self.max_tokens = model.get("max_tokens", global_config.model.model_max_output_length)
         # print(f"max_tokens: {self.max_tokens}")
-        self.custom_params = model.get("custom_params", "{}")
-        self.custom_params = json.loads(self.custom_params)
+        custom_params_str = model.get("custom_params", "{}")
+        try:
+            self.custom_params = json.loads(custom_params_str)
+        except json.JSONDecodeError as e:
+            logger.error(f"Invalid JSON in custom_params for model '{self.model_name}': {custom_params_str}")
+            self.custom_params = {}
+
 
         # 获取数据库实例
         self._init_database()


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
- 更新LLMRequest类以支持自定义参数
有一些键值无法在目前的配置文件中配置，因此在model配置项引入了接收json字符串的custom_params，用于兼容~~某些展现命名自由的Gemini文档编写人员和他们的~~extra_body等参数：
```python
"messages": [{"role": "user", "content": "..."}],
'extra_body': {
        "google": {
          "thinking_config": {
            "thinking_budget": 800,
            "include_thoughts": True
          }
        }
      }
```
- 更新payload键值添加逻辑，兼容不支持某些键值的api #1046 
- 删除了一些_prepare_request重复的代码

# 其他信息
- **关联   ##Issue**：
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新 LLMRequest 以解析和应用自定义参数，并改进 payload 构造，从而避免不支持的键，仅包含已配置的值。

新特性：
- 在 LLMRequest 中添加对 `custom_params` JSON 的支持，以传递任意额外的参数

增强功能：
- 从模型配置加载 `custom_params` 并合并到请求中
- 仅在显式设置时才有条件地包含 `temperature`、`thinking`、`budget` 和 `max_tokens`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update LLMRequest to parse and apply custom parameters and refine payload construction to avoid unsupported keys by including only configured values.

New Features:
- Add support for custom_params JSON in LLMRequest to pass arbitrary extra parameters

Enhancements:
- Load custom_params from model config and merge into requests
- Conditionally include temperature, thinking, budget, and max_tokens only when explicitly set

</details>