### PR TITLE
修复MaiBot可能的内存泄露问题

### DIFF
--- a/src/bw_learner/expression_learner.py
+++ b/src/bw_learner/expression_learner.py
@@ -625,6 +625,8 @@ init_prompt()
 
 
 class ExpressionLearnerManager:
+    MAX_LEARNERS = 50  # 最大实例数量限制
+
     def __init__(self):
         self.expression_learners = {}
 
@@ -632,6 +634,11 @@ class ExpressionLearnerManager:
 
     def get_expression_learner(self, chat_id: str) -> ExpressionLearner:
         if chat_id not in self.expression_learners:
+            # 限制最大实例数量
+            while len(self.expression_learners) >= self.MAX_LEARNERS:
+                oldest_chat_id = next(iter(self.expression_learners.keys()))
+                self.expression_learners.pop(oldest_chat_id, None)
+                logger.debug(f"移除最久未使用的 ExpressionLearner: {oldest_chat_id}")
             self.expression_learners[chat_id] = ExpressionLearner(chat_id)
         return self.expression_learners[chat_id]
 

--- a/src/chat/brain_chat/brain_chat.py
+++ b/src/chat/brain_chat/brain_chat.py
@@ -93,6 +93,7 @@ class BrainChatting:
         self.history_loop: List[CycleDetail] = []
         self._cycle_counter = 0
         self._current_cycle_detail: CycleDetail = None  # type: ignore
+        self._max_history_loop_size = 100  # 最大保留的思考记录数量
 
         self.last_read_time = time.time() - 2
 
@@ -147,6 +148,9 @@ class BrainChatting:
         self.history_loop.append(self._current_cycle_detail)
         self._current_cycle_detail.timers = cycle_timers
         self._current_cycle_detail.end_time = time.time()
+        # 清理过期的思考记录，保留最近的最大数量
+        if len(self.history_loop) > self._max_history_loop_size:
+            self.history_loop = self.history_loop[-self._max_history_loop_size:]
 
     def print_cycle_info(self, cycle_timers):
         # 记录循环信息和计时器结果

--- a/src/chat/heart_flow/heartFC_chat.py
+++ b/src/chat/heart_flow/heartFC_chat.py
@@ -98,6 +98,7 @@ class HeartFChatting:
         self.history_loop: List[CycleDetail] = []
         self._cycle_counter = 0
         self._current_cycle_detail: CycleDetail = None  # type: ignore
+        self._max_history_loop_size = 100  # 最大保留的思考记录数量
 
         self.last_read_time = time.time() - 2
 
@@ -164,6 +165,9 @@ class HeartFChatting:
         self.history_loop.append(self._current_cycle_detail)
         self._current_cycle_detail.timers = cycle_timers
         self._current_cycle_detail.end_time = time.time()
+        # 清理过期的思考记录，保留最近的最大数量
+        if len(self.history_loop) > self._max_history_loop_size:
+            self.history_loop = self.history_loop[-self._max_history_loop_size:]
 
     def print_cycle_info(self, cycle_timers):
         # 记录循环信息和计时器结果

--- a/src/chat/heart_flow/heartflow.py
+++ b/src/chat/heart_flow/heartflow.py
@@ -1,3 +1,5 @@
+import asyncio
+import time
 import traceback
 from typing import Any, Optional, Dict
 
@@ -13,12 +15,71 @@ logger = get_logger("heartflow")
 class Heartflow:
     """主心流协调器，负责初始化并协调聊天"""
 
+    # 最大缓存的聊天实例数量
+    MAX_CHAT_INSTANCES = 100
+    # 不活跃阈值（秒），超过此时间未访问且已停止的实例将被清理
+    INACTIVE_THRESHOLD = 3600  # 1小时
+
     def __init__(self):
         self.heartflow_chat_list: Dict[Any, HeartFChatting | BrainChatting] = {}
