### PR TITLE
增加三处对记忆系统是否启用的检查

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -37,7 +37,7 @@ logger = get_logger("main")
 class MainSystem:
     def __init__(self):
         # 根据配置条件性地初始化记忆系统
-        if global_config.memory.enable_memory:
+        if global_config.memory.enable_memory and hippocampus_manager is not None:
             self.hippocampus_manager = hippocampus_manager
         else:
             self.hippocampus_manager = None


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：若记忆系统关闭 麦麦接收到消息后仍然尝试访问未被初始化的HippocampusManager
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**: 2025-08-30 17:22:56 [所见] 消息处理失败: HippocampusManager 尚未初始化，请先调用 initialize 方法
Traceback (most recent call last):
  File "/home/yepian/MaiBot/MaiBot/src/chat/heart_flow/heartflow_message_processor.py", line 121, in process_message
    interested_rate, keywords = await _calculate_interest(message)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yepian/MaiBot/MaiBot/src/chat/heart_flow/heartflow_message_processor.py", line 42, in _calculate_interest
    interested_rate, keywords,keywords_lite = await hippocampus_manager.get_activate_from_text(
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
    )
    ^
  File "/home/yepian/MaiBot/MaiBot/src/chat/memory_system/Hippocampus.py", line 1421, in get_activate_from_text
    raise RuntimeError("HippocampusManager 尚未初始化，请先调用 initialize 方法")
RuntimeError: HippocampusManager 尚未初始化，请先调用 initialize 方法

## Sourcery 总结

使用启用标志守护内存操作并添加错误处理，以防止在内存系统被禁用或失败时出现未初始化的 `HippocampusManager` 错误。

Bug 修复:
- 在消息处理、提示构建和主初始化中，调用 `HippocampusManager` 之前检查 `global_config.memory.enable_memory` 标志，以避免访问未初始化的内存系统。

增强:
- 将 `get_activate_from_text` 和 `get_memory_from_text` 的调用封装在 `try-except` 块中，以便在内存检索失败时记录失败并回退到默认空值。
- 当内存系统被禁用时，使用空默认值初始化消息关键词和内存块。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard memory operations with the enable flag and add error handling to prevent uninitialized HippocampusManager errors when the memory system is disabled or fails.

Bug Fixes:
- Check the global_config.memory.enable_memory flag before invoking HippocampusManager in message processing, prompt building, and main initialization to avoid accessing an uninitialized memory system.

Enhancements:
- Wrap calls to get_activate_from_text and get_memory_from_text in try-except blocks to log failures and fallback to default empty values when memory retrieval fails.
- Initialize message keywords and memory blocks with empty defaults when the memory system is disabled.

</details>