### PR TITLE
修复消息过滤时机：将过滤检查移至消息处理之后

### DIFF
--- a/src/chat/message_receive/bot.py
+++ b/src/chat/message_receive/bot.py
@@ -251,18 +251,6 @@ class ChatBot:
                 # return
                 pass
 
-            # 过滤检查
-            if _check_ban_words(
-                message.processed_plain_text,
-                user_info,  # type: ignore
-                group_info,
-            ) or _check_ban_regex(
-                message.raw_message,  # type: ignore
-                user_info,  # type: ignore
-                group_info,
-            ):
-                return
-
             get_chat_manager().register_message(message)
 
             chat = await get_chat_manager().get_or_create_stream(
@@ -275,6 +263,18 @@ class ChatBot:
 
             # 处理消息内容，生成纯文本
             await message.process()
+
+            # 过滤检查（在消息处理之后进行）
+            if _check_ban_words(
+                message.processed_plain_text,
+                user_info,  # type: ignore
+                group_info,
+            ) or _check_ban_regex(
+                message.raw_message,  # type: ignore
+                user_info,  # type: ignore
+                group_info,
+            ):
+                return
 
             # if await self.check_ban_content(message):
             #     logger.warning(f"检测到消息中含有违法，色情，暴力，反动，敏感内容，消息内容：{message.processed_plain_text}，发送者：{message.message_info.user_info.user_nickname}")


### PR DESCRIPTION
- 修复_check_ban_words函数使用processed_plain_text导致关键词过滤不生效的问题
- 现在关键词过滤和正则过滤都使用message.raw_message，确保过滤逻辑一致性
- 解决过滤检查在message.process()之前进行导致的时序问题

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #1253
- **截图/GIF**：
- **附加信息**:
