### PR TITLE
解决麦麦对同一句话连续给予多个相似回复的问题

### DIFF
--- a/src/chat/focus_chat/planners/planner_simple.py
+++ b/src/chat/focus_chat/planners/planner_simple.py
@@ -29,6 +29,11 @@ def init_prompt():
 {chat_context_description}，以下是具体的聊天内容：
 {chat_content_block}
 {moderation_prompt}
+
+重要提醒：避免重复回复同一话题
+- 如果你在最近1分钟内已经对某个话题进行了回复，不要再次回复相同或相似的内容
+- 如果聊天记录显示你刚刚已经回复过相似内容，即使话题仍然在进行，也应该选择no_reply
+
 现在请你根据聊天内容选择合适的action:
 
 {action_options_text}


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：麦麦经常对同一句话给予多个相似回复
# 其他信息
- **关联 Issue**：Open #1087 
- **截图/GIF**：
- **附加信息**:
在reply动作描述中有在action_require = ["你想要闲聊或者随便附和", "有人提到你", "如果你刚刚进行了回复，不要对同一个话题重复回应"] 但是麦麦经常不遵循 于是在动作选择器提示词中强调
重要提醒：避免重复回复同一话题
- 如果你在最近1分钟内已经对某个话题进行了回复，不要再次回复相同或相似的内容
- 如果聊天记录显示你刚刚已经回复过相似内容，即使话题仍然在进行，也应该选择no_reply
能不能解决我也不知道 现在貌似问题好很多 但是 呃 还和大模型本身有关吧 忽略提示词了