### PR TITLE
调整了generator方法；给base_action群聊环境也获取个人参数；支持上报自身消息更新数据库message_id

### DIFF
--- a/src/chat/message_receive/bot.py
+++ b/src/chat/message_receive/bot.py
@@ -131,12 +131,12 @@ class ChatBot:
             message = MessageRecv(message_data)
             group_info = message.message_info.group_info
             user_info = message.message_info.user_info
-            sent_message = message.message_info.additional_config.get("sent_message", False)
-
-            if user_info.user_id == global_config.bot.qq_account and sent_message: # 这一段只是为了在一切处理前劫持上报的自身消息，用于更新message_id，需要ada支持上报事件，实际测试中不会对正常使用造成任何问题
-                await message.process()
-                await MessageStorage.update_message(message)
-                return
+            if message.message_info.additional_config:
+                sent_message = message.message_info.additional_config.get("sent_message", False)
+                if user_info.user_id == global_config.bot.qq_account and sent_message: # 这一段只是为了在一切处理前劫持上报的自身消息，用于更新message_id，需要ada支持上报事件，实际测试中不会对正常使用造成任何问题
+                    await message.process()
+                    await MessageStorage.update_message(message)
+                    return
 
             get_chat_manager().register_message(message)
 

--- a/src/chat/message_receive/bot.py
+++ b/src/chat/message_receive/bot.py
@@ -132,12 +132,12 @@ class ChatBot:
             group_info = message.message_info.group_info
             user_info = message.message_info.user_info
             if message.message_info.additional_config:
-                sent_message = message.message_info.additional_config.get("sent_message", False)
-                if user_info.user_id == global_config.bot.qq_account and sent_message: # 这一段只是为了在一切处理前劫持上报的自身消息，用于更新message_id，需要ada支持上报事件，实际测试中不会对正常使用造成任何问题
+                sent_message = message.message_info.additional_config.get("echo", False)
+                if sent_message: # 这一段只是为了在一切处理前劫持上报的自身消息，用于更新message_id，需要ada支持上报事件，实际测试中不会对正常使用造成任何问题
                     await message.process()
                     await MessageStorage.update_message(message)
                     return
-
+                
             get_chat_manager().register_message(message)
 
             # 创建聊天流

--- a/src/chat/message_receive/bot.py
+++ b/src/chat/message_receive/bot.py
@@ -131,6 +131,13 @@ class ChatBot:
             message = MessageRecv(message_data)
             group_info = message.message_info.group_info
             user_info = message.message_info.user_info
+            sent_message = message.message_info.additional_config.get("sent_message", False)
+
+            if user_info.user_id == global_config.bot.qq_account and sent_message: # 这一段只是为了在一切处理前劫持上报的自身消息，用于更新message_id，需要ada支持上报事件，实际测试中不会对正常使用造成任何问题
+                await message.process()
+                await MessageStorage.update_message(message)
+                return
+
             get_chat_manager().register_message(message)
 
             # 创建聊天流

--- a/src/chat/message_receive/storage.py
+++ b/src/chat/message_receive/storage.py
@@ -1,10 +1,13 @@
 import re
-from typing import Union
+import base64
+import hashlib
+from typing import Union, List
 
 # from ...common.database.database import db  # db is now Peewee's SqliteDatabase instance
 from .message import MessageSending, MessageRecv
 from .chat_stream import ChatStream
 from ...common.database.database_model import Messages, RecalledMessages  # Import Peewee models
+from ...common.database.database_model import Images
 from src.common.logger import get_logger
 
 logger = get_logger("message_storage")
@@ -103,3 +106,109 @@ class MessageStorage:
 
 
 # 如果需要其他存储相关的函数，可以在这里添加
