### PR TITLE
fix(gemini): 对 thinking_budget 不同模型的处理

### DIFF
--- a/src/llm_models/model_client/gemini_client.py
+++ b/src/llm_models/model_client/gemini_client.py
@@ -44,10 +44,13 @@ from ..payload_content.tool_option import ToolOption, ToolParam, ToolCall
 
 logger = get_logger("Gemini客户端")
 
-# gemini_thinking参数
-GEMINI_THINKING_BUDGET_MIN = 512
-GEMINI_THINKING_BUDGET_MAX = 24576
-DEFAULT_THINKING_BUDGET = 1024
+# gemini_thinking参数（默认范围）
+# 对不同模型的思考预算范围配置
+THINKING_BUDGET_LIMITS = {
+    "gemini-2.5-flash":       {"min": 1,   "max": 24576, "can_disable": True},
+    "gemini-2.5-flash-lite":  {"min": 512, "max": 24576, "can_disable": True},
+    "gemini-2.5-pro":         {"min": 128, "max": 32768, "can_disable": False},
+}
 
 gemini_safe_settings = [
     SafetySetting(category=HarmCategory.HARM_CATEGORY_HATE_SPEECH, threshold=HarmBlockThreshold.BLOCK_NONE),
@@ -333,6 +336,30 @@ class GeminiClient(BaseClient):
             api_key=api_provider.api_key,
         )  # 这里和openai不一样，gemini会自己决定自己是否需要retry
 
+    # 思维预算的特殊值
+    TB_DYNAMIC_MODE = -1
+    TB_DISABLE_OR_MIN = 0
+
+    @staticmethod
+    def clamp_thinking_budget(tb: int, model_id: str) -> int:
+        """
+        按模型限制思考预算范围，仅支持指定的模型
+        """
+        limits = THINKING_BUDGET_LIMITS.get(model_id)
+        if limits is None:
+            raise ValueError(f"模型 {model_id} 不支持 ThinkingConfig")
+        if tb == GeminiClient.TB_DYNAMIC_MODE:
+            return GeminiClient.TB_DYNAMIC_MODE  # 动态思考模式
+        if tb == GeminiClient.TB_DISABLE_OR_MIN:
+            if limits["can_disable"]:
+                # 允许禁用思考预算
+                return GeminiClient.TB_DISABLE_OR_MIN
+            else:
+                # 不允许禁用，返回最小值
+                return limits["min"]
+        # 正常范围裁剪
+        return max(limits["min"], min(tb, limits["max"]))
+
     async def get_response(
         self,
         model_info: ModelInfo,
@@ -379,17 +406,17 @@ class GeminiClient(BaseClient):
         # 将tool_options转换为Gemini API所需的格式
         tools = _convert_tool_options(tool_options) if tool_options else None
         # 将response_format转换为Gemini API所需的格式
+        # 处理 thinking_budget
         try:
             if extra_params and "thinking_budget" in extra_params:
-                tb = extra_params["thinking_budget"]
-                tb = int(tb)  # 尝试转换为整数
+                tb = int(extra_params["thinking_budget"])
             else:
                 tb = int(max_tokens / 2)
-        except (TypeError, ValueError) as e:
-            logger.warning(f"无效的thinking_budget值 {extra_params.get('thinking_budget') if extra_params else None}，使用默认值 {DEFAULT_THINKING_BUDGET}: {e}")
-            tb = DEFAULT_THINKING_BUDGET
+        except (ValueError, TypeError):
+            logger.warning(f"无效的thinking_budget值 {extra_params.get('thinking_budget') if extra_params else None}，将使用 max_tokens/2 作为默认值")
+            tb = int(max_tokens / 2)
 
-        tb = max(GEMINI_THINKING_BUDGET_MIN, min(tb, GEMINI_THINKING_BUDGET_MAX))  # 限制在合法范围（512-24576）
+        tb = self.clamp_thinking_budget(tb, model_info.model_identifier)
 
         generation_config_dict = {
             "max_output_tokens": max_tokens,


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

## Sourcery 总结

在 Gemini 客户端中实现每个模型的 `thinking_budget` 处理，通过将全局默认值替换为可配置的限制，引入特殊模式，并改进错误处理。

Bug 修复：
- 将旧的全局 `thinking_budget` 常量替换为模型特定的限制，以修复不正确的预算强制执行

改进：
- 添加 `THINKING_BUDGET_LIMITS` 映射，其中包含每个模型的 `min`、`max` 和 `can_disable` 标志
- 引入 `clamp_thinking_budget` 方法，以强制执行模型特定的边界并支持动态/禁用模式
- 更新 `get_response` 以解析、限制并记录无效的 `thinking_budget` 值，并改进了回退逻辑

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement per-model thinking_budget handling in the Gemini client by replacing global defaults with configurable limits, introducing special modes, and improving error handling.

Bug Fixes:
- Replace old global thinking_budget constants with model-specific limits to fix incorrect budget enforcement

Enhancements:
- Add THINKING_BUDGET_LIMITS mapping with min, max, and can_disable flags for each model
- Introduce clamp_thinking_budget method to enforce model-specific bounds and support dynamic/disable modes
- Update get_response to parse, clamp, and log invalid thinking_budget values with improved fallback logic

</details>