### PR TITLE
修复hfc在私聊情况下的糟糕表现，让no_reply对私聊不执行退出专注模式的逻辑

### DIFF
--- a/src/chat/focus_chat/heartFC_chat.py
+++ b/src/chat/focus_chat/heartFC_chat.py
@@ -190,12 +190,6 @@ class HeartFChatting:
                                 if loop_info["loop_action_info"]["command"] == "stop_focus_chat":
                                     logger.info(f"{self.log_prefix} 麦麦决定停止专注聊天")
 
-                                    # 如果是私聊，则不停止，而是重置疲劳度并继续
-                                    if not self.chat_stream.group_info:
-                                        logger.info(f"{self.log_prefix} 私聊模式下收到停止请求，不退出。")
-                                        continue  # 继续下一次循环，而不是退出
-
-                                    # 如果是群聊，则执行原来的停止逻辑
                                     # 如果设置了回调函数，则调用它
                                     if self.on_stop_focus_chat:
                                         try:

--- a/src/chat/focus_chat/heartFC_chat.py
+++ b/src/chat/focus_chat/heartFC_chat.py
@@ -478,10 +478,6 @@ class HeartFChatting:
                     )
                     # 设置系统命令，在下次循环检查时触发退出
                     command = "stop_focus_chat"
-                elif self._message_count >= current_threshold and global_config.chat.chat_mode != "auto":
-                    logger.info(
-                        f"{self.log_prefix} [非auto模式] 已发送 {self._message_count} 条消息，达到疲惫阈值 {current_threshold}，但非auto模式不会自动退出"
-                    )
             else:
                 if reply_text == "timeout":
                     self.reply_timeout_count += 1

--- a/src/plugins/built_in/core_actions/no_reply.py
+++ b/src/plugins/built_in/core_actions/no_reply.py
@@ -107,7 +107,7 @@ class NoReplyAction(BaseAction):
                 current_time = time.time()
                 elapsed_time = current_time - start_time
 
-                if global_config.chat.chat_mode == "auto":
+                if global_config.chat.chat_mode == "auto" and self.is_group:
                     # 检查是否超时
                     if elapsed_time >= self._max_timeout:
                         logger.info(f"{self.log_prefix} 达到最大等待时间{self._max_timeout}秒，退出专注模式")
@@ -220,73 +220,81 @@ class NoReplyAction(BaseAction):
                         frequency_block = ""
                         should_skip_llm_judge = False  # 是否跳过LLM判断
 
-                        try:
-                            # 获取过去10分钟的所有消息
-                            past_10min_time = current_time - 600  # 10分钟前
-                            all_messages_10min = message_api.get_messages_by_time_in_chat(
-                                chat_id=self.chat_id,
-                                start_time=past_10min_time,
-                                end_time=current_time,
-                            )
+                        # 【新增】如果是私聊环境，跳过疲劳度检查
+                        if not self.is_group:
+                            frequency_block = "你正在和别人私聊，你不会疲惫，正常聊天即可。"
+                            should_skip_llm_judge = False
+                            logger.debug(f"{self.log_prefix} 私聊环境，跳过疲劳度检查")
 
-                            # 手动过滤bot自己的消息
-                            bot_message_count = 0
-                            if all_messages_10min:
-                                user_id = global_config.bot.qq_account
+                        else:
 
-                                for message in all_messages_10min:
-                                    # 检查消息发送者是否是bot
-                                    sender_id = message.get("user_id", "")
+                            try:
+                                # 获取过去10分钟的所有消息
+                                past_10min_time = current_time - 600  # 10分钟前
+                                all_messages_10min = message_api.get_messages_by_time_in_chat(
+                                    chat_id=self.chat_id,
+                                    start_time=past_10min_time,
+                                    end_time=current_time,
+                                )
 
-                                    if sender_id == user_id:
-                                        bot_message_count += 1
+                                # 手动过滤bot自己的消息
+                                bot_message_count = 0
+                                if all_messages_10min:
+                                    user_id = global_config.bot.qq_account
 
-                            talk_frequency_threshold = global_config.chat.get_current_talk_frequency(self.chat_id) * 10
+                                    for message in all_messages_10min:
+                                        # 检查消息发送者是否是bot
+                                        sender_id = message.get("user_id", "")
 
