### PR TITLE
fix: 修复 question_maker 中 UnboundLocalError 的问题

### DIFF
--- a/src/memory_system/question_maker.py
+++ b/src/memory_system/question_maker.py
@@ -70,11 +70,15 @@ class QuestionMaker:
 
             # 按权重随机选择
             chosen_conflict = random.choices(conflicts, weights=weights, k=1)[0]
+        else:
+            # 所有冲突都已被提问过（raise_time ≥ 1），仅 5% 概率返回
+            if random.random() > 0.05:
+                return None
+            chosen_conflict = random.choice(conflicts)
 
         # 选中后，自增 raise_time 并保存
-            chosen_conflict.raise_time = (getattr(chosen_conflict, "raise_time", 0) or 0) + 1
-            chosen_conflict.save()
-
+        chosen_conflict.raise_time = (getattr(chosen_conflict, "raise_time", 0) or 0) + 1
+        chosen_conflict.save()
 
         return chosen_conflict
 


### PR DESCRIPTION
- 在 get_random_unanswered_conflict() 方法中新增 else 分支
- 当所有冲突 raise_time >= 1 时，按 5% 概率随机选择
- 避免 chosen_conflict 未赋值导致的 UnboundLocalError 异常

异常log：
```
Traceback (most recent call last):
  File "/MaiMBot/src/chat/heart_flow/heartFC_chat.py", line 207, in _loopbody
    question, context,conflict_context = await question_maker.make_question()
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/MaiMBot/src/memory_system/question_maker.py", line 89, in make_question
    conflict = await self.get_random_unanswered_conflict()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/MaiMBot/src/memory_system/question_maker.py", line 79, in get_random_unanswered_conflict
    return chosen_conflict
           ^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'chosen_conflict' where it is not associated with a value

```


<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

## Sourcery 总结

通过添加备用分支并确保 `raise_time` 更新的一致性，防止 `get_random_unanswered_conflict` 中出现 `UnboundLocalError`

错误修复：
- 添加 `else` 分支，当所有冲突都已被提问时返回 `None`，以避免访问未定义的变量

增强：
- 引入 5% 的概率，当没有新的冲突时，随机选择一个之前已提问的冲突
- 将 `raise_time` 的递增和保存操作移出条件块之外，以实现一致的行为

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent UnboundLocalError in get_random_unanswered_conflict by adding a fallback branch and ensuring consistent raise_time updates

Bug Fixes:
- Add else branch to return None when all conflicts have been asked to avoid undefined variable access

Enhancements:
- Introduce a 5% probability to randomly select a previously asked conflict when no new ones remain
- Move increment and save of raise_time outside of conditional blocks for consistent behavior

</details>