### PR TITLE
Fix expression learner text fallback

### DIFF
--- a/src/chat/utils/chat_message_builder.py
+++ b/src/chat/utils/chat_message_builder.py
@@ -983,8 +983,8 @@ async def build_bare_messages(messages: List[DatabaseMessages]) -> str:
     output_lines = []
 
     for msg in messages:
-        # 获取纯文本内容
-        content = msg.processed_plain_text or ""
+        # 获取纯文本内容，优先使用processed_plain_text，回退到display_message
+        content = msg.processed_plain_text or getattr(msg, "display_message", None) or ""
 
         # 处理图片ID
         pic_pattern = r"\[picid:[^\]]+\]"

--- a/src/express/expression_learner.py
+++ b/src/express/expression_learner.py
@@ -438,7 +438,12 @@ class ExpressionLearner:
                 continue
             
             prev_original_idx = bare_lines[pos - 1][0]
-            up_content = filter_message_content(random_msg[prev_original_idx].processed_plain_text or "")
+            source_content = (
+                random_msg[prev_original_idx].processed_plain_text
+                or getattr(random_msg[prev_original_idx], "display_message", None)
+                or ""
+            )
+            up_content = filter_message_content(source_content)
             if not up_content:
                 # 上一句为空，跳过该表达
                 continue
@@ -493,8 +498,8 @@ class ExpressionLearner:
         bare_lines: List[Tuple[int, str]] = []
         
         for idx, msg in enumerate(messages):
-            content = msg.processed_plain_text or ""
-            content = filter_message_content(content)
+            raw_content = msg.processed_plain_text or getattr(msg, "display_message", None) or ""
+            content = filter_message_content(raw_content)
             # 即使content为空也要记录，防止错位
             bare_lines.append((idx, content))
                 


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [ ] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [ ] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #1320 
- **截图/GIF**：
- **附加信息**:

## Sourcery 摘要

Bug 修复：
- 当 expression learner 和 chat message builder 中的 `processed_plain_text` 为空时，使用 `display_message` 作为备用，以防止内容为空

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Use display_message as fallback when processed_plain_text is empty in expression learner and chat message builder to prevent empty content

</details>