### PR TITLE
使planner和replayer能够正常构建no_read_command属性消息

### DIFF
--- a/src/chat/planner_actions/action_modifier.py
+++ b/src/chat/planner_actions/action_modifier.py
@@ -69,7 +69,7 @@ class ActionModifier:
             chat_id=self.chat_stream.stream_id,
             timestamp=time.time(),
             limit=min(int(global_config.chat.max_context_size * 0.33), 10),
-            filter_no_read_command=True,
+            filter_no_read_command=False,
         )
 
         chat_content = build_readable_messages(

--- a/src/chat/planner_actions/planner.py
+++ b/src/chat/planner_actions/planner.py
@@ -316,7 +316,7 @@ class ActionPlanner:
             chat_id=self.chat_id,
             timestamp=time.time(),
             limit=int(global_config.chat.max_context_size * 0.6),
-            filter_no_read_command=True,
+            filter_no_read_command=False,
         )
         message_id_list: list[Tuple[str, "DatabaseMessages"]] = []
         chat_content_block, message_id_list = build_readable_messages_with_id(

--- a/src/chat/replyer/group_generator.py
+++ b/src/chat/replyer/group_generator.py
@@ -941,7 +941,7 @@ class DefaultReplyer:
             chat_id=chat_id,
             timestamp=time.time(),
             limit=min(int(global_config.chat.max_context_size * 0.33), 15),
-            filter_no_read_command=True,
+            filter_no_read_command=False,
         )
         chat_talking_prompt_half = build_readable_messages(
             message_list_before_now_half,


### PR DESCRIPTION

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的： 
我认为这个is_no_read_command属性其实不应该只属于command，它应该是一个通用属性，作用就是让不会让麦麦去触发“思考”，但是回复和规划的时候必须要用上，要不然存了跟没存没区别。 
我认为让replayer和planner考虑这些消息也应当是必要的，因为让麦麦得知用户曾经做过什么行为是有助于麦麦的行为连贯性的。

# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:
