### PR TITLE
修复依赖版本不一致问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,5 +27,5 @@ toml>=0.10.2
 tomlkit>=0.13.3
 urllib3>=2.5.0
 uvicorn>=0.35.0
-msgpack
-zstandard
+msgpack>=1.1.2
+zstandard>=0.25.0


### PR DESCRIPTION
## 问题描述
`requirements.txt` 中 `msgpack` 和 `zstandard` 缺少版本约束，而其他依赖都有明确的版本号，这会导致：
- 构建不可重现
- 可能引入不兼容的版本
- 与 `pyproject.toml` 中的定义不一致

## 改进内容
- 为 `msgpack` 添加版本约束 `>=1.1.2`
- 为 `zstandard` 添加版本约束 `>=0.25.0`
- 使 `requirements.txt` 与 `pyproject.toml` 保持一致

## 测试
- [x] 版本号与 `pyproject.toml` 一致
- [x] 符合项目依赖管理规范


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **任务类**
  * 更新项目依赖版本约束，确保最小版本兼容性和稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->