### PR TITLE
修改 Dockerfile 打包过程，优化镜像打包和更新

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.13.5-slim-bookworm
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+EXPOSE 8000
+
+# 编译器
+RUN RUN apt-get update && apt-get install -y build-essential && rm -rf /var/lib/apt/lists/*
+RUN uv pip install --system --upgrade pip Cython py-cpuinfo setuptools
 
 # 工作目录
 WORKDIR /MaiMBot
@@ -10,23 +15,15 @@ COPY requirements.txt .
 #COPY maim_message /maim_message
 COPY MaiMBot-LPMM /MaiMBot-LPMM
 
-# 编译器
-RUN apt-get update && apt-get install -y build-essential
-
 # lpmm编译安装
 RUN cd /MaiMBot-LPMM && uv pip install --system -r requirements.txt
-RUN uv pip install --system Cython py-cpuinfo setuptools
 RUN cd /MaiMBot-LPMM/lib/quick_algo && python build_lib.py --cleanup --cythonize --install
 
-
 # 安装依赖
-RUN uv pip install --system --upgrade pip
 #RUN uv pip install --system -e /maim_message
 RUN uv pip install --system -r requirements.txt
 
 # 复制项目代码
 COPY . .
-
-EXPOSE 8000
 
 ENTRYPOINT [ "python","bot.py" ]


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [ ] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）: 无实际代码更新
6. 请简要说明本次更新的内容和目的：

这大概既不算 BUG 修复也不算功能新增，可能只是个次要改进，所以上面的两个勾我都没有勾选。

包含下面的更改：

1. 将一些固定不变的操作提前，这样就算发布新版本，这些镜像层也不会发生变化，减少了重复拉取浪费的流量和时间
2. 新加了一个 `apt-get clean` 操作，在必须的软件包安装完成后，将本地的 apt 仓库缓存删除，不要将其带入 Docker 镜像中，会严重增加体积，增加镜像拉取耗时

主要是减少镜像层数和镜像大小来改进拉取速度，目的主要是加快新版本发布时的拉取速度。我正在跟着 dev 分支更新麦麦，但是麦麦每次更新，我都要重新下载大量的镜像层。在Docker主仓库和主流镜像站被屏蔽/关闭无法访问后，目前拉取全靠公益镜像站，速度较慢，单次拉取需要消耗接近 15 分钟的时间。而在检查镜像后发现很多本可以避免拉取的内容，此 PR 正是改进这一点。

此更改未经测试，因为在 docker buid 的时候 MaiMBot-LPMM 不存在，但是 MaiMBot-LPMM 仓库又说是早期开发Demo，不能直接应用到MaiMBot项目中。再加上也没有 ci 之类的文件可以复现麦麦是怎么打包容器的，所以我决定跳过无法完成的测试。

# 其他信息
- **关联 Issue**：不适用
- **截图/GIF**：不适用
- **附加信息**: `uv pip install --system --upgrade pip` 和 `uv pip install --system Cython py-cpuinfo setuptools` 似乎也能合并到一起，减少一层镜像层。但是我对 pip 不是非常熟悉，所以决定没有改动这一点。