-                            if bot_message_count > talk_frequency_threshold:
-                                over_count = bot_message_count - talk_frequency_threshold
+                                        if sender_id == user_id:
+                                            bot_message_count += 1
 
-                                # 根据超过的数量设置不同的提示词和跳过概率
-                                skip_probability = 0
-                                if over_count <= 3:
-                                    frequency_block = "你感觉稍微有些累，回复的有点多了。\n"
-                                elif over_count <= 5:
-                                    frequency_block = "你今天说话比较多，感觉有点疲惫，想要稍微休息一下。\n"
-                                elif over_count <= 8:
-                                    frequency_block = "你发现自己说话太多了，感觉很累，想要安静一会儿，除非有重要的事情否则不想回复。\n"
-                                    skip_probability = self._skip_probability
-                                else:
-                                    frequency_block = "你感觉非常累，想要安静一会儿。\n"
-                                    skip_probability = 1
+                                talk_frequency_threshold = global_config.chat.get_current_talk_frequency(self.chat_id) * 10
 
-                                # 根据配置和概率决定是否跳过LLM判断
-                                if self._skip_judge_when_tired and random.random() < skip_probability:
-                                    should_skip_llm_judge = True
+                                if bot_message_count > talk_frequency_threshold:
+                                    over_count = bot_message_count - talk_frequency_threshold
+
+                                    # 根据超过的数量设置不同的提示词和跳过概率
+                                    skip_probability = 0
+                                    if over_count <= 3:
+                                        frequency_block = "你感觉稍微有些累，回复的有点多了。\n"
+                                    elif over_count <= 5:
+                                        frequency_block = "你今天说话比较多，感觉有点疲惫，想要稍微休息一下。\n"
+                                    elif over_count <= 8:
+                                        frequency_block = "你发现自己说话太多了，感觉很累，想要安静一会儿，除非有重要的事情否则不想回复。\n"
+                                        skip_probability = self._skip_probability
+                                    else:
+                                        frequency_block = "你感觉非常累，想要安静一会儿。\n"
+                                        skip_probability = 1
+
+                                    # 根据配置和概率决定是否跳过LLM判断
+                                    if self._skip_judge_when_tired and random.random() < skip_probability:
+                                        should_skip_llm_judge = True
+                                        logger.info(
+                                            f"{self.log_prefix} 发言过多(超过{over_count}条)，随机决定跳过此次LLM判断(概率{skip_probability * 100:.0f}%)"
+                                        )
+
                                     logger.info(
-                                        f"{self.log_prefix} 发言过多(超过{over_count}条)，随机决定跳过此次LLM判断(概率{skip_probability * 100:.0f}%)"
+                                        f"{self.log_prefix} 过去10分钟发言{bot_message_count}条，超过阈值{talk_frequency_threshold}，添加疲惫提示"
+                                    )
+                                else:
+                                    # 回复次数少时的正向提示
+                                    under_count = talk_frequency_threshold - bot_message_count
+
+                                    if under_count >= talk_frequency_threshold * 0.8:  # 回复很少（少于20%）
+                                        frequency_block = "你感觉精力充沛，状态很好，积极参与聊天。\n"
+                                    elif under_count >= talk_frequency_threshold * 0.5:  # 回复较少（少于50%）
+                                        frequency_block = "你感觉状态不错。\n"
+                                    else:  # 刚好达到阈值
+                                        frequency_block = ""
+
+                                    logger.info(
+                                        f"{self.log_prefix} 过去10分钟发言{bot_message_count}条，未超过阈值{talk_frequency_threshold}，添加正向提示"
                                     )
 
-                                logger.info(
-                                    f"{self.log_prefix} 过去10分钟发言{bot_message_count}条，超过阈值{talk_frequency_threshold}，添加疲惫提示"
-                                )
-                            else:
-                                # 回复次数少时的正向提示
-                                under_count = talk_frequency_threshold - bot_message_count
-
-                                if under_count >= talk_frequency_threshold * 0.8:  # 回复很少（少于20%）
-                                    frequency_block = "你感觉精力充沛，状态很好，积极参与聊天。\n"
-                                elif under_count >= talk_frequency_threshold * 0.5:  # 回复较少（少于50%）
-                                    frequency_block = "你感觉状态不错。\n"
-                                else:  # 刚好达到阈值
-                                    frequency_block = ""
-
-                                logger.info(
-                                    f"{self.log_prefix} 过去10分钟发言{bot_message_count}条，未超过阈值{talk_frequency_threshold}，添加正向提示"
-                                )
-
-                        except Exception as e:
-                            logger.warning(f"{self.log_prefix} 检查发言频率时出错: {e}")
-                            frequency_block = ""
+                            except Exception as e:
+                                logger.warning(f"{self.log_prefix} 检查发言频率时出错: {e}")
+                                frequency_block = ""
 
                         # 如果决定跳过LLM判断，直接更新时间并继续等待
                         if should_skip_llm_judge:
@@ -294,10 +302,11 @@ class NoReplyAction(BaseAction):
                             continue  # 跳过本次LLM判断，继续循环等待
 
                         # 构建判断上下文
