### PR TITLE
修复配置文件中禁用LPMM无效的问题

### DIFF
--- a/src/chat/focus_chat/info_processors/working_memory_processor.py
+++ b/src/chat/focus_chat/info_processors/working_memory_processor.py
@@ -71,6 +71,7 @@ class WorkingMemoryProcessor(BaseProcessor):
         """
         working_memory = None
         chat_info = ""
+        chat_obs = None
         try:
             for observation in observations:
                 if isinstance(observation, WorkingMemoryObservation):
@@ -79,9 +80,14 @@ class WorkingMemoryProcessor(BaseProcessor):
                     chat_info = observation.get_observe_info()
                     chat_obs = observation
                     # 检查是否有待压缩内容
-            if chat_obs.compressor_prompt:
+            if chat_obs and chat_obs.compressor_prompt:
                 logger.debug(f"{self.log_prefix} 压缩聊天记忆")
                 await self.compress_chat_memory(working_memory, chat_obs)
+
+            # 检查working_memory是否为None
+            if working_memory is None:
+                logger.debug(f"{self.log_prefix} 没有找到工作记忆观察，跳过处理")
+                return []
 
             all_memory = working_memory.get_all_memories()
             if not all_memory:
@@ -183,6 +189,11 @@ class WorkingMemoryProcessor(BaseProcessor):
             working_memory: 工作记忆对象
             obs: 聊天观察对象
         """
+        # 检查working_memory是否为None
+        if working_memory is None:
+            logger.warning(f"{self.log_prefix} 工作记忆对象为None，无法压缩聊天记忆")
+            return
+            
         try:
             summary_result, _ = await self.llm_model.generate_response_async(obs.compressor_prompt)
             if not summary_result:
