### PR TITLE
feat: 增加群名片支持

### DIFF
--- a/src/chat/heart_flow/heartflow_message_processor.py
+++ b/src/chat/heart_flow/heartflow_message_processor.py
@@ -81,12 +81,14 @@ class HeartFCMessageReceiver:
             # if not processed_plain_text:
             # print(message)
 
-            logger.info(f"[{mes_name}]{userinfo.user_nickname}:{processed_plain_text}")  # type: ignore
+            display_name = userinfo.user_cardname or userinfo.user_nickname  # type: ignore
+            logger.info(f"[{mes_name}]{display_name}:{processed_plain_text}")  # type: ignore
 
+            preferred_name = display_name or userinfo.user_nickname  # type: ignore
             _ = Person.register_person(
                 platform=message.message_info.platform,  # type: ignore
                 user_id=message.message_info.user_info.user_id,  # type: ignore
-                nickname=userinfo.user_nickname,  # type: ignore
+                nickname=preferred_name,  # type: ignore
             )
 
         except Exception as e:

--- a/src/chat/message_receive/bot.py
+++ b/src/chat/message_receive/bot.py
@@ -40,7 +40,8 @@ def _check_ban_words(text: str, userinfo: UserInfo, group_info: Optional[GroupIn
     for word in global_config.message_receive.ban_words:
         if word in text:
             chat_name = group_info.group_name if group_info else "私聊"
-            logger.info(f"[{chat_name}]{userinfo.user_nickname}:{text}")
+            display_name = userinfo.user_cardname or userinfo.user_nickname
+            logger.info(f"[{chat_name}]{display_name}:{text}")
             logger.info(f"[过滤词识别]消息中含有{word}，filtered")
             return True
     return False
@@ -64,7 +65,8 @@ def _check_ban_regex(text: str, userinfo: UserInfo, group_info: Optional[GroupIn
     for pattern in global_config.message_receive.ban_msgs_regex:
         if re.search(pattern, text):
             chat_name = group_info.group_name if group_info else "私聊"
-            logger.info(f"[{chat_name}]{userinfo.user_nickname}:{text}")
+            display_name = userinfo.user_cardname or userinfo.user_nickname
+            logger.info(f"[{chat_name}]{display_name}:{text}")
             logger.info(f"[正则表达式过滤]消息匹配到{pattern}，filtered")
             return True
     return False
@@ -205,6 +207,13 @@ class ChatBot:
             message = MessageRecv(message_data)
             group_info = message.message_info.group_info
             user_info = message.message_info.user_info
+
+            if (
+                group_info
+                and user_info
+                and (not user_info.user_cardname or not str(user_info.user_cardname).strip())
+            ):
+                user_info.user_cardname = user_info.user_nickname or ""
 
             continue_flag, modified_message = await events_manager.handle_mai_events(
                 EventType.ON_MESSAGE_PRE_PROCESS, message

--- a/src/chat/message_receive/chat_stream.py
+++ b/src/chat/message_receive/chat_stream.py
@@ -313,8 +313,10 @@ class ChatManager:
 
         if stream.group_info and stream.group_info.group_name:
             return stream.group_info.group_name
-        elif stream.user_info and stream.user_info.user_nickname:
-            return f"{stream.user_info.user_nickname}的私聊"
+        elif stream.user_info:
+            display_name = stream.user_info.user_cardname or stream.user_info.user_nickname
+            if display_name:
+                return f"{display_name}的私聊"
         else:
             return None
 

--- a/src/chat/message_receive/message.py
+++ b/src/chat/message_receive/message.py
@@ -283,7 +283,11 @@ class MessageProcessBase(Message):
                 if self.reply and hasattr(self.reply, "processed_plain_text"):
                     # print(f"self.reply.processed_plain_text: {self.reply.processed_plain_text}")
                     # print(f"reply: {self.reply}")
-                    return f"[回复<{self.reply.message_info.user_info.user_nickname}:{self.reply.message_info.user_info.user_id}> 的消息：{self.reply.processed_plain_text}]"  # type: ignore
+                    reply_user_info = self.reply.message_info.user_info  # type: ignore
+                    reply_name = reply_user_info.user_cardname or reply_user_info.user_nickname  # type: ignore
+                    return (
+                        f"[回复<{reply_name}:{reply_user_info.user_id}> 的消息：{self.reply.processed_plain_text}]"
+                    )  # type: ignore
                 return ""
             else:
                 return f"[{segment.type}:{str(segment.data)}]"

--- a/src/chat/utils/chat_message_builder.py
+++ b/src/chat/utils/chat_message_builder.py
@@ -413,7 +413,8 @@ def _build_readable_messages_internal(
         if message.is_action_record:
             # 对于动作记录，也处理图片ID
             content = process_pic_ids(message.display_message)
-            detailed_messages_raw.append((message.time, message.user_nickname, content, True))
+            action_name = message.user_cardname or message.user_nickname or "系统"
+            detailed_messages_raw.append((message.time, action_name, content, True))
             continue
 
         platform = message.user_platform
@@ -434,9 +435,9 @@ def _build_readable_messages_internal(
 
         person = Person(platform=platform, user_id=user_id)
         # 根据 replace_bot_name 参数决定是否替换机器人名称
-        person_name = (
-            person.person_name or f"{user_nickname}" or (f"昵称：{user_cardname}" if user_cardname else "某人")
-        )
+        preferred_display = user_cardname or user_nickname
+        fallback_display = user_nickname or user_cardname or "某人"
+        person_name = person.person_name or preferred_display or fallback_display
         if replace_bot_name and (
             (platform == global_config.bot.platform and user_id == global_config.bot.qq_account)
             or (platform == "telegram" and user_id == getattr(global_config.bot, "telegram_account", ""))

--- a/src/chat/utils/statistic.py
+++ b/src/chat/utils/statistic.py
@@ -480,7 +480,7 @@ class StatisticOutputTask(AsyncTask):
             elif message.user_id:  # Fallback to sender's info for chat_id if not a group_info based chat
                 # This uses the message SENDER's ID as per original logic's fallback
                 chat_id = f"u{message.user_id}"  # SENDER's user_id
-                chat_name = message.user_nickname  # SENDER's nickname
+                chat_name = message.user_cardname or message.user_nickname  # SENDER's display name
             else:
                 # If neither group_id nor sender_id is available for chat identification
                 logger.warning(
@@ -704,7 +704,7 @@ class StatisticOutputTask(AsyncTask):
                     if group_name and group_name.strip():
                         return group_name.strip()
                 elif stream.user_info and hasattr(stream.user_info, "user_nickname"):
-                    user_name = stream.user_info.user_nickname
+                    user_name = stream.user_info.user_cardname or stream.user_info.user_nickname
                     if user_name and user_name.strip():
                         return user_name.strip()
 
@@ -1293,7 +1293,7 @@ class StatisticOutputTask(AsyncTask):
                 if message.chat_info_group_id:
                     chat_name = message.chat_info_group_name or f"群{message.chat_info_group_id}"
                 elif message.user_id:
-                    chat_name = message.user_nickname or f"用户{message.user_id}"
+                    chat_name = (message.user_cardname or message.user_nickname) or f"用户{message.user_id}"
                 else:
                     continue
 

--- a/src/chat/utils/utils.py
+++ b/src/chat/utils/utils.py
@@ -585,10 +585,11 @@ def get_chat_type_and_target_info(chat_id: str) -> Tuple[bool, Optional["TargetP
                 from src.common.data_models.info_data_model import TargetPersonInfo  # 解决循环导入问题
 
                 # Initialize target_info with basic info
+                display_name = user_info.user_cardname or user_info.user_nickname  # type: ignore
                 target_info = TargetPersonInfo(
                     platform=platform,
                     user_id=user_id,
-                    user_nickname=user_info.user_nickname,  # type: ignore
+                    user_nickname=display_name,  # type: ignore
                     person_id=None,
                     person_name=None,
                 )
@@ -597,7 +598,7 @@ def get_chat_type_and_target_info(chat_id: str) -> Tuple[bool, Optional["TargetP
                 try:
                     person = Person(platform=platform, user_id=user_id)
                     if not person.is_known:
-                        logger.warning(f"用户 {user_info.user_nickname} 尚未认识")
+                        logger.warning(f"用户 {display_name} 尚未认识")
                         # 如果用户尚未认识，则返回False和None
                         return False, None
                     if person.person_id:


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [ ] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [ ] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [ ] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:

## Sourcery 总结

引入对群名片的支持，将 user_cardname 视为主要的显示名称，并更新人物注册逻辑以处理修剪过的、默认的以及同步的昵称。

新功能：
- 在聊天上下文中支持将群名片 (user_cardname) 作为主要的显示名称

改进：
- 更新 Person.register_person 以修剪输入的昵称，生成默认显示名称，并将更新后的昵称和 person_name 同步到数据库。
- 重构日志记录、消息构建、流命名和统计信息收集模块，统一优先使用 user_cardname，并回退到 user_nickname。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce support for group card names by treating user_cardname as the main display name and updating person registration logic to handle trimmed, defaulted, and synchronized nicknames.

New Features:
- Support group card name (user_cardname) as the primary display name in chat contexts

Enhancements:
- Update Person.register_person to trim input nicknames, generate default display names, and sync updated nickname and person_name to the database
- Refactor logging, message building, stream naming, and statistics collection modules to uniformly prefer user_cardname with fallback to user_nickname

</details>