+        self._last_access_time: Dict[Any, float] = {}
+        self._cleanup_task: Optional[asyncio.Task] = None
+
+    async def start_cleanup_task(self):
+        """启动定期清理任务"""
+        if self._cleanup_task is None or self._cleanup_task.done():
+            self._cleanup_task = asyncio.create_task(self._periodic_cleanup())
+
+    async def _periodic_cleanup(self):
+        """定期清理不活跃的聊天实例"""
+        while True:
+            await asyncio.sleep(600)  # 每10分钟检查一次
+            try:
+                await self._cleanup_inactive_chats()
+            except Exception as e:
+                logger.error(f"清理不活跃聊天实例时出错: {e}")
+
+    async def _cleanup_inactive_chats(self):
+        """清理不活跃且已停止的聊天实例"""
+        now = time.time()
+        to_remove = []
+
+        for chat_id, last_time in list(self._last_access_time.items()):
+            # 检查是否超过不活跃阈值
+            if now - last_time > self.INACTIVE_THRESHOLD:
+                chat = self.heartflow_chat_list.get(chat_id)
+                # 只有当实例已停止运行时才清理
+                if chat is None or not getattr(chat, 'running', False):
+                    to_remove.append(chat_id)
+
+        for chat_id in to_remove:
+            self.heartflow_chat_list.pop(chat_id, None)
+            self._last_access_time.pop(chat_id, None)
+
+        if to_remove:
+            logger.info(f"已清理 {len(to_remove)} 个不活跃的聊天实例")
+
+    def _enforce_max_size(self):
+        """强制限制最大缓存数量"""
+        while len(self.heartflow_chat_list) > self.MAX_CHAT_INSTANCES:
+            # 找到最久未访问的实例
+            oldest_chat_id = min(self._last_access_time.keys(), key=lambda k: self._last_access_time[k])
+            chat = self.heartflow_chat_list.get(oldest_chat_id)
+
+            # 尝试停止实例
+            if chat and getattr(chat, 'running', False):
+                chat.running = False
+
+            self.heartflow_chat_list.pop(oldest_chat_id, None)
+            self._last_access_time.pop(oldest_chat_id, None)
+            logger.debug(f"移除最久未访问的聊天实例: {oldest_chat_id}")
 
     async def get_or_create_heartflow_chat(self, chat_id: Any) -> Optional[HeartFChatting | BrainChatting]:
         """获取或创建一个新的HeartFChatting实例"""
         try:
+            # 更新访问时间
+            self._last_access_time[chat_id] = time.time()
+
             if chat_id in self.heartflow_chat_list:
                 if chat := self.heartflow_chat_list.get(chat_id):
                     return chat
@@ -32,6 +93,10 @@ class Heartflow:
                     new_chat = BrainChatting(chat_id=chat_id)
                 await new_chat.start()
                 self.heartflow_chat_list[chat_id] = new_chat
+
+                # 检查并限制最大数量
+                self._enforce_max_size()
+
                 return new_chat
         except Exception as e:
             logger.error(f"创建心流聊天 {chat_id} 失败: {e}", exc_info=True)

--- a/src/chat/message_receive/chat_stream.py
+++ b/src/chat/message_receive/chat_stream.py
@@ -118,6 +118,7 @@ class ChatManager:
 
     _instance = None
     _initialized = False
+    MAX_STREAMS_CACHE = 500  # 最大缓存数量
 
     def __new__(cls):
         if cls._instance is None:
@@ -286,6 +287,8 @@ class ChatManager:
             logger.error(f"聊天流 {stream_id} 不在最后消息列表中，可能是新创建的")
         # 保存到内存和数据库
         self.streams[stream_id] = stream
+        # LRU 缓存清理：当缓存数量超过最大值时，移除最久未活跃的流
+        self._enforce_max_cache_size()
         await self._save_stream(stream)
         return stream
 
@@ -317,6 +320,17 @@ class ChatManager:
             return f"{stream.user_info.user_nickname}的私聊"
         else:
             return None
+
+    def _enforce_max_cache_size(self):
+        """当缓存数量超过最大值时，移除最久未活跃的流"""
+        while len(self.streams) > self.MAX_STREAMS_CACHE:
+            oldest_stream_id = min(
+                self.streams.keys(),
+                key=lambda sid: self.streams[sid].last_active_time
+            )
+            self.streams.pop(oldest_stream_id, None)
+            self.last_messages.pop(oldest_stream_id, None)
+            logger.debug(f"移除最久未活跃的聊天流缓存: {oldest_stream_id}")
 
     @staticmethod
     async def _save_stream(stream: ChatStream):

--- a/src/main.py
+++ b/src/main.py
@@ -114,6 +114,10 @@ class MainSystem:
 
         logger.info("聊天管理器初始化成功")
 
+        # 启动 heartflow 清理任务
+        from src.chat.heart_flow.heartflow import heartflow
+        await heartflow.start_cleanup_task()
+
         # await asyncio.sleep(0.5) #防止logger输出飞了
 
         # 将bot.py中的chat_bot.message_process消息处理函数注册到api.py的消息处理基类中


### PR DESCRIPTION
# 修复MaiBot可能的内存泄露问题
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）: 完全没有
6. 请简要说明本次更新的内容和目的：

### 本次更新修复了目前出线已久的MaiBot主程序运行期间内存占用持续提升的问题，以下为具体的改动说明：
   1.  修复 `history_loop` 历史消息对象无限制被创建的问题，添加 `history_loop` 清理机制，限制最大保留数量
   2. 添加 `heartflow_chat_list` 清理机制，定期清理不活跃实例
   3. 添加 `ChatManager.streams` LRU 缓存，限制内存缓存大小
   4. 添加 `ExpressionLearnerManager` 清理机制，限制实例数量
   
# 其他信息
- **关联 Issue**：Close #1271 ，以及同类issue #1335 、 #1395 

