### PR TITLE
修复对于古早缺失字段的图片反复生成新picid记录的BUG

### DIFF
--- a/src/chat/utils/utils_image.py
+++ b/src/chat/utils/utils_image.py
@@ -403,7 +403,16 @@ class ImageManager:
                     or existing_image.vlm_processed is None
                 ):
                     logger.debug(f"图片记录缺少必要字段，补全旧记录: {image_hash}")
-                    image_id = str(uuid.uuid4())
+                    if not existing_image.image_id:
+                        existing_image.image_id = str(uuid.uuid4())
+                    if existing_image.count is None:
+                        existing_image.count = 0
+                    if existing_image.vlm_processed is None:
+                        existing_image.vlm_processed = False
+                    
+                    existing_image.count += 1
+                    existing_image.save()
+                    return existing_image.image_id, f"[picid:{existing_image.image_id}]"
                 else:
                     # print(f"图片已存在: {existing_image.image_id}")
                     # print(f"图片描述: {existing_image.description}")


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：修复对于古早缺失字段的图片反复生成新picid记录的BUG,如果存在很早就被记录的图片但是缺失字段，将会反复生成重复的记录。
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复了旧版图像重复生成 picid 的问题，通过初始化缺失的元数据字段并重用现有图像 ID 并更新计数。

Bug 修复：
- 阻止为缺少存储字段的图像无休止地创建新的 picid 记录，方法是重用原始图像 ID

增强功能：
- 在现有图像记录上初始化缺失的 image_id、count 和 vlm_processed 字段
- 增加并持久化先前缺少元数据的图像的使用计数

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix duplicate picid generation for legacy images by initializing missing metadata fields and reusing existing image IDs with updated counts.

Bug Fixes:
- Prevent endless creation of new picid records for images missing stored fields by reusing the original image ID

Enhancements:
- Initialize missing image_id, count, and vlm_processed fields on existing image records
- Increment and persist the usage count for images with previously missing metadata

</details>