+    @staticmethod
+    async def update_message(message: MessageRecv) -> None: # 用于实时更新数据库的自身发送消息ID，目前能处理text,reply,image和emoji
+        """更新最新一条匹配消息的message_id，区分文字和图片情况"""
+        try:
+            new_message_id = message.message_info.message_id
+            user_id = message.message_info.user_info.user_id
+            
+            # 检查消息是否包含图片
+            image_hashes = MessageStorage._extract_image_hashes(message.message_segment)
+            
+            if image_hashes:
+                # 图片消息处理
+                await MessageStorage._update_image_message(message, new_message_id, user_id, image_hashes)
+            else:
+                # 文本消息处理
+                await MessageStorage._update_text_message(message, new_message_id, user_id)
+                
+        except Exception:
+            logger.exception("更新消息ID失败")
+
+    @staticmethod
+    def _extract_image_hashes(segment) -> List[str]:
+        """递归提取消息段中的所有图片哈希值"""
+        hashes = []
+        
+        if segment.type == "image" or segment.type == "emoji":
+            try:
+                # 计算图片哈希值
+                binary_data = base64.b64decode(segment.data)
+                file_hash = hashlib.md5(binary_data).hexdigest()
+                hashes.append(file_hash)
+            except Exception as e:
+                logger.error(f"计算图片哈希失败: {e}")
+        
+        elif segment.type == "seglist":
+            # 递归处理子消息段
+            for sub_seg in segment.data:
+                hashes.extend(MessageStorage._extract_image_hashes(sub_seg))
+        
+        return hashes
+
+    @staticmethod
+    async def _update_image_message(message: MessageRecv, new_message_id: str, user_id: str, image_hashes: List[str]) -> None:
+        """处理图片消息的更新逻辑"""
+        
+        # 使用第一张图片的哈希值查询描述
+        first_image_hash = image_hashes[0]
+        logger.info(f"{first_image_hash}")
+        
+        try:
+            # 查询图片描述
+            image_desc = Images.get_or_none(
+                Images.emoji_hash == first_image_hash
+            )
+            
+            if not image_desc or not image_desc.description:
+                logger.debug(f"未找到图片描述: {first_image_hash}")
+                return
+                
+            # 在Messages表中查找包含该描述的最新消息
+            matched_message = Messages.select().where(
+                (Messages.user_id == user_id) &
+                (Messages.processed_plain_text.contains(image_desc.description))
+            ).order_by(Messages.time.desc()).first()
+            
+            if matched_message:
+                # 更新找到的消息记录
+                Messages.update(message_id=new_message_id).where(
+                    Messages.id == matched_message.id
+                ).execute()
+                logger.info(f"更新图片消息ID成功: {matched_message.message_id} -> {new_message_id}")
+            else:
+                logger.debug(f"未找到包含描述'{image_desc.description}'的消息")
+                
+        except Exception as e:
+            logger.error(f"更新图片消息失败: {e}")
+
+    @staticmethod
+    async def _update_text_message(message: MessageRecv, new_message_id: str, user_id: str) -> None:
+        """处理文本消息的更新逻辑"""
+        try:
+            # 过滤处理文本（与store_message相同的处理方式）
+            pattern = r"<MainRule>.*?</MainRule>|<schedule>.*?</schedule>|<UserMessage>.*?</UserMessage>"
+            processed_plain_text = re.sub(
+                pattern, "", 
+                message.processed_plain_text, 
+                flags=re.DOTALL
+            ) if message.processed_plain_text else ""
+            
+            # 查询最新一条匹配消息
+            matched_message = Messages.select().where(
+                (Messages.user_id == user_id) &
+                (Messages.processed_plain_text == processed_plain_text)
+            ).order_by(Messages.time.desc()).first()
+            
+            if matched_message:
+                # 更新找到的消息记录
+                Messages.update(message_id=new_message_id).where(
+                    Messages.id == matched_message.id
+                ).execute()
+                logger.info(f"更新文本消息ID成功: {matched_message.message_id} -> {new_message_id}")
+            else:
+                logger.debug("未找到匹配的文本消息")
+                
+        except Exception as e:
+            logger.error(f"更新文本消息失败: {e}")

--- a/src/chat/message_receive/storage.py
+++ b/src/chat/message_receive/storage.py
@@ -108,107 +108,24 @@ class MessageStorage:
 # 如果需要其他存储相关的函数，可以在这里添加
     @staticmethod
     async def update_message(message: MessageRecv) -> None: # 用于实时更新数据库的自身发送消息ID，目前能处理text,reply,image和emoji
-        """更新最新一条匹配消息的message_id，区分文字和图片情况"""
+        """更新最新一条匹配消息的message_id"""
         try:
-            new_message_id = message.message_info.message_id
-            user_id = message.message_info.user_info.user_id
-            
-            # 检查消息是否包含图片
-            image_hashes = MessageStorage._extract_image_hashes(message.message_segment)
-            
-            if image_hashes:
-                # 图片消息处理
-                await MessageStorage._update_image_message(message, new_message_id, user_id, image_hashes)
-            else:
-                # 文本消息处理
-                await MessageStorage._update_text_message(message, new_message_id, user_id)
-                
-        except Exception:
-            logger.exception("更新消息ID失败")
-
-    @staticmethod
-    def _extract_image_hashes(segment) -> List[str]:
-        """递归提取消息段中的所有图片哈希值"""
-        hashes = []
-        
-        if segment.type == "image" or segment.type == "emoji":
-            try:
-                # 计算图片哈希值
-                binary_data = base64.b64decode(segment.data)
-                file_hash = hashlib.md5(binary_data).hexdigest()
-                hashes.append(file_hash)
-            except Exception as e:
-                logger.error(f"计算图片哈希失败: {e}")
-        
-        elif segment.type == "seglist":
-            # 递归处理子消息段
-            for sub_seg in segment.data:
-                hashes.extend(MessageStorage._extract_image_hashes(sub_seg))
-        
-        return hashes
-
-    @staticmethod
-    async def _update_image_message(message: MessageRecv, new_message_id: str, user_id: str, image_hashes: List[str]) -> None:
-        """处理图片消息的更新逻辑"""
-        
-        # 使用第一张图片的哈希值查询描述
-        first_image_hash = image_hashes[0]
-        logger.info(f"{first_image_hash}")
-        
-        try:
-            # 查询图片描述
-            image_desc = Images.get_or_none(
-                Images.emoji_hash == first_image_hash
-            )
-            
-            if not image_desc or not image_desc.description:
-                logger.debug(f"未找到图片描述: {first_image_hash}")
-                return
-                
-            # 在Messages表中查找包含该描述的最新消息
-            matched_message = Messages.select().where(
-                (Messages.user_id == user_id) &
-                (Messages.processed_plain_text.contains(image_desc.description))
-            ).order_by(Messages.time.desc()).first()
-            
-            if matched_message:
-                # 更新找到的消息记录
-                Messages.update(message_id=new_message_id).where(
-                    Messages.id == matched_message.id
-                ).execute()
-                logger.info(f"更新图片消息ID成功: {matched_message.message_id} -> {new_message_id}")
-            else:
-                logger.debug(f"未找到包含描述'{image_desc.description}'的消息")
-                
-        except Exception as e:
-            logger.error(f"更新图片消息失败: {e}")
-
-    @staticmethod
-    async def _update_text_message(message: MessageRecv, new_message_id: str, user_id: str) -> None:
-        """处理文本消息的更新逻辑"""
-        try:
-            # 过滤处理文本（与store_message相同的处理方式）
-            pattern = r"<MainRule>.*?</MainRule>|<schedule>.*?</schedule>|<UserMessage>.*?</UserMessage>"
-            processed_plain_text = re.sub(
-                pattern, "", 
-                message.processed_plain_text, 
-                flags=re.DOTALL
-            ) if message.processed_plain_text else ""
+            mmc_message_id = message.message_segment.data.get("echo")
+            qq_message_id = message.message_segment.data.get("actual_id")
             
             # 查询最新一条匹配消息
             matched_message = Messages.select().where(
-                (Messages.user_id == user_id) &
-                (Messages.processed_plain_text == processed_plain_text)
+                (Messages.message_id == mmc_message_id)
             ).order_by(Messages.time.desc()).first()
             
             if matched_message:
                 # 更新找到的消息记录
-                Messages.update(message_id=new_message_id).where(
+                Messages.update(message_id=qq_message_id).where(
                     Messages.id == matched_message.id
                 ).execute()
-                logger.info(f"更新文本消息ID成功: {matched_message.message_id} -> {new_message_id}")
+                logger.info(f"更新消息ID成功: {matched_message.message_id} -> {qq_message_id}")
             else:
-                logger.debug("未找到匹配的文本消息")
+                logger.debug("未找到匹配的消息")
                 
         except Exception as e:
-            logger.error(f"更新文本消息失败: {e}")
+            logger.error(f"更新消息ID失败: {e}")

--- a/src/chat/replyer/default_generator.py
+++ b/src/chat/replyer/default_generator.py
@@ -162,6 +162,8 @@ class DefaultReplyer:
     async def generate_reply_with_context(
         self,
         reply_data: Dict[str, Any],
+        enable_splitter: bool=True,
+        enable_chinese_typo: bool=True
     ) -> Tuple[bool, Optional[List[str]]]:
         """
         回复器 (Replier): 核心逻辑，负责生成回复文本。
@@ -191,7 +193,7 @@ class DefaultReplyer:
                 logger.error(f"{self.log_prefix}LLM 生成失败: {llm_e}")
                 return False, None  # LLM 调用失败则无法生成回复
 
-            processed_response = process_llm_response(content)
+            processed_response = process_llm_response(content,enable_splitter,enable_chinese_typo)
 
             # 5. 处理 LLM 响应
             if not content:
@@ -216,6 +218,8 @@ class DefaultReplyer:
     async def rewrite_reply_with_context(
         self,
         reply_data: Dict[str, Any],
+        enable_splitter: bool=True,
+        enable_chinese_typo: bool=True
     ) -> Tuple[bool, Optional[List[str]]]:
         """
         表达器 (Expressor): 核心逻辑，负责生成回复文本。
@@ -252,7 +256,7 @@ class DefaultReplyer:
                 logger.error(f"{self.log_prefix}LLM 生成失败: {llm_e}")
                 return False, None  # LLM 调用失败则无法生成回复
 
-            processed_response = process_llm_response(content)
+            processed_response = process_llm_response(content,enable_splitter,enable_chinese_typo)
 
             # 5. 处理 LLM 响应
             if not content:

--- a/src/chat/utils/utils.py
+++ b/src/chat/utils/utils.py
@@ -321,7 +321,7 @@ def random_remove_punctuation(text: str) -> str:
     return result
 
 
-def process_llm_response(text: str) -> list[str]:
+def process_llm_response(text: str, enable_splitter: bool=True, enable_chinese_typo: bool=True) -> list[str]:
     if not global_config.response_post_process.enable_response_post_process:
         return [text]
 
@@ -359,14 +359,14 @@ def process_llm_response(text: str) -> list[str]:
         word_replace_rate=global_config.chinese_typo.word_replace_rate,
     )
 
-    if global_config.response_splitter.enable:
+    if global_config.response_splitter.enable and enable_splitter:
         split_sentences = split_into_sentences_w_remove_punctuation(cleaned_text)
     else:
         split_sentences = [cleaned_text]
 
     sentences = []
     for sentence in split_sentences:
-        if global_config.chinese_typo.enable:
+        if global_config.chinese_typo.enable and enable_chinese_typo:
             typoed_text, typo_corrections = typo_generator.create_typo_sentence(sentence)
             sentences.append(typoed_text)
             if typo_corrections:

