### PR TITLE
docker数据库网页端添加arm64支持

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,8 @@ services:
     networks:
       - maim_bot
   sqlite-web:
-    image: coleifer/sqlite-web
+    # image: coleifer/sqlite-web
+    image: wwaaafa/sqlite-web
     container_name: sqlite-web
     restart: always
     ports:


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：添加了docker sqlite网页端的arm64支持
# 其他信息
- **关联 Issue**：Close #1064 
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新 docker-compose 中的 sqlite-web 服务以使用与 ARM64 兼容的 Docker 镜像

新特性：
- 通过切换到多架构镜像，为 Docker Compose 中的 sqlite-web 添加 ARM64 支持

部署：
- 使用 `wwaaafa/sqlite-web` Docker 镜像以启用 ARM64 兼容性

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the sqlite-web service in docker-compose to use an ARM64-compatible Docker image

New Features:
- Add ARM64 support for sqlite-web in Docker Compose by switching to a multi-architecture image

Deployment:
- Use wwaaafa/sqlite-web Docker image to enable ARM64 compatibility

</details>