### PR TITLE
docker数据库网页端添加arm64支持，修复第一次部署时创建MaiBot.db为文件夹的问题

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,8 @@ services:
     networks:
       - maim_bot
   sqlite-web:
-    image: coleifer/sqlite-web
+    # image: coleifer/sqlite-web
+    image: wwaaafa/sqlite-web
     container_name: sqlite-web
     restart: always
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,9 +58,9 @@ services:
     ports:
       - "8120:8080"
     volumes:
-      - ./data/MaiMBot/MaiBot.db:/data/MaiBot.db
+      - ./data/MaiBot:/data/MaiBot
     environment:
-      - SQLITE_DATABASE=MaiBot.db  # 你的数据库文件
+      - SQLITE_DATABASE=MaiBot/MaiBot.db  # 你的数据库文件
     networks:
       - maim_bot
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,9 +58,9 @@ services:
     ports:
       - "8120:8080"
     volumes:
-      - ./data/MaiBot:/data/MaiBot
+      - ./data/MaiMBot:/data/MaiMBot
     environment:
-      - SQLITE_DATABASE=MaiBot/MaiBot.db  # 你的数据库文件
+      - SQLITE_DATABASE=MaiMBot/MaiBot.db  # 你的数据库文件
     networks:
       - maim_bot
 networks:


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：为docker数据库网页端添加了arm64支持，并修复了部署问题
# 其他信息
- **关联 Issue**：Close #1064 
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

启用 arm64 对 SQLite web UI 的兼容性，并更正数据库卷配置，以防止 MaiBot.db 被视为文件夹。

新功能：
- 通过切换到 wwaaafa/sqlite-web 镜像，为 SQLite web 界面添加 arm64 支持。

Bug 修复：
- 修复了 MaiBot.db 被创建为目录的初始部署问题，方法是更新卷挂载到目录并调整 SQLITE_DATABASE 路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable arm64 compatibility for the SQLite web UI and correct the database volume configuration to prevent MaiBot.db from being treated as a folder.

New Features:
- Add arm64 support for the SQLite web interface by switching to the wwaaafa/sqlite-web image.

Bug Fixes:
- Fix initial deployment issue where MaiBot.db was created as a directory by updating the volume mount to a directory and adjusting the SQLITE_DATABASE path.

</details>