### PR TITLE
fix: 修复 EventsManager 任务清理时 Key 不一致

### DIFF
--- a/src/plugin_system/core/events_manager.py
+++ b/src/plugin_system/core/events_manager.py
@@ -325,9 +325,10 @@ class EventsManager:
 
             task_name = f"{handler.plugin_name}-{handler.handler_name}"
             task.set_name(task_name)
-            task.add_done_callback(lambda t: self._task_done_callback(t, event_type))
+            handler_name = handler.handler_name
+            task.add_done_callback(lambda t: self._task_done_callback(t, event_type, handler_name))
 
-            self._handler_tasks.setdefault(handler.handler_name, []).append(task)
+            self._handler_tasks.setdefault(handler_name, []).append(task)
         except Exception as e:
             logger.error(f"创建事件处理器任务 {handler.handler_name} 时发生异常: {e}", exc_info=True)
 
@@ -382,6 +383,7 @@ class EventsManager:
         self,
         task: asyncio.Task[Tuple[bool, bool, str | None, CustomEventHandlerResult | None, MaiMessages | None]],
         event_type: EventType | str,
+        handler_name: str,
     ):
         """任务完成回调"""
         task_name = task.get_name() or "Unknown Task"
@@ -406,7 +408,10 @@ class EventsManager:
             logger.error(f"事件处理任务 {task_name} 发生异常: {e}")
         finally:
             with contextlib.suppress(ValueError, KeyError):
-                self._handler_tasks[task_name].remove(task)
+                tasks = self._handler_tasks[handler_name]
+                tasks.remove(task)
+                if not tasks:
+                    del self._handler_tasks[handler_name]
 
 
 events_manager = EventsManager()


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:无
6. 请简要说明本次更新的内容和目的：
修复 EventsManager 中异步任务清理逻辑 Key 值不一致导致的 KeyError 问题。

问题现象：原代码在 _dispatch_handler_task 中使用 handler_name 作为 key 存储任务，但在 _task_done_callback 中却尝试使用 task.get_name()（包含 plugin 前缀）作为 key 移除任务，导致回调执行时任务无法被正常清理。

修复方案：通过闭包将确定的 handler_name 传递给回调函数，确保插入和删除使用的 key 完全一致。

优化：在回调中增加了对空任务列表的自动删除逻辑，避免 _handler_tasks 字典无效膨胀。
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:
