### PR TITLE
适配无兴趣度消息

### DIFF
--- a/src/chat/focus_chat/heartFC_chat.py
+++ b/src/chat/focus_chat/heartFC_chat.py
@@ -462,7 +462,7 @@ class HeartFChatting:
         在"兴趣"模式下，判断是否回复并生成内容。
         """
 
-        interested_rate = message_data.get("interest_value", 0.0) * self.willing_amplifier
+        interested_rate = (message_data.get("interest_value") or 0.0) * self.willing_amplifier
     
         self.willing_manager.setup(message_data, self.chat_stream)
     

--- a/src/chat/willing/willing_manager.py
+++ b/src/chat/willing/willing_manager.py
@@ -104,7 +104,7 @@ class BaseWillingManager(ABC):
             is_mentioned_bot=message.get("is_mentioned", False),
             is_emoji=message.get("is_emoji", False),
             is_picid=message.get("is_picid", False),
-            interested_rate=message.get("interest_value", 0),
+            interested_rate = message.get("interest_value") or 0.0,
         )
 
     def delete(self, message_id: str):


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：适配无兴趣度消息
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

好的，这是将 pull request 总结翻译成中文的结果：

## Sourcery 总结

Bug 修复：
- 将从消息数据中检索的 `interest_value` 默认值设置为 `0.0`，以防止 `None` 或缺失值导致 `heartFC_chat` 和 `willing_manager` 中出现错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Default interest_value to 0.0 when retrieving from message data to prevent None or missing values causing errors in heartFC_chat and willing_manager

</details>