### PR TITLE
fix(gemini): 对 thinking_budget 不同模型的处理

### DIFF
--- a/src/llm_models/model_client/gemini_client.py
+++ b/src/llm_models/model_client/gemini_client.py
@@ -44,10 +44,13 @@ from ..payload_content.tool_option import ToolOption, ToolParam, ToolCall
 
 logger = get_logger("Gemini客户端")
 
-# gemini_thinking参数
-GEMINI_THINKING_BUDGET_MIN = 512
-GEMINI_THINKING_BUDGET_MAX = 24576
-DEFAULT_THINKING_BUDGET = 1024
+# gemini_thinking参数（默认范围）
+# 不同模型的思考预算范围配置
+THINKING_BUDGET_LIMITS = {
+    "gemini-2.5-flash":       {"min": 1,   "max": 24576, "can_disable": True},
+    "gemini-2.5-flash-lite":  {"min": 512, "max": 24576, "can_disable": True},
+    "gemini-2.5-pro":         {"min": 128, "max": 32768, "can_disable": False},
+}
 
 gemini_safe_settings = [
     SafetySetting(category=HarmCategory.HARM_CATEGORY_HATE_SPEECH, threshold=HarmBlockThreshold.BLOCK_NONE),
@@ -333,6 +336,23 @@ class GeminiClient(BaseClient):
             api_key=api_provider.api_key,
         )  # 这里和openai不一样，gemini会自己决定自己是否需要retry
 
+    @staticmethod
+    def clamp_thinking_budget(tb: int, model_id: str) -> int:
+        """
+        按模型限制思考预算范围，仅支持指定的模型
+        """
+        if model_id not in THINKING_BUDGET_LIMITS:
+            raise ValueError(f"模型 {model_id} 不支持 ThinkingConfig")
+        limits = THINKING_BUDGET_LIMITS[model_id]
+        if tb == -1:
+            return -1  # 动态思考模式
+        if tb == 0:
+            if limits["can_disable"]:
+                return 0
+            else:
+                return limits["min"]
+        return max(limits["min"], min(tb, limits["max"]))
+
     async def get_response(
         self,
         model_info: ModelInfo,
@@ -379,17 +399,14 @@ class GeminiClient(BaseClient):
         # 将tool_options转换为Gemini API所需的格式
         tools = _convert_tool_options(tool_options) if tool_options else None
         # 将response_format转换为Gemini API所需的格式
-        try:
-            if extra_params and "thinking_budget" in extra_params:
-                tb = extra_params["thinking_budget"]
-                tb = int(tb)  # 尝试转换为整数
-            else:
-                tb = int(max_tokens / 2)
-        except (TypeError, ValueError) as e:
-            logger.warning(f"无效的thinking_budget值 {extra_params.get('thinking_budget') if extra_params else None}，使用默认值 {DEFAULT_THINKING_BUDGET}: {e}")
-            tb = DEFAULT_THINKING_BUDGET
+        # 处理 thinking_budget
+        if extra_params and "thinking_budget" in extra_params:
+            tb = extra_params["thinking_budget"]
+            tb = int(tb)  # 尝试转换为整数
+        else:
+            tb = int(max_tokens / 2)
 
-        tb = max(GEMINI_THINKING_BUDGET_MIN, min(tb, GEMINI_THINKING_BUDGET_MAX))  # 限制在合法范围（512-24576）
+        tb = self.clamp_thinking_budget(tb, model_info.model_identifier)
 
         generation_config_dict = {
             "max_output_tokens": max_tokens,


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

## Sourcery 总结

在 Gemini 客户端中，通过将全局常量替换为每个模型的配置，并添加一个钳制方法以正确处理预算，从而强制执行模型特定的 thinking_budget 限制

错误修复：
- 根据每个模型的特定最小/最大值钳制 thinking_budget，并处理禁用/动态模式
- 在应用 ThinkingConfig 时，对于不受支持的模型引发错误

改进：
- 移除旧的全局常量 DEFAULT_THINKING_BUDGET，并替换为 THINKING_BUDGET_LIMITS 映射
- 更新 get_response 以使用新的 clamp_thinking_budget 方法来处理 thinking_budget

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce model-specific thinking_budget limits in Gemini client by replacing global constants with a per-model configuration and adding a clamping method for correct budget handling

Bug Fixes:
- Clamp thinking_budget according to each model’s specific min/max and handle disable/dynamic modes
- Raise error for unsupported models when applying ThinkingConfig

Enhancements:
- Remove old global DEFAULT_THINKING_BUDGET and replace with THINKING_BUDGET_LIMITS mapping
- Update get_response to use the new clamp_thinking_budget method for processing thinking_budget

</details>