### PR TITLE
规划器返回的JSON中，time 字段被解析为字符串而不是数字

### DIFF
--- a/src/chat/heart_flow/heartFC_chat.py
+++ b/src/chat/heart_flow/heartFC_chat.py
@@ -557,7 +557,12 @@ class HeartFChatting:
             
             elif action_planner_info.action_type == "wait_time":
                 logger.info(f"{self.log_prefix} 等待{action_planner_info.action_data['time']}秒后回复")
-                await asyncio.sleep(action_planner_info.action_data["time"])
+                try:
+                    sleep_time = float(action_planner_info.action_data["time"])
+                    await asyncio.sleep(sleep_time)
+                except (ValueError, TypeError) as e:
+                    print(f"无效的等待时间: {action_planner_info.action_data['time']}, 使用默认值1秒")
+                    await asyncio.sleep(1)
                 return {"action_type": "wait_time", "success": True, "reply_text": "", "command": ""}
             
             elif action_planner_info.action_type == "no_reply_until_call":


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [ ] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
```
09-11 22:19:34 [规划器] [*******]动作'wait_time'缺少target_message_id，使用最新消息作为target_message
09-11 22:19:34 [规划器] [*******]动作'no_reply_until_call'缺少target_message_id，使用最新消息作为target_message
09-11 22:19:34 [规划器] [*******]规划器决定执行2个动作: wait_time no_reply_until_call
09-11 22:19:34 [聊天节奏] [*******] 等待30秒后回复
09-11 22:19:34 [聊天节奏] [*******] 执行动作时出错: '<=' not supported between instances of 'str' and 'int'
09-11 22:19:34 [聊天节奏] [*******] 错误信息: Traceback (most recent call last):
  File "/MaiMBot/src/chat/heart_flow/heartFC_chat.py", line 560, in _execute_action
    await asyncio.sleep(action_planner_info.action_data["time"])
  File "/usr/local/lib/python3.13/asyncio/tasks.py", line 705, in sleep
    if delay <= 0:
       ^^^^^^^^^^
TypeError: '<=' not supported between instances of 'str' and 'int'

```
- 规划器模型返回的JSON中，数字字段被引号包围了（如 "time": "30" 而不是 "time": 30）
- JSON解析时没有正确转换数据类型

## Sourcery 总结

在执行 `wait_time` 操作时，将规划器的 `time` 字段从字符串转换为浮点数，并在输入无效时默认为 1 秒

Bug 修复:
- 在调用 `asyncio.sleep` 之前将 'time' 值解析为浮点数，以防止类型错误
- 当提供的时间不是一个有效数字时，添加一个回退机制，默认休眠 1 秒

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

错误修复：
- 在休眠之前将规划器的 'time' 值解析为浮点数，并在无效输入时回退到 1 秒

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Parse the planner's 'time' value as a float before sleeping and fallback to 1 second on invalid input

</details>

</details>