### PR TITLE
fix: add UA header for some openai client

### DIFF
--- a/src/llm_models/model_client/openai_client.py
+++ b/src/llm_models/model_client/openai_client.py
@@ -396,6 +396,7 @@ class OpenaiClient(BaseClient):
             api_key=api_provider.api_key,
             max_retries=0,
             timeout=api_provider.timeout,
+            default_headers={"User-Agent": "python-requests/2.32.0"},
         )
 
     async def get_response(


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [ ] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [ ] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #1323 
- **截图/GIF**：
- **附加信息**:

## Sourcery 总结

错误修复:
- 在 OpenAI 客户端构造函数中包含一个带有 "User-Agent" 字段的 `default_headers` 参数，以解决 UA 标头缺失的问题

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Include a default_headers parameter with a "User-Agent" field in the OpenAI client constructor to address missing UA header issues

</details>