@@ -235,6 +246,11 @@ class WorkingMemoryProcessor(BaseProcessor):
             memory_id1: 第一个记忆ID
             memory_id2: 第二个记忆ID
         """
+        # 检查working_memory是否为None
+        if working_memory is None:
+            logger.warning(f"{self.log_prefix} 工作记忆对象为None，无法合并记忆")
+            return
+            
         try:
             merged_memory = await working_memory.merge_memory(memory_id1, memory_id2)
             logger.debug(f"{self.log_prefix} 合并后的记忆梗概: {merged_memory.brief}")

--- a/src/chat/knowledge/knowledge_lib.py
+++ b/src/chat/knowledge/knowledge_lib.py
@@ -5,60 +5,68 @@ from src.chat.knowledge.mem_active_manager import MemoryActiveManager
 from src.chat.knowledge.qa_manager import QAManager
 from src.chat.knowledge.kg_manager import KGManager
 from src.chat.knowledge.global_logger import logger
+from src.config.config import global_config as bot_global_config
 # try:
 #     import quick_algo
 # except ImportError:
 #     print("quick_algo not found, please install it first")
 
-logger.info("正在初始化Mai-LPMM\n")
-logger.info("创建LLM客户端")
-llm_client_list = dict()
-for key in global_config["llm_providers"]:
-    llm_client_list[key] = LLMClient(
-        global_config["llm_providers"][key]["base_url"],
-        global_config["llm_providers"][key]["api_key"],
+# 检查LPMM知识库是否启用
+if bot_global_config.lpmm_knowledge.enable:
+    logger.info("正在初始化Mai-LPMM\n")
+    logger.info("创建LLM客户端")
+    llm_client_list = dict()
+    for key in global_config["llm_providers"]:
+        llm_client_list[key] = LLMClient(
+            global_config["llm_providers"][key]["base_url"],
+            global_config["llm_providers"][key]["api_key"],
+        )
+
+    # 初始化Embedding库
+    embed_manager = EmbeddingManager(llm_client_list[global_config["embedding"]["provider"]])
+    logger.info("正在从文件加载Embedding库")
+    try:
+        embed_manager.load_from_file()
+    except Exception as e:
+        logger.warning("此消息不会影响正常使用：从文件加载Embedding库时，{}".format(e))
+        # logger.warning("如果你是第一次导入知识，或者还未导入知识，请忽略此错误")
+    logger.info("Embedding库加载完成")
+    # 初始化KG
+    kg_manager = KGManager()
+    logger.info("正在从文件加载KG")
+    try:
+        kg_manager.load_from_file()
+    except Exception as e:
+        logger.warning("此消息不会影响正常使用：从文件加载KG时，{}".format(e))
+        # logger.warning("如果你是第一次导入知识，或者还未导入知识，请忽略此错误")
+    logger.info("KG加载完成")
+
+    logger.info(f"KG节点数量：{len(kg_manager.graph.get_node_list())}")
+    logger.info(f"KG边数量：{len(kg_manager.graph.get_edge_list())}")
+
+
+    # 数据比对：Embedding库与KG的段落hash集合
+    for pg_hash in kg_manager.stored_paragraph_hashes:
+        key = PG_NAMESPACE + "-" + pg_hash
+        if key not in embed_manager.stored_pg_hashes:
+            logger.warning(f"KG中存在Embedding库中不存在的段落：{key}")
+
+    # 问答系统（用于知识库）
+    qa_manager = QAManager(
+        embed_manager,
+        kg_manager,
+        llm_client_list[global_config["embedding"]["provider"]],
+        llm_client_list[global_config["qa"]["llm"]["provider"]],
+        llm_client_list[global_config["qa"]["llm"]["provider"]],
     )
 
-# 初始化Embedding库
-embed_manager = EmbeddingManager(llm_client_list[global_config["embedding"]["provider"]])
-logger.info("正在从文件加载Embedding库")
-try:
-    embed_manager.load_from_file()
-except Exception as e:
-    logger.warning("此消息不会影响正常使用：从文件加载Embedding库时，{}".format(e))
-    # logger.warning("如果你是第一次导入知识，或者还未导入知识，请忽略此错误")
-logger.info("Embedding库加载完成")
-# 初始化KG
-kg_manager = KGManager()
-logger.info("正在从文件加载KG")
-try:
-    kg_manager.load_from_file()
-except Exception as e:
-    logger.warning("此消息不会影响正常使用：从文件加载KG时，{}".format(e))
-    # logger.warning("如果你是第一次导入知识，或者还未导入知识，请忽略此错误")
-logger.info("KG加载完成")
-
-logger.info(f"KG节点数量：{len(kg_manager.graph.get_node_list())}")
-logger.info(f"KG边数量：{len(kg_manager.graph.get_edge_list())}")
-
-
-# 数据比对：Embedding库与KG的段落hash集合
-for pg_hash in kg_manager.stored_paragraph_hashes:
-    key = PG_NAMESPACE + "-" + pg_hash
-    if key not in embed_manager.stored_pg_hashes:
-        logger.warning(f"KG中存在Embedding库中不存在的段落：{key}")
-
-# 问答系统（用于知识库）
-qa_manager = QAManager(
-    embed_manager,
-    kg_manager,
-    llm_client_list[global_config["embedding"]["provider"]],
-    llm_client_list[global_config["qa"]["llm"]["provider"]],
-    llm_client_list[global_config["qa"]["llm"]["provider"]],
-)
-
-# 记忆激活（用于记忆库）
-inspire_manager = MemoryActiveManager(
-    embed_manager,
-    llm_client_list[global_config["embedding"]["provider"]],
-)
+    # 记忆激活（用于记忆库）
+    inspire_manager = MemoryActiveManager(
+        embed_manager,
+        llm_client_list[global_config["embedding"]["provider"]],
+    )
+else:
+    logger.info("LPMM知识库已禁用，跳过初始化")
+    # 创建空的占位符对象，避免导入错误
+    qa_manager = None
+    inspire_manager = None

--- a/src/chat/replyer/default_generator.py
+++ b/src/chat/replyer/default_generator.py
@@ -956,6 +956,11 @@ async def get_prompt_info(message: str, threshold: float):
     logger.debug(f"获取知识库内容，元消息：{message[:30]}...，消息长度: {len(message)}")
     # 从LPMM知识库获取知识
     try:
+        # 检查LPMM知识库是否启用
+        if qa_manager is None:
+            logger.debug("LPMM知识库已禁用，跳过知识获取")
+            return ""
+            
         found_knowledge_from_lpmm = qa_manager.get_knowledge(message)
 
         end_time = time.time()

--- a/src/experimental/PFC/pfc_KnowledgeFetcher.py
+++ b/src/experimental/PFC/pfc_KnowledgeFetcher.py
@@ -35,6 +35,11 @@ class KnowledgeFetcher:
 
         logger.debug(f"[私聊][{self.private_name}]正在从LPMM知识库中获取知识")
         try:
+            # 检查LPMM知识库是否启用
+            if qa_manager is None:
+                logger.debug(f"[私聊][{self.private_name}]LPMM知识库已禁用，跳过知识获取")
+                return "未找到匹配的知识"
+                
             knowledge_info = qa_manager.get_knowledge(query)
             logger.debug(f"[私聊][{self.private_name}]LPMM知识库查询结果: {knowledge_info:150}")
             return knowledge_info

--- a/src/tools/not_using/lpmm_get_knowledge.py
+++ b/src/tools/not_using/lpmm_get_knowledge.py
@@ -36,6 +36,11 @@ class SearchKnowledgeFromLPMMTool(BaseTool):
             query = function_args.get("query")
             # threshold = function_args.get("threshold", 0.4)
 
+            # 检查LPMM知识库是否启用
+            if qa_manager is None:
+                logger.debug("LPMM知识库已禁用，跳过知识获取")
+                return {"type": "info", "id": query, "content": "LPMM知识库已禁用"}
+
             # 调用知识库搜索
 
             knowledge_info = qa_manager.get_knowledge(query)


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：由于LPMM初始化和部分调用前未检验配置文件是否禁用LPMM 导致禁用无效
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的pull request总结：

## Sourcery 总结

通过配置驱动的方式禁用 LPMM 知识模块，具体方法是在禁用时跳过其初始化过程，并阻止所有知识检索调用。

Bug修复：
- 遵循 `lpmm_knowledge.enable` 标志，跳过 LPMM 初始化，避免不必要的设置。
- 当 LPMM 被禁用时，通过添加空值检查和使用合适的fallback提前返回，来阻止调用 `qa_manager.get_knowledge`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement configuration-driven disabling of the LPMM knowledge module by bypassing its initialization and guarding all knowledge retrieval calls when disabled.

Bug Fixes:
- Respect the `lpmm_knowledge.enable` flag to skip LPMM initialization and avoid unintended setup.
- Prevent calls to `qa_manager.get_knowledge` when LPMM is disabled by adding null checks and early returns with appropriate fallbacks.

</details>