### PR TITLE
feat: 添加 fallback（按顺序降级）模型选择策略

### DIFF
--- a/src/config/api_ada_configs.py
+++ b/src/config/api_ada_configs.py
@@ -98,7 +98,7 @@ class TaskConfig(ConfigBase):
     """慢请求阈值（秒），超过此值会输出警告日志"""
 
     selection_strategy: str = field(default="balance")
-    """模型选择策略：balance（负载均衡）或 random（随机选择）"""
+    """模型选择策略：balance（负载均衡）、random（随机选择）或 fallback（按顺序降级）"""
 
 
 @dataclass

--- a/template/model_config_template.toml
+++ b/template/model_config_template.toml
@@ -140,45 +140,45 @@ model_list = ["siliconflow-deepseek-v3.2"] # 使用的模型列表，每个子�
 temperature = 0.2                        # 模型温度，新V3建议0.1-0.3
 max_tokens = 4096                         # 最大输出token数
 slow_threshold = 15.0                     # 慢请求阈值（秒），模型等待回复时间超过此值会输出警告日志
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 fallback（按顺序降级）
 
 [model_task_config.tool_use] #功能模型，需要使用支持工具调用的模型，请使用较快的小模型（调用量较大）
 model_list = ["qwen3-30b","qwen3-next-80b"]
 temperature = 0.7
 max_tokens = 1024
 slow_threshold = 10.0
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 fallback（按顺序降级）
 
 [model_task_config.replyer] # 首要回复模型，还用于表达方式学习
 model_list = ["siliconflow-deepseek-v3.2","siliconflow-deepseek-v3.2-think","siliconflow-glm-4.6","siliconflow-glm-4.6-think"]
 temperature = 0.3                        # 模型温度，新V3建议0.1-0.3
 max_tokens = 2048
 slow_threshold = 25.0
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 fallback（按顺序降级）
 
 [model_task_config.planner] #决策：负责决定麦麦该什么时候回复的模型
 model_list = ["siliconflow-deepseek-v3.2"]
 temperature = 0.3
 max_tokens = 800
 slow_threshold = 12.0
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 fallback（按顺序降级）
 
 [model_task_config.vlm] # 图像识别模型
 model_list = ["qwen3-vl-30"]
 max_tokens = 256
 slow_threshold = 15.0
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 fallback（按顺序降级）
 
 [model_task_config.voice] # 语音识别模型
 model_list = ["sensevoice-small"]
 slow_threshold = 12.0
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 fallback（按顺序降级）
 
 # 嵌入模型
 [model_task_config.embedding]
 model_list = ["bge-m3"]
 slow_threshold = 5.0
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 fallback（按顺序降级）
 
 # ------------LPMM知识库模型------------
 
@@ -187,11 +187,11 @@ model_list = ["siliconflow-deepseek-v3.2"]
 temperature = 0.2
 max_tokens = 800
 slow_threshold = 20.0
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 fallback（按顺序降级）
 
 [model_task_config.lpmm_rdf_build] # RDF构建模型
 model_list = ["siliconflow-deepseek-v3.2"]
 temperature = 0.2
 max_tokens = 800
 slow_threshold = 20.0
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 fallback（按顺序降级）


### PR DESCRIPTION
## 功能描述

新增模型选择策略 `fallback`（按顺序降级），按照模型列表顺序选择模型，只有当前模型不可用时才会使用下一个模型。

## 使用场景

- 有一个首选的高质量模型，但可能偶尔不可用
- 希望设置备用模型作为后备方案
- 需要确保模型选择的确定性和可预测性

## 修改内容

- `src/config/api_ada_configs.py`：更新 `selection_strategy` 字段文档说明
- `src/llm_models/utils_model.py`：在 `_select_model` 方法中添加 fallback 策略逻辑
- `template/model_config_template.toml`：更新所有 `selection_strategy` 配置注释

## 策略对比

| 策略 | 英文名 | 行为描述 |
|------|--------|----------|
| 负载均衡 | `balance` | 优先选择使用次数少的模型 |
| 随机选择 | `random` | 完全随机从模型列表中选择 |
| **按顺序降级** | `fallback` | 按模型列表顺序选择，只有前序不可用才向后降级 |

## 注意

WebUI 前端需要在 MaiBot-Dashboard 仓库单独更新以显示新选项。