### PR TITLE
修复使用VLM生成情感标签时未正确分割的问题

### DIFF
--- a/src/chat/emoji_system/emoji_manager.py
+++ b/src/chat/emoji_system/emoji_manager.py
@@ -271,7 +271,7 @@ def _to_emoji_objects(data: Any) -> Tuple[List["MaiEmoji"], int]:
 
             emoji.description = emoji_data.description
             # Deserialize emotion string from DB to list
-            emoji.emotion = emoji_data.emotion.split(",") if emoji_data.emotion else []
+            emoji.emotion = emoji_data.emotion.replace("，",",").split(",") if emoji_data.emotion else []
             emoji.usage_count = emoji_data.usage_count
 
             db_last_used_time = emoji_data.last_used_time
@@ -732,7 +732,7 @@ class EmojiManager:
                 emoji_record = Emoji.get_or_none(Emoji.emoji_hash == emoji_hash)
                 if emoji_record and emoji_record.emotion:
                     logger.info(f"[缓存命中] 从数据库获取表情包情感标签: {emoji_record.emotion[:50]}...")
-                    return emoji_record.emotion.split(",")
+                    return emoji_record.emotion.replace("，",",").split(",")
             except Exception as e:
                 logger.error(f"从数据库查询表情包情感标签时出错: {e}")
 


### PR DESCRIPTION
# 请填写以下内容
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：
将VLM生成的情感标签及调用的缓存中的中文逗号替换为英文逗号，确保能够被正确分割
# 其他信息
- **关联 Issue**：Close #1423 
- **截图/GIF**：
- **附加信息**:
