### PR TITLE
修复WebUI保存插件配置时的点号键与列表类型问题

### DIFF
--- a/src/webui/plugin_routes.py
+++ b/src/webui/plugin_routes.py
@@ -83,13 +83,6 @@ def normalize_dotted_keys(obj: Dict[str, Any]) -> Dict[str, Any]:
     将形如 {'a.b': 1} 的键展开为嵌套结构 {'a': {'b': 1}}。
     若遇到中间节点已存在且非字典，记录日志并覆盖为字典。
     """
-    def _deep_merge(dst: Dict[str, Any], src: Dict[str, Any]) -> None:
-        for k, v in src.items():
-            if k in dst and isinstance(dst[k], dict) and isinstance(v, dict):
-                _deep_merge(dst[k], v)
-            else:
-                dst[k] = v
-
     result: Dict[str, Any] = {}
     dotted_items = []
 


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:
- 增加 normalize_dotted_keys/coerce_types 辅助，保存前规范化扁平键并按 schema 将字符串 list 转为数组，使用深合并处理嵌套，过滤空路径。
插件实例查找提取为 find_plugin_instance 并加类型标注。
针对 list 和 typing.List[...] 的类型检测。
