### PR TITLE
fix: avoid slice error when content is not sliceable

### DIFF
--- a/src/tools/tool_executor.py
+++ b/src/tools/tool_executor.py
@@ -187,7 +187,12 @@ class ToolExecutor:
                     tool_results.append(tool_info)
 
                     logger.info(f"{self.log_prefix}工具{tool_name}执行成功，类型: {tool_info['type']}")
-                    logger.debug(f"{self.log_prefix}工具{tool_name}结果内容: {tool_info['content'][:200]}...")
+                    content = tool_info['content']
+                    if isinstance(content, (str, list, tuple)):
+                        preview = content[:200]
+                    else:
+                        preview = str(content)[:200]
+                    logger.debug(f"{self.log_prefix}工具{tool_name}结果内容: {preview}...")
 
             except Exception as e:
                 logger.error(f"{self.log_prefix}工具{tool_name}执行失败: {e}")

--- a/src/tools/tool_executor.py
+++ b/src/tools/tool_executor.py
@@ -188,10 +188,9 @@ class ToolExecutor:
 
                     logger.info(f"{self.log_prefix}工具{tool_name}执行成功，类型: {tool_info['type']}")
                     content = tool_info['content']
-                    if isinstance(content, (str, list, tuple)):
-                        preview = content[:200]
-                    else:
-                        preview = str(content)[:200]
+                    if not isinstance(content, (str, list, tuple)):
+                        content = str(content)
+                    preview = content[:200]
                     logger.debug(f"{self.log_prefix}工具{tool_name}结果内容: {preview}...")
 
             except Exception as e:


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

## Sourcery 总结

Bug 修复：
- 避免在记录工具输出时发生切片错误，方法是在预览之前处理不可切片的内容类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid slice errors when logging tool output by handling non-sliceable content types before previewing.

</details>