### PR TITLE
feat(database): 添加MySQL支持并重构数据库配置

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -14,6 +14,7 @@ from src.common.logger import get_logger
 from src.config.config_base import ConfigBase
 from src.config.official_configs import (
     BotConfig,
+    DataBaseConfig,
     PersonalityConfig,
     ExpressionConfig,
     ChatConfig,
@@ -348,6 +349,7 @@ class Config(ConfigBase):
     debug: DebugConfig
     custom_prompt: CustomPromptConfig
     voice: VoiceConfig
+    data_base: DataBaseConfig
 
 
 @dataclass

--- a/src/config/official_configs.py
+++ b/src/config/official_configs.py
@@ -1,5 +1,4 @@
 import re
-
 from dataclasses import dataclass, field
 from typing import Literal, Optional
 
@@ -17,7 +16,7 @@ from src.config.config_base import ConfigBase
 @dataclass
 class BotConfig(ConfigBase):
     """QQ机器人配置类"""
-    
+
     platform: str
     """平台"""
 
@@ -68,7 +67,7 @@ class ChatConfig(ConfigBase):
 
     max_context_size: int = 18
     """上下文长度"""
-    
+
     willing_amplifier: float = 1.0
 
     replyer_random_probability: float = 0.5
@@ -272,6 +271,7 @@ class NormalChatConfig(ConfigBase):
     willing_mode: str = "classical"
     """意愿模式"""
 
+
 @dataclass
 class ExpressionConfig(ConfigBase):
     """表达配置类"""
@@ -301,7 +301,8 @@ class ToolConfig(ConfigBase):
 
     enable_tool: bool = False
     """是否在聊天中启用工具"""
-    
+
+
 @dataclass
 class VoiceConfig(ConfigBase):
     """语音识别配置类"""
@@ -387,7 +388,7 @@ class MemoryConfig(ConfigBase):
 
     memory_ban_words: list[str] = field(default_factory=lambda: ["表情包", "图片", "回复", "聊天记录"])
     """不允许记忆的词列表"""
-    
+
     enable_instant_memory: bool = True
     """是否启用即时记忆"""
 
@@ -398,7 +399,7 @@ class MoodConfig(ConfigBase):
 
     enable_mood: bool = False
     """是否启用情绪系统"""
-    
+
     mood_update_threshold: float = 1.0
     """情绪更新阈值,越高，更新越慢"""
 
@@ -448,6 +449,7 @@ class KeywordReactionConfig(ConfigBase):
         for rule in self.keyword_rules + self.regex_rules:
             if not isinstance(rule, KeywordRuleConfig):
                 raise ValueError(f"规则必须是KeywordRuleConfig类型，而不是{type(rule).__name__}")
+
 
 @dataclass
 class CustomPromptConfig(ConfigBase):
@@ -598,3 +600,27 @@ class LPMMKnowledgeConfig(ConfigBase):
     embedding_dimension: int = 1024
     """嵌入向量维度，应该与模型的输出维度一致"""
 
+
+class DataBaseConfig(ConfigBase):
+    """数据库配置类"""
+
+    db_type: Literal["sqlite", "mysql"] = "sqlite"
+    """数据库类型，支持sqlite、mysql"""
+
+    host: str = "127.0.0.1"
+    """数据库主机地址"""
+
+    port: int = 3306
+    """数据库端口号"""
+
+    username: str = ""
+    """数据库用户名"""
+
+    password: str = ""
+    """数据库密码"""
+
+    database: str = "MaiBot"
+    """数据库名称"""
+
+    table_prefix: str = ""
+    """数据库表前缀"""

--- a/template/bot_config_template.toml
+++ b/template/bot_config_template.toml
@@ -1,5 +1,5 @@
 [inner]
-version = "6.0.0"
+version = "6.1.0"
 
 #----以下是给开发人员阅读的，如果你只是部署了麦麦，不需要阅读----
 #如果你想要修改配置文件，请在修改后将version的值进行变更
@@ -13,14 +13,14 @@ version = "6.0.0"
 #----以上是给开发人员阅读的，如果你只是部署了麦麦，不需要阅读----
 
 [bot]
-platform = "qq" 
+platform = "qq"
 qq_account = 1145141919810 # 麦麦的QQ账号
 nickname = "麦麦" # 麦麦的昵称
 alias_names = ["麦叠", "牢麦"] # 麦麦的别名
 
 [personality]
 # 建议50字以内，描述人格的核心特质
-personality_core = "是一个积极向上的女大学生" 
+personality_core = "是一个积极向上的女大学生"
 # 人格的细节，描述人格的一些侧面
 personality_side = "用一句话或几句话描述人格的侧面特质"
 #アイデンティティがない 生まれないらららら
@@ -39,7 +39,7 @@ enable_expression_learning = false # 是否启用表达学习，麦麦会学习�
 learning_interval = 350 # 学习间隔 单位秒
 
 expression_groups = [
-    ["qq:1919810:private","qq:114514:private","qq:1111111:group"], # 在这里设置互通组，相同组的chat_id会共享学习到的表达方式
+    ["qq:1919810:private", "qq:114514:private", "qq:1111111:group"], # 在这里设置互通组，相同组的chat_id会共享学习到的表达方式
     # 格式：["qq:123456:private","qq:654321:group"]
     # 注意：如果为群聊，则需要设置为group，如果设置为私聊，则需要设置为private
 ]
@@ -51,7 +51,7 @@ relation_frequency = 1 # 关系频率，麦麦构建关系的频率
 
 
 [chat] #麦麦的聊天通用设置
-focus_value = 1 
+focus_value = 1
 # 麦麦的专注思考能力，越高越容易专注，可能消耗更多token
 # 专注时能更好把握发言时机，能够进行持久的连续对话
 
@@ -95,7 +95,7 @@ talk_frequency_adjust = [
 # 以下是消息过滤，可以根据规则过滤特定消息，将不会读取这些消息
 ban_words = [
     # "403","张三"
-    ]
+]
 
 ban_msgs_regex = [
     # 需要过滤的消息（原始消息）匹配的正则表达式，匹配到的消息将被过滤，若不了解正则表达式请勿修改
@@ -139,7 +139,7 @@ consolidation_check_percentage = 0.05 # 检查节点比例
 enable_instant_memory = false # 是否启用即时记忆，测试功能，可能存在未知问题
 
 #不希望记忆的词，已经记忆的不会受到影响，需要手动清理
-memory_ban_words = [ "表情包", "图片", "回复", "聊天记录" ]
+memory_ban_words = ["表情包", "图片", "回复", "聊天记录"]
 
 [voice]
 enable_asr = false # 是否启用语音识别，启用后麦麦可以识别语音消息，启用该功能需要配置语音识别模型[model.voice]s
@@ -190,10 +190,10 @@ enable_response_post_process = true # 是否启用回复后处理，包括错别
 
 [chinese_typo]
 enable = true # 是否启用中文错别字生成器
-error_rate=0.01 # 单字替换概率
-min_freq=9 # 最小字频阈值
-tone_error_rate=0.1 # 声调错误概率
-word_replace_rate=0.006 # 整词替换概率
+error_rate = 0.01 # 单字替换概率
+min_freq = 9 # 最小字频阈值
+tone_error_rate = 0.1 # 声调错误概率
+word_replace_rate = 0.006 # 整词替换概率
 
 [response_splitter]
 enable = true # 是否启用回复分割器
@@ -210,8 +210,8 @@ console_log_level = "INFO" # 控制台日志级别，可选: DEBUG, INFO, WARNIN
 file_log_level = "DEBUG" # 文件日志级别，可选: DEBUG, INFO, WARNING, ERROR, CRITICAL
 
 # 第三方库日志控制
-suppress_libraries = ["faiss","httpx", "urllib3", "asyncio", "websockets", "httpcore", "requests", "peewee", "openai","uvicorn","jieba"] # 完全屏蔽的库
-library_log_levels = { "aiohttp" = "WARNING"} # 设置特定库的日志级别
+suppress_libraries = ["faiss", "httpx", "urllib3", "asyncio", "websockets", "httpcore", "requests", "peewee", "openai", "uvicorn", "jieba"] # 完全屏蔽的库
+library_log_levels = { "aiohttp" = "WARNING" } # 设置特定库的日志级别
 
 [debug]
 show_prompt = false # 是否显示prompt
@@ -220,9 +220,9 @@ show_prompt = false # 是否显示prompt
 auth_token = [] # 认证令牌，用于API验证，为空则不启用验证
 # 以下项目若要使用需要打开use_custom，并单独配置maim_message的服务器
 use_custom = false # 是否启用自定义的maim_message服务器，注意这需要设置新的端口，不能与.env重复
-host="127.0.0.1"
-port=8090
-mode="ws" # 支持ws和tcp两种模式
+host = "127.0.0.1"
+port = 8090
+mode = "ws" # 支持ws和tcp两种模式
 use_wss = false # 是否使用WSS安全连接，只支持ws模式
 cert_file = "" # SSL证书文件路径，仅在use_wss=true时有效
 key_file = "" # SSL密钥文件路径，仅在use_wss=true时有效
@@ -232,3 +232,13 @@ enable = true
 
 [experimental] #实验性功能
 enable_friend_chat = false # 是否启用好友聊天
+
+[data_base] #数据库配置
+# 数据库类型，可选：sqlite, mysql
+db_type = "sqlite" # 数据库类型
+host = "" # 数据库主机地址,如果是sqlite则不需要填写
+port = 3306 # 数据库端口,如果是sqlite则不需要填写
+username = "" # 数据库用户名,如果是sqlite则不需要填写
+password = "" # 数据库密码,如果是sqlite则不需要填写
+database = "MaiBot" # 数据库名称,如果是sqlite则不需要填写
+table_prefix = "" # 数据库表前缀,用于支持多实例部署


### PR DESCRIPTION
- 新增DataBaseConfig类用于集中管理数据库配置
- 重构数据库初始化逻辑，支持SQLite和MySQL两种数据库类型
- 为数据库表添加表前缀支持，便于多实例部署
- 更新数据库模型字段类型和长度限制
- 在配置模板中添加数据库配置节

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：添加MySQL支持并重构数据库配置
# 其他信息
- **关联 Issue**：Close #1162 
- **截图/GIF**：
- **附加信息**:

## Sourcery 总结

重构数据库配置，以集中化设置，并同时支持 MySQL 和 SQLite，为 Peewee 模型引入表前缀，更新模型字段类型和长度，并扩展机器人配置模板，增加新的数据库部分。

新功能：
- 添加 DataBaseConfig 类以及 bot_config_template 中的新 [data_base] 部分，用于配置数据库类型、凭据和表前缀。
- 实现 create_peewee_database 工厂函数，根据配置初始化 MySQL 或 SQLite 数据库。
- 通过 global_config 为所有 Peewee 模型表名添加表前缀支持。

改进：
- 将数据库初始化逻辑重构到 database.py 中，并整合连接指令。
- 将各种模型字段从 TextField 迁移到 CharField，并设置合适的 max_length，同时保留索引。
- 将配置模板版本更新到 6.1.0，并调整模板中的格式一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor database configuration to centralize settings and enable MySQL support alongside SQLite, introduce table prefixing for Peewee models, update model field types and lengths, and extend the bot configuration template with a new database section.

New Features:
- Add DataBaseConfig class and new [data_base] section in bot_config_template to configure database type, credentials, and table prefix.
- Implement create_peewee_database factory to initialize either MySQL or SQLite database based on configuration.
- Add table prefix support to all Peewee model table names via global_config.

Enhancements:
- Refactor database initialization logic into database.py and consolidate connection pragmas.
- Migrate various model fields from TextField to CharField with appropriate max_length and retain indexes.
- Update config template version to 6.1.0 and adjust formatting consistency across template.

</details>