### PR TITLE
修复消息过滤时机：将过滤检查移至消息处理之后

### DIFF
--- a/src/chat/message_receive/bot.py
+++ b/src/chat/message_receive/bot.py
@@ -251,8 +251,6 @@ class ChatBot:
                 # return
                 pass
 
-            get_chat_manager().register_message(message)
-
             chat = await get_chat_manager().get_or_create_stream(
                 platform=message.message_info.platform,  # type: ignore
                 user_info=user_info,  # type: ignore
@@ -275,6 +273,9 @@ class ChatBot:
                 group_info,
             ):
                 return
+
+            # 只有通过过滤检查的消息才注册到chat_manager
+            get_chat_manager().register_message(message)
 
             # if await self.check_ban_content(message):
             #     logger.warning(f"检测到消息中含有违法，色情，暴力，反动，敏感内容，消息内容：{message.processed_plain_text}，发送者：{message.message_info.user_info.user_nickname}")


### PR DESCRIPTION
- 将过滤检查从message.process()之前移动到之后
- 确保_check_ban_words使用processed_plain_text时能正常工作
- 保持_check_ban_regex使用raw_message，确保正则过滤正常工作
- 这样既保证了过滤功能的完整性，又符合消息处理的逻辑顺序

修复问题：
- 原代码在message.process()之前进行过滤检查
- 此时processed_plain_text还是空的，导致关键词过滤不生效
- 现在过滤检查在消息处理之后进行，确保所有过滤功能正常工作


<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #1253
- **截图/GIF**：
- **附加信息**:

## Sourcery 总结

将消息过滤检查移至内容处理之后，以确保禁用词过滤能正确地与 `processed_plain_text` 一起工作，同时保留对原始消息的基于正则表达式的过滤。

错误修复：
- 将禁用词和正则表达式消息过滤重新定位到 `message.process()` 之后
- 确保禁用词检查使用 `processed_plain_text`，正则表达式检查使用 `raw_message` 以实现准确过滤

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move message filtering checks to after content processing to ensure ban word filtering functions properly with processed_plain_text while retaining regex-based filtering on raw messages.

Bug Fixes:
- Relocate ban word and regex message filtering to after message.process()
- Ensure ban word check uses processed_plain_text and regex check uses raw_message for accurate filtering

</details>