### PR TITLE
feat: 更新 Docker 工作流配置，调整arm运行环境由qemu至 arm服务器 ，优化分支和标签设置

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,27 +1,23 @@
 name: Docker Build and Push
 
 on:
-  # push:
-  #   branches:
-  #     - main
-  #     - classical
-  #     - dev
-  #   tags:
-  #     - "v*.*.*"
-  #     - "v*"
-  #     - "*.*.*"
-  #     - "*.*.*-*"
-  workflow_dispatch: # 允许手动触发工作流
+  push:
     branches:
       - main
+      - classical
       - dev
-      - dev-refactor
+    tags:
+      - "v*.*.*"
+      - "v*"
+      - "*.*.*"
+      - "*.*.*-*"
+  workflow_dispatch: # 允许手动触发工作流
 
 # Workflow's jobs
 jobs:
   build-amd64:
     name: Build AMD64 Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
@@ -74,7 +70,7 @@ jobs:
 
   build-arm64:
     name: Build ARM64 Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
@@ -89,11 +85,6 @@ jobs:
 
       - name: Clone lpmm
         run: git clone https://github.com/MaiM-with-u/MaiMBot-LPMM.git MaiMBot-LPMM
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -132,7 +123,7 @@ jobs:
 
   create-manifest:
     name: Create Multi-Arch Manifest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - build-amd64
       - build-arm64


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

## Sourcery 总结

更新 Docker 构建工作流，以激活在指定分支和标签上的推送触发器，将运行器环境标准化为 Ubuntu 24.04（包括一个 ARM 专用运行器），并移除用于 ARM 构建的 QEMU 仿真设置。

CI:
- 启用在 main、classical 和 dev 分支以及语义版本标签上的推送触发器
- 将 AMD 和 ARM 构建作业分别切换到 ubuntu-24.04 和 ubuntu-24.04-arm 运行器
- 移除 QEMU 设置步骤，并依赖原生 ARM 服务器进行 ARM64 构建

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Docker build workflow to activate push triggers on designated branches and tags, standardize runner environments to Ubuntu 24.04 (including an ARM-specific runner), and remove the QEMU emulation setup for ARM builds

CI:
- Enable push triggers on main, classical, and dev branches as well as semantic version tags
- Switch AMD and ARM build jobs to ubuntu-24.04 and ubuntu-24.04-arm runners respectively
- Remove the QEMU setup step and rely on a native ARM server for ARM64 builds

</details>