### PR TITLE
feat: 更加详细的模型API请求错误提示与添加遇到常见的频繁API请求超时的建议

### DIFF
--- a/src/llm_models/exceptions.py
+++ b/src/llm_models/exceptions.py
@@ -18,11 +18,12 @@ error_code_mapping = {
 class NetworkConnectionError(Exception):
     """连接异常，常见于网络问题或服务器不可用"""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, message: str | None = None):
+        super().__init__(message)
+        self.message = message
 
     def __str__(self):
-        return "连接异常，请检查网络连接状态或URL是否正确"
+        return self.message or "连接异常，请检查网络连接状态或URL是否正确"
 
 
 class ReqAbortException(Exception):


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：

让API请求时的发生网络错误的错误信息更详细地展示出来，以及对一个不应该是错误的错误，加入应对的提示。
当你把model_config.toml中对应API Provider的timeout值设置过短，而恰好你用的API比较慢的时候，就会触发超时错误然后重试，这不是API的问题，而且的确需要用户自己根据自己的情况进行修正，否则会出现不必要的重复请求，可能导致多余不必要的token消耗。
