### PR TITLE
fix: 修复docker-image.yml中的分支和标签配置，取消qemu更新arm服务器，更新docker-compose.yml格式

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,27 +1,23 @@
 name: Docker Build and Push
 
 on:
-  # push:
-  #   branches:
-  #     - main
-  #     - classical
-  #     - dev
-  #   tags:
-  #     - "v*.*.*"
-  #     - "v*"
-  #     - "*.*.*"
-  #     - "*.*.*-*"
-  workflow_dispatch: # 允许手动触发工作流
+  push:
     branches:
       - main
+      - classical
       - dev
-      - dev-refactor
+    tags:
+      - "v*.*.*"
+      - "v*"
+      - "*.*.*"
+      - "*.*.*-*"
+  workflow_dispatch: # 允许手动触发工作流
 
 # Workflow's jobs
 jobs:
   build-amd64:
     name: Build AMD64 Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
@@ -74,7 +70,7 @@ jobs:
 
   build-arm64:
     name: Build ARM64 Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
@@ -89,11 +85,6 @@ jobs:
 
       - name: Clone lpmm
         run: git clone https://github.com/MaiM-with-u/MaiMBot-LPMM.git MaiMBot-LPMM
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -132,7 +123,7 @@ jobs:
 
   create-manifest:
     name: Create Multi-Arch Manifest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - build-amd64
       - build-arm64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,7 @@ services:
   #     - ./data/MaiMBot:/data/MaiMBot
   #   networks:
   #     - maim_bot
+  
 volumes:
   site-packages:
 networks:


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [ ] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

## Sourcery 总结

修复 Docker 镜像工作流中的分支和标签匹配问题，将所有构建作业的 GitHub Actions 运行器更新到 Ubuntu 24.04，移除 ARM 构建的 QEMU 设置步骤，并清理 docker-compose.yml 格式。

改进:
- 清理 docker-compose.yml 格式中的间距

CI:
- 修复 .github/workflows/docker-image.yml 中的分支和标签过滤器
- 更新构建和 manifest 作业，使其在 AMD64 上运行于 Ubuntu 24.04，ARM64 上运行于 Ubuntu 24.04-arm，以及 manifest 运行于 Ubuntu 24.04
- 从 ARM64 构建作业中移除 QEMU 设置操作

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix branch and tag matching in the Docker image workflow, update GitHub Actions runners to Ubuntu 24.04 for all build jobs, remove the QEMU setup step for ARM builds, and clean up docker-compose.yml formatting

Enhancements:
- Add spacing cleanup in docker-compose.yml format

CI:
- Fix branch and tag filters in .github/workflows/docker-image.yml
- Update build and manifest jobs to run on Ubuntu 24.04 for AMD64, Ubuntu 24.04-arm for ARM64, and Ubuntu 24.04 for the manifest
- Remove the QEMU setup action from the ARM64 build job

</details>