### PR TITLE
relation_frequency为int时，如果配置了较小的值会出现除以0的问题

### DIFF
--- a/src/config/official_configs.py
+++ b/src/config/official_configs.py
@@ -61,8 +61,8 @@ class RelationshipConfig(ConfigBase):
     enable_relationship: bool = True
     """是否启用关系系统"""
 
-    relation_frequency: int = 1
-    """关系频率，麦麦构建关系的速度"""
+    relation_frequency: float = 1
+    """关系频率，麦麦构建关系的速度，值越大，构建的频率越高"""
 
 
 @dataclass


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：relation_frequency为int时，如果配置了较小的值会出现除以0的问题
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

## Sourcery 总结

将 `relation_frequency` 的类型改为浮点数，以允许小数数值，并防止当配置值过小时发生除以零的错误。

错误修复：
- 防止当 `relation_frequency` 设置为较小值时发生除以零的错误

功能改进：
- 将 `relation_frequency` 的类型从 int 更改为 float，并更新其文档

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use float for relation_frequency to allow fractional values and prevent division by zero when configured too small

Bug Fixes:
- Prevent division by zero when relation_frequency is set to a small value

Enhancements:
- Change relation_frequency type from int to float and update its documentation

</details>