### PR TITLE
fix:识图token限制 commit 没有修复完全

### DIFF
--- a/src/chat/utils/utils_image.py
+++ b/src/chat/utils/utils_image.py
@@ -146,7 +146,7 @@ class ImageManager:
                     return "[表情包(GIF处理失败)]"
                 vlm_prompt = "这是一个动态图表情包，每一张图代表了动态图的某一帧，黑色背景代表透明，描述一下表情包表达的情感和内容，描述细节，从互联网梗,meme的角度去分析"
                 detailed_description, _ = await self.vlm.generate_response_for_image(
-                    vlm_prompt, image_base64_processed, "jpg", temperature=0.4, max_tokens=300
+                    vlm_prompt, image_base64_processed, "jpg", temperature=0.4
                 )
             else:
                 vlm_prompt = (


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：fix:识图token限制 没有修复完全 导致识图思考模型识别gif图时回复被截断
# 其他信息
- **关联 Issue**
- **截图/GIF**：
- **附加信息**: 感谢麦麦超大五号水群 晴空群友提供的帮助 :3

## Sourcery 总结

错误修复：
- 在 `generate_response_for_image` 调用中，处理 GIF 时省略 `max_tokens` 参数，以使用默认限制并避免响应被截断

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Omit the max_tokens parameter in generate_response_for_image calls for GIF processing to use default limits and avoid clipped responses

</details>