### PR TITLE
feat: 新增顺序优先模型选择策略

### DIFF
--- a/dashboard/src/routes/config/model/components/TaskConfigCard.tsx
+++ b/dashboard/src/routes/config/model/components/TaskConfigCard.tsx
@@ -143,10 +143,11 @@ export const TaskConfigCard = React.memo(function TaskConfigCard({
             <SelectContent>
               <SelectItem value="balance">负载均衡（balance）</SelectItem>
               <SelectItem value="random">随机选择（random）</SelectItem>
+              <SelectItem value="sequential">顺序优先（sequential）</SelectItem>
             </SelectContent>
           </Select>
           <p className="text-xs text-muted-foreground">
-            负载均衡：优先选择使用次数少的模型。随机选择：完全随机从模型列表中选择
+            负载均衡：优先选择使用次数少的模型。随机选择：完全随机选择。顺序优先：按列表顺序，前者不可用才用后者
           </p>
         </div>
       </div>

--- a/src/config/api_ada_configs.py
+++ b/src/config/api_ada_configs.py
@@ -98,7 +98,7 @@ class TaskConfig(ConfigBase):
     """慢请求阈值（秒），超过此值会输出警告日志"""
 
     selection_strategy: str = field(default="balance")
-    """模型选择策略：balance（负载均衡）或 random（随机选择）"""
+    """模型选择策略：balance（负载均衡）、random（随机选择）或 sequential（顺序优先）"""
 
 
 @dataclass

--- a/src/llm_models/utils_model.py
+++ b/src/llm_models/utils_model.py
@@ -267,7 +267,7 @@ class LLMRequest:
 
     def _select_model(self, exclude_models: Optional[Set[str]] = None) -> Tuple[ModelInfo, APIProvider, BaseClient]:
         """
-        根据配置的策略选择模型：balance（负载均衡）或 random（随机选择）
+        根据配置的策略选择模型：balance（负载均衡）、random（随机选择）或 sequential（顺序优先）
         """
         available_models = {
             model: scores
@@ -282,6 +282,15 @@ class LLMRequest:
         if strategy == "random":
             # 随机选择策略
             selected_model_name = random.choice(list(available_models.keys()))
+        elif strategy == "sequential":
+            # 顺序优先策略：按照model_list中的顺序，选择第一个可用的模型
+            selected_model_name = None
+            for model_name in self.model_for_task.model_list:
+                if model_name in available_models:
+                    selected_model_name = model_name
+                    break
+            if selected_model_name is None:
+                raise RuntimeError("没有可用的模型可供选择。所有模型均已尝试失败。")
         elif strategy == "balance":
             # 负载均衡策略：根据总tokens和惩罚值选择
             selected_model_name = min(

--- a/template/model_config_template.toml
+++ b/template/model_config_template.toml
@@ -140,45 +140,45 @@ model_list = ["siliconflow-deepseek-v3.2"] # 使用的模型列表，每个子�
 temperature = 0.2                        # 模型温度，新V3建议0.1-0.3
 max_tokens = 4096                         # 最大输出token数
 slow_threshold = 15.0                     # 慢请求阈值（秒），模型等待回复时间超过此值会输出警告日志
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 sequential（顺序优先）
 
 [model_task_config.tool_use] #功能模型，需要使用支持工具调用的模型，请使用较快的小模型（调用量较大）
 model_list = ["qwen3-30b","qwen3-next-80b"]
 temperature = 0.7
 max_tokens = 1024
 slow_threshold = 10.0
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 sequential（顺序优先）
 
 [model_task_config.replyer] # 首要回复模型，还用于表达方式学习
 model_list = ["siliconflow-deepseek-v3.2","siliconflow-deepseek-v3.2-think","siliconflow-glm-4.6","siliconflow-glm-4.6-think"]
 temperature = 0.3                        # 模型温度，新V3建议0.1-0.3
 max_tokens = 2048
 slow_threshold = 25.0
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 sequential（顺序优先）
 
 [model_task_config.planner] #决策：负责决定麦麦该什么时候回复的模型
 model_list = ["siliconflow-deepseek-v3.2"]
 temperature = 0.3
 max_tokens = 800
 slow_threshold = 12.0
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 sequential（顺序优先）
 
 [model_task_config.vlm] # 图像识别模型
 model_list = ["qwen3-vl-30"]
 max_tokens = 256
 slow_threshold = 15.0
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 sequential（顺序优先）
 
 [model_task_config.voice] # 语音识别模型
 model_list = ["sensevoice-small"]
 slow_threshold = 12.0
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 sequential（顺序优先）
 
 # 嵌入模型
 [model_task_config.embedding]
 model_list = ["bge-m3"]
 slow_threshold = 5.0
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 sequential（顺序优先）
 
 # ------------LPMM知识库模型------------
 
@@ -187,11 +187,11 @@ model_list = ["siliconflow-deepseek-v3.2"]
 temperature = 0.2
 max_tokens = 800
 slow_threshold = 20.0
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 sequential（顺序优先）
 
 [model_task_config.lpmm_rdf_build] # RDF构建模型
 model_list = ["siliconflow-deepseek-v3.2"]
 temperature = 0.2
 max_tokens = 800
 slow_threshold = 20.0
-selection_strategy = "random"           # 模型选择策略：balance（负载均衡）或 random（随机选择）
+selection_strategy = "random"           # 模型选择策略：balance（负载均衡）、random（随机选择）或 sequential（顺序优先）


### PR DESCRIPTION
- Add 'sequential' strategy to select models in order
- Only try next model when current one is unavailable
- Update frontend UI to include sequential option
- Update config template with new strategy documentation

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）: 无破坏性更新，完全向后兼容
6. 请简要说明本次更新的内容和目的：
   新增 `sequential`（顺序优先）模型选择策略。该策略按照配置文件中 `model_list` 的顺序使用模型，只有当前模型不可用时才会切换到下一个模型。适用于主备模型场景，用户可以明确指定模型优先级，确保优先使用性能更好或成本更低的主模型。

# 其他信息
- **关联 Issue**：https://github.com/Mai-with-u/MaiBot/issues/1498
- **截图/GIF**：前端UI新增了 sequential 选项，用户可在模型配置页面的"模型选择策略"下拉菜单中选择
- **附加信息**: 
  - 后端修改：[utils_model.py]、[api_ada_configs.py]、[model_config_template.toml]
  - 前端修改：[TaskConfigCard.tsx]
  - 现支持三种策略：balance（负载均衡）、random（随机）、sequential（顺序优先）