+                        chat_context = "QQ群" if self.is_group else "私聊"
                         judge_prompt = f"""
 {identity_block}
 
-你现在正在QQ群参与聊天，以下是聊天内容：
+你现在正在{chat_context}参与聊天，以下是聊天内容：
 {context_str}
 在以上的聊天中，你选择了暂时不回复，现在，你看到了新的聊天消息如下：
 {messages_text}
@@ -383,11 +392,11 @@ class NoReplyAction(BaseAction):
                 # 每10秒输出一次等待状态
                 if elapsed_time < 60:
                     if int(elapsed_time) % 10 == 0 and int(elapsed_time) > 0:
-                        logger.info(f"{self.log_prefix} 已等待{elapsed_time:.0f}秒，等待新消息...")
+                        logger.debug(f"{self.log_prefix} 已等待{elapsed_time:.0f}秒，等待新消息...")
                         await asyncio.sleep(1)
                 else:
                     if int(elapsed_time) % 60 == 0 and int(elapsed_time) > 0:
-                        logger.info(f"{self.log_prefix} 已等待{elapsed_time / 60:.0f}分钟，等待新消息...")
+                        logger.debug(f"{self.log_prefix} 已等待{elapsed_time / 60:.0f}分钟，等待新消息...")
                         await asyncio.sleep(1)
 
                 # 短暂等待后继续检查

--- a/src/plugins/built_in/core_actions/no_reply.py
+++ b/src/plugins/built_in/core_actions/no_reply.py
@@ -109,41 +109,11 @@ class NoReplyAction(BaseAction):
 
                 if global_config.chat.chat_mode == "auto" and self.is_group:
                     # 检查是否超时
-                    if elapsed_time >= self._max_timeout:
-                        logger.info(f"{self.log_prefix} 达到最大等待时间{self._max_timeout}秒，退出专注模式")
+                    if elapsed_time >= self._max_timeout or self._check_no_activity_and_exit_focus(current_time):
+                        logger.info(f"{self.log_prefix} 等待时间过久（{self._max_timeout}秒）或过去10分钟完全没有发言，退出专注模式")
                         # 标记退出专注模式
                         self.action_data["_system_command"] = "stop_focus_chat"
-                        exit_reason = f"{global_config.bot.nickname}（你）等待了{self._max_timeout}秒，感觉群里没有新内容，决定退出专注模式，稍作休息"
-                        await self.store_action_info(
-                            action_build_into_prompt=True,
-                            action_prompt_display=exit_reason,
-                            action_done=True,
-                        )
-                        return True, exit_reason
-
-                    # **新增**：检查回复频率，决定是否退出专注模式
-                    should_exit_focus = await self._check_frequency_and_exit_focus(current_time)
-                    if should_exit_focus:
-                        logger.info(f"{self.log_prefix} 检测到回复频率过高，退出专注模式")
-                        # 标记退出专注模式
-                        self.action_data["_system_command"] = "stop_focus_chat"
-                        exit_reason = (
-                            f"{global_config.bot.nickname}（你）发现自己回复太频繁了，决定退出专注模式，稍作休息"
-                        )
-                        await self.store_action_info(
-                            action_build_into_prompt=True,
-                            action_prompt_display=exit_reason,
-                            action_done=True,
-                        )
-                        return True, exit_reason
-
-                    # **新增**：检查过去10分钟是否完全没有发言，如果是则退出专注模式
-                    should_exit_no_activity = await self._check_no_activity_and_exit_focus(current_time)
-                    if should_exit_no_activity:
-                        logger.info(f"{self.log_prefix} 检测到过去10分钟完全没有发言，退出专注模式")
-                        # 标记退出专注模式
-                        self.action_data["_system_command"] = "stop_focus_chat"
-                        exit_reason = f"{global_config.bot.nickname}（你）发现自己过去10分钟完全没有说话，感觉可能不太活跃，决定退出专注模式"
+                        exit_reason = f"{global_config.bot.nickname}（你）等待了{self._max_timeout}秒，或完全没有说话，感觉群里没有新内容，决定退出专注模式，稍作休息"
                         await self.store_action_info(
                             action_build_into_prompt=True,
                             action_prompt_display=exit_reason,
@@ -220,83 +190,76 @@ class NoReplyAction(BaseAction):
                         frequency_block = ""
                         should_skip_llm_judge = False  # 是否跳过LLM判断
 
-                        # 【新增】如果是私聊环境，跳过疲劳度检查
-                        if not self.is_group:
-                            frequency_block = "你正在和别人私聊，你不会疲惫，正常聊天即可。"
-                            should_skip_llm_judge = False
-                            logger.debug(f"{self.log_prefix} 私聊环境，跳过疲劳度检查")
+                        try:
+                            # 获取过去10分钟的所有消息
+                            past_10min_time = current_time - 600  # 10分钟前
+                            all_messages_10min = message_api.get_messages_by_time_in_chat(
+                                chat_id=self.chat_id,
+                                start_time=past_10min_time,
+                                end_time=current_time,
+                            )
 
-                        else:
+                            # 手动过滤bot自己的消息
+                            bot_message_count = 0
+                            if all_messages_10min:
+                                user_id = global_config.bot.qq_account
 
-                            try:
-                                # 获取过去10分钟的所有消息
-                                past_10min_time = current_time - 600  # 10分钟前
-                                all_messages_10min = message_api.get_messages_by_time_in_chat(
-                                    chat_id=self.chat_id,
-                                    start_time=past_10min_time,
-                                    end_time=current_time,
+                                for message in all_messages_10min:
+                                    # 检查消息发送者是否是bot
+                                    sender_id = message.get("user_id", "")
+
+                                    if sender_id == user_id:
+                                        bot_message_count += 1
+
+                            talk_frequency_threshold = global_config.chat.get_current_talk_frequency(self.chat_id) * 10
+
+                            if bot_message_count > talk_frequency_threshold:
+                                over_count = bot_message_count - talk_frequency_threshold
+
+                                # 根据超过的数量设置不同的提示词和跳过概率
+                                skip_probability = 0
+                                if over_count <= 3:
+                                    frequency_block = "你感觉稍微有些累，回复的有点多了。\n"
+                                elif over_count <= 5:
+                                    frequency_block = "你今天说话比较多，感觉有点疲惫，想要稍微休息一下。\n"
+                                elif over_count <= 8:
+                                    frequency_block = "你发现自己说话太多了，感觉很累，想要安静一会儿，除非有重要的事情否则不想回复。\n"
+                                    skip_probability = self._skip_probability
+                                else:
+                                    frequency_block = "你感觉非常累，想要安静一会儿。\n"
+                                    skip_probability = 1
+
+                                # 根据配置和概率决定是否跳过LLM判断
+                                if self._skip_judge_when_tired and random.random() < skip_probability:
+                                    should_skip_llm_judge = True
+                                    logger.info(
+                                        f"{self.log_prefix} 发言过多(超过{over_count}条)，随机决定跳过此次LLM判断(概率{skip_probability * 100:.0f}%)"
+                                    )
+
+                                logger.info(
+                                    f"{self.log_prefix} 过去10分钟发言{bot_message_count}条，超过阈值{talk_frequency_threshold}，添加疲惫提示"
+                                )
+                            else:
+                                # 回复次数少时的正向提示
+                                under_count = talk_frequency_threshold - bot_message_count
+
+                                if under_count >= talk_frequency_threshold * 0.8:  # 回复很少（少于20%）
+                                    frequency_block = "你感觉精力充沛，状态很好，积极参与聊天。\n"
+                                elif under_count >= talk_frequency_threshold * 0.5:  # 回复较少（少于50%）
+                                    frequency_block = "你感觉状态不错。\n"
+                                else:  # 刚好达到阈值
+                                    frequency_block = ""
+
+                                logger.info(
+                                    f"{self.log_prefix} 过去10分钟发言{bot_message_count}条，未超过阈值{talk_frequency_threshold}，添加正向提示"
                                 )
 
-                                # 手动过滤bot自己的消息
-                                bot_message_count = 0
-                                if all_messages_10min:
-                                    user_id = global_config.bot.qq_account
-
-                                    for message in all_messages_10min:
-                                        # 检查消息发送者是否是bot
-                                        sender_id = message.get("user_id", "")
-
-                                        if sender_id == user_id:
-                                            bot_message_count += 1
-
-                                talk_frequency_threshold = global_config.chat.get_current_talk_frequency(self.chat_id) * 10
-
-                                if bot_message_count > talk_frequency_threshold:
-                                    over_count = bot_message_count - talk_frequency_threshold
-
-                                    # 根据超过的数量设置不同的提示词和跳过概率
-                                    skip_probability = 0
-                                    if over_count <= 3:
-                                        frequency_block = "你感觉稍微有些累，回复的有点多了。\n"
-                                    elif over_count <= 5:
-                                        frequency_block = "你今天说话比较多，感觉有点疲惫，想要稍微休息一下。\n"
-                                    elif over_count <= 8:
-                                        frequency_block = "你发现自己说话太多了，感觉很累，想要安静一会儿，除非有重要的事情否则不想回复。\n"
-                                        skip_probability = self._skip_probability
-                                    else:
-                                        frequency_block = "你感觉非常累，想要安静一会儿。\n"
-                                        skip_probability = 1
-
-                                    # 根据配置和概率决定是否跳过LLM判断
-                                    if self._skip_judge_when_tired and random.random() < skip_probability:
-                                        should_skip_llm_judge = True
-                                        logger.info(
-                                            f"{self.log_prefix} 发言过多(超过{over_count}条)，随机决定跳过此次LLM判断(概率{skip_probability * 100:.0f}%)"
-                                        )
-
-                                    logger.info(
-                                        f"{self.log_prefix} 过去10分钟发言{bot_message_count}条，超过阈值{talk_frequency_threshold}，添加疲惫提示"
-                                    )
-                                else:
-                                    # 回复次数少时的正向提示
-                                    under_count = talk_frequency_threshold - bot_message_count
-
-                                    if under_count >= talk_frequency_threshold * 0.8:  # 回复很少（少于20%）
-                                        frequency_block = "你感觉精力充沛，状态很好，积极参与聊天。\n"
-                                    elif under_count >= talk_frequency_threshold * 0.5:  # 回复较少（少于50%）
-                                        frequency_block = "你感觉状态不错。\n"
-                                    else:  # 刚好达到阈值
-                                        frequency_block = ""
-
-                                    logger.info(
-                                        f"{self.log_prefix} 过去10分钟发言{bot_message_count}条，未超过阈值{talk_frequency_threshold}，添加正向提示"
-                                    )
-
-                            except Exception as e:
-                                logger.warning(f"{self.log_prefix} 检查发言频率时出错: {e}")
-                                frequency_block = ""
+                        except Exception as e:
+                            logger.warning(f"{self.log_prefix} 检查发言频率时出错: {e}")
+                            frequency_block = ""
 
                         # 如果决定跳过LLM判断，直接更新时间并继续等待
+                        
                         if should_skip_llm_judge:
                             last_judge_time = time.time()  # 更新判断时间，避免立即重新判断
                             continue  # 跳过本次LLM判断，继续循环等待
@@ -389,7 +352,10 @@ class NoReplyAction(BaseAction):
                             logger.error(f"{self.log_prefix} 模型判断异常: {e}，继续等待")
                             last_judge_time = time.time()  # 异常时也更新时间，避免频繁重试
 
+                
+                
                 # 每10秒输出一次等待状态
+                logger.info(f"{self.log_prefix} 开始等待新消息...")
                 if elapsed_time < 60:
                     if int(elapsed_time) % 10 == 0 and int(elapsed_time) > 0:
                         logger.debug(f"{self.log_prefix} 已等待{elapsed_time:.0f}秒，等待新消息...")
@@ -414,65 +380,7 @@ class NoReplyAction(BaseAction):
             )
             return False, f"不回复动作执行失败: {e}"
 
-    async def _check_frequency_and_exit_focus(self, current_time: float) -> bool:
-        """检查回复频率，决定是否退出专注模式
-
-        Args:
-            current_time: 当前时间戳
-
-        Returns:
-            bool: 是否应该退出专注模式
-        """
-        try:
-            # 只在auto模式下进行频率检查
-            if global_config.chat.chat_mode != "auto":
-                return False
-
-            # 获取检查窗口内的所有消息
-            window_start_time = current_time - self._frequency_check_window
-            all_messages = message_api.get_messages_by_time_in_chat(
-                chat_id=self.chat_id,
-                start_time=window_start_time,
-                end_time=current_time,
-            )
-
-            if not all_messages:
-                return False
-
-            # 统计bot自己的回复数量
-            bot_message_count = 0
-            user_id = global_config.bot.qq_account
-
-            for message in all_messages:
-                sender_id = message.get("user_id", "")
-                if sender_id == user_id:
-                    bot_message_count += 1
-
-            # 计算当前回复频率（每分钟回复数）
-            window_minutes = self._frequency_check_window / 60
-            current_frequency = bot_message_count / window_minutes
-
-            # 计算阈值频率：使用 exit_focus_threshold * 1.5
-            threshold_multiplier = global_config.chat.exit_focus_threshold * 1.5
-            threshold_frequency = global_config.chat.get_current_talk_frequency(self.chat_id) * threshold_multiplier
-
-            # 判断是否超过阈值
-            if current_frequency > threshold_frequency:
-                logger.info(
-                    f"{self.log_prefix} 回复频率检查：当前频率 {current_frequency:.2f}/分钟，超过阈值 {threshold_frequency:.2f}/分钟 (exit_threshold={global_config.chat.exit_focus_threshold} * 1.5)，准备退出专注模式"
-                )
-                return True
-            else:
-                logger.debug(
-                    f"{self.log_prefix} 回复频率检查：当前频率 {current_frequency:.2f}/分钟，未超过阈值 {threshold_frequency:.2f}/分钟 (exit_threshold={global_config.chat.exit_focus_threshold} * 1.5)"
-                )
-                return False
-
-        except Exception as e:
-            logger.error(f"{self.log_prefix} 检查回复频率时出错: {e}")
-            return False
-
-    async def _check_no_activity_and_exit_focus(self, current_time: float) -> bool:
+    def _check_no_activity_and_exit_focus(self, current_time: float) -> bool:
         """检查过去10分钟是否完全没有发言，决定是否退出专注模式
 
         Args:


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：修复hfc在私聊情况下的永劫轮回（因为no_reply对发言频率的判定太容易出意外，致使每次都发送退出专注模式指令，但此前在HFC写的是私聊收到直接开始下一轮循环，于是变成了高频思考），我直接从no_reply下手了。
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复了私聊中 focus chat 的错误行为，通过禁用 `no_reply` 超时和疲劳检查（仅在群聊中启用），恢复了正确的停止命令处理，并降低了日志的冗余程度。

Bug 修复：
- 阻止 `no_reply` 在私聊中退出 focus 模式，通过将超时和疲劳逻辑限制在群聊中实现
- 恢复私聊中的 `stop_focus_chat` 处理，通过移除阻止 focus 退出的覆盖来实现

增强：
- 在 judge 提示中嵌入聊天上下文标签（群组 vs 私人）
- 将周期性等待日志从 info 调整为 debug，以减少冗余信息

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix focus chat misbehavior in private chats by disabling no_reply timeout and fatigue checks outside group chats, restoring proper stop command handling, and reducing log verbosity.

Bug Fixes:
- Prevent no_reply from exiting focus mode in private chats by restricting timeout and fatigue logic to group chats
- Restore stop_focus_chat handling in private chats by removing override that blocked focus exit

Enhancements:
- Embed chat context label (group vs private) in judge prompts
- Adjust periodic waiting logs from info to debug for less verbosity

</details>