### PR TITLE
消息存储additional_config，让过滤麦麦消息的功能同时过滤指令截断的消息，让no_reply真正启用过滤麦麦消息功能

### DIFF
--- a/src/chat/message_receive/storage.py
+++ b/src/chat/message_receive/storage.py
@@ -94,6 +94,7 @@ class MessageStorage:
                 interest_value=interest_value,
                 priority_mode=priority_mode,
                 priority_info=priority_info,
+                additional_config=message.message_info.additional_config,
                 is_emoji=is_emoji,
                 is_picid=is_picid,
             )

--- a/src/chat/message_receive/storage.py
+++ b/src/chat/message_receive/storage.py
@@ -94,7 +94,7 @@ class MessageStorage:
                 interest_value=interest_value,
                 priority_mode=priority_mode,
                 priority_info=priority_info,
-                additional_config=message.message_info.additional_config,
+                additional_config=message.message_info.get('additional_config', None),
                 is_emoji=is_emoji,
                 is_picid=is_picid,
             )

--- a/src/chat/message_receive/storage.py
+++ b/src/chat/message_receive/storage.py
@@ -94,7 +94,7 @@ class MessageStorage:
                 interest_value=interest_value,
                 priority_mode=priority_mode,
                 priority_info=priority_info,
-                additional_config=message.message_info.get('additional_config', None),
+                additional_config=message.message_info.additional_config,
                 is_emoji=is_emoji,
                 is_picid=is_picid,
             )

--- a/src/plugin_system/apis/message_api.py
+++ b/src/plugin_system/apis/message_api.py
@@ -472,10 +472,12 @@ async def get_person_ids_from_messages(messages: List[Dict[str, Any]]) -> List[s
 
 def filter_mai_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
-    从消息列表中移除麦麦的消息
+    从消息列表中移除麦麦的消息并顺便过滤掉已经被命令截断的消息
     Args:
         messages: 消息列表，每个元素是消息字典
     Returns:
         过滤后的消息列表
     """
-    return [msg for msg in messages if msg.get("user_id") != str(global_config.bot.qq_account)]
+    return [msg for msg in messages if msg.get("user_id") != str(global_config.bot.qq_account)
+            and msg.get("interested_rate") is not None
+            ]

--- a/src/plugins/built_in/core_actions/no_reply.py
+++ b/src/plugins/built_in/core_actions/no_reply.py
@@ -79,7 +79,7 @@ class NoReplyAction(BaseAction):
 
                 # 1. 检查新消息
                 recent_messages_dict = message_api.get_messages_by_time_in_chat(
-                    chat_id=self.chat_id, start_time=start_time, end_time=current_time
+                    chat_id=self.chat_id, start_time=start_time, end_time=current_time, filter_mai=True
                 )
                 new_message_count = len(recent_messages_dict)
 


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：消息存储additional_config，让过滤麦麦消息的功能同时过滤指令截断的消息，让no_reply真正启用过滤麦麦消息功能
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

将 additional_config 与每条消息一起存储，并将增强的 filter_mai_messages 逻辑连接到 no_reply 操作，以正确过滤机器人消息和截断的消息。

增强功能：
- 将消息 additional_config 持久化到存储层
- 扩展 filter_mai_messages，通过 interested_rate 检查排除命令截断的消息
- 使 no_reply 操作能够在获取最近消息时应用增强的 Mai 消息过滤器

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Store additional_config with each message and wire up the enhanced filter_mai_messages logic into the no_reply action to properly filter both bot and truncated messages

Enhancements:
- Persist message additional_config in the storage layer
- Extend filter_mai_messages to also exclude command-truncated messages via interested_rate check
- Enable the no_reply action to apply the enhanced Mai message filter when fetching recent messages

</details>