### PR TITLE
修复未检查记忆系统是否启用导致的无法回复

### DIFF
--- a/src/chat/heart_flow/heartflow_message_processor.py
+++ b/src/chat/heart_flow/heartflow_message_processor.py
@@ -37,16 +37,21 @@ async def _calculate_interest(message: MessageRecv) -> Tuple[float, list[str]]:
     
     is_mentioned,is_at,reply_probability_boost = is_mentioned_bot_in_message(message)
     interested_rate = 0.0
+    keywords = []
+    keywords_lite = []
 
-    with Timer("记忆激活"):
-        interested_rate, keywords,keywords_lite = await hippocampus_manager.get_activate_from_text(
-            message.processed_plain_text,
-            max_depth= 4,
-            fast_retrieval=global_config.chat.interest_rate_mode == "fast",
-        )
-        message.key_words = keywords
-        message.key_words_lite = keywords_lite
-        logger.debug(f"记忆激活率: {interested_rate:.2f}, 关键词: {keywords}")
+    if global_config.memory.enable_memory:
+        with Timer("记忆激活"):
+            interested_rate, keywords,keywords_lite = await hippocampus_manager.get_activate_from_text(
+                message.processed_plain_text,
+                max_depth= 4,
+                fast_retrieval=global_config.chat.interest_rate_mode == "fast",
+            )
+            logger.debug(f"记忆激活率: {interested_rate:.2f}, 关键词: {keywords}")
+
+    # 无论是否启用记忆系统，都为消息对象写入关键词字段（禁用时为空）
+    message.key_words = keywords
+    message.key_words_lite = keywords_lite
 
     text_len = len(message.processed_plain_text)
     # 根据文本长度分布调整兴趣度，采用分段函数实现更精确的兴趣度计算


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：心流系统调用海马体管理器时 添加对记忆系统启用状态的检查
# 其他信息
- **关联 Issue**：Open #1226 
- **截图/GIF**：
- **附加信息**:

## Sourcery 总结

使用启用标志守护内存激活调用，并始终分配消息关键词，以防止在内存禁用时出现回复失败。

**错误修复：**
- 将 `hippocampus_manager.get_activate_from_text` 调用封装在内存启用检查中，以避免在内存关闭时遗漏激活。

**改进：**
- 无条件初始化 `message.key_words` 和 `key_words_lite`（当内存禁用时为空）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard memory activation call with enable flag and always assign message keywords to prevent reply failures when memory is disabled

Bug Fixes:
- Wrap hippocampus_manager.get_activate_from_text call in an enable-memory check to avoid missing activation when memory is off

Enhancements:
- Initialize message.key_words and key_words_lite unconditionally (empty when memory disabled)

</details>