--- a/src/plugin_system/apis/generator_api.py
+++ b/src/plugin_system/apis/generator_api.py
@@ -73,6 +73,8 @@ async def generate_reply(
     chat_stream=None,
     action_data: Dict[str, Any] = None,
     chat_id: str = None,
+    enable_splitter: bool=True,
+    enable_chinese_typo: bool=True
 ) -> Tuple[bool, List[Tuple[str, Any]]]:
     """生成回复
 
@@ -80,6 +82,8 @@ async def generate_reply(
         chat_stream: 聊天流对象（优先）
         action_data: 动作数据
         chat_id: 聊天ID（备用）
+        enable_splitter: 是否启用消息分割器
+        enable_chinese_typo: 是否启用错字生成器
 
     Returns:
         Tuple[bool, List[Tuple[str, Any]]]: (是否成功, 回复集合)
@@ -96,6 +100,8 @@ async def generate_reply(
         # 调用回复器生成回复
         success, reply_set = await replyer.generate_reply_with_context(
             reply_data=action_data or {},
+            enable_splitter=enable_splitter,
+            enable_chinese_typo=enable_chinese_typo
         )
 
         if success:
@@ -114,6 +120,8 @@ async def rewrite_reply(
     chat_stream=None,
     reply_data: Dict[str, Any] = None,
     chat_id: str = None,
+    enable_splitter: bool=True,
+    enable_chinese_typo: bool=True
 ) -> Tuple[bool, List[Tuple[str, Any]]]:
     """重写回复
 
@@ -121,6 +129,8 @@ async def rewrite_reply(
         chat_stream: 聊天流对象（优先）
         reply_data: 回复数据
         chat_id: 聊天ID（备用）
+        enable_splitter: 是否启用消息分割器
+        enable_chinese_typo: 是否启用错字生成器
 
     Returns:
         Tuple[bool, List[Tuple[str, Any]]]: (是否成功, 回复集合)
@@ -137,6 +147,8 @@ async def rewrite_reply(
         # 调用回复器重写回复
         success, reply_set = await replyer.rewrite_reply_with_context(
             reply_data=reply_data or {},
+            enable_splitter=enable_splitter,
+            enable_chinese_typo=enable_chinese_typo
         )
 
         if success:

--- a/src/plugin_system/base/base_action.py
+++ b/src/plugin_system/base/base_action.py
@@ -108,6 +108,8 @@ class BaseAction(ABC):
             # print(self.chat_stream.group_info)
             if self.chat_stream.group_info:
                 self.is_group = True
+                self.user_id = str(self.chat_stream.user_info.user_id)
+                self.user_nickname = getattr(self.chat_stream.user_info, "user_nickname", None)
                 self.group_id = str(self.chat_stream.group_info.group_id)
                 self.group_name = getattr(self.chat_stream.group_info, "group_name", None)
             else:


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：调整了generator方法；给base_action群聊环境也获取个人参数；支持了上报自身消息更新数据库message_id。其中上报自身消息更新数据库需要ada支持，不过现在也已经写出来一个轮子了，就等UN那边写完新的架构再进行适配。
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在生成器 API 中添加了对每个请求的响应拆分和中文错字生成控制，通过匹配现有记录（通过文本或图像哈希）来实现自发送消息 ID 更新，在机器人中拦截自发送消息以进行数据库更新，并在群聊操作中捕获用户参数。

新功能：
- 支持更新自发送消息的数据库 message_id，同时处理文本和图像
- 在 `generate_reply` 和 `rewrite_reply` API 中引入 `enable_splitter` 和 `enable_chinese_typo` 参数，以控制响应拆分和错字注入

增强功能：
- 在机器人处理中拦截自发送消息，以触发立即消息 ID 更新
- 扩展 `process_llm_response` 以遵守每次调用的拆分器和中文错字标志
- 在 `BaseAction` 中存储 `user_id` 和 `user_nickname`，用于群聊上下文

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-request control for response splitting and Chinese typo generation in the generator APIs, implement self-sent message ID updates by matching existing records (via text or image hash), intercept self-sent messages in the bot for database updates, and capture user parameters in group chat actions.

New Features:
- Support updating database message_id for self-sent messages, handling both text and images
- Introduce enable_splitter and enable_chinese_typo parameters in generate_reply and rewrite_reply APIs to control response splitting and typo injection

Enhancements:
- Intercept self-sent messages in bot processing to trigger immediate message ID updates
- Extend process_llm_response to respect per-call splitter and Chinese typo flags
- Store user_id and user_nickname in BaseAction for group chat context

</details>