### PR TITLE
尝试修复多次回复和错误回复的问题

### DIFF
--- a/src/chat/heart_flow/heartflow.py
+++ b/src/chat/heart_flow/heartflow.py
@@ -1,3 +1,4 @@
+import asyncio
 import traceback
 from typing import Any, Optional, Dict
 
@@ -15,14 +16,23 @@ class Heartflow:
 
     def __init__(self):
         self.heartflow_chat_list: Dict[Any, HeartFChatting | BrainChatting] = {}
+        self._create_locks: Dict[Any, asyncio.Lock] = {}
 
     async def get_or_create_heartflow_chat(self, chat_id: Any) -> Optional[HeartFChatting | BrainChatting]:
         """获取或创建一个新的HeartFChatting实例"""
-        try:
+        if chat_id in self.heartflow_chat_list:
+            if chat := self.heartflow_chat_list.get(chat_id):
+                return chat
+
+        # 获取 per-chat_id 锁，防止并发创建多个实例
+        if chat_id not in self._create_locks:
+            self._create_locks[chat_id] = asyncio.Lock()
+        async with self._create_locks[chat_id]:
+            # 在等待锁期间可能已被其他协程创建
             if chat_id in self.heartflow_chat_list:
                 if chat := self.heartflow_chat_list.get(chat_id):
                     return chat
-            else:
+            try:
                 chat_stream: ChatStream | None = get_chat_manager().get_stream(chat_id)
                 if not chat_stream:
                     raise ValueError(f"未找到 chat_id={chat_id} 的聊天流")
@@ -33,10 +43,10 @@ class Heartflow:
                 await new_chat.start()
                 self.heartflow_chat_list[chat_id] = new_chat
                 return new_chat
-        except Exception as e:
-            logger.error(f"创建心流聊天 {chat_id} 失败: {e}", exc_info=True)
-            traceback.print_exc()
-            return None
+            except Exception as e:
+                logger.error(f"创建心流聊天 {chat_id} 失败: {e}", exc_info=True)
+                traceback.print_exc()
+                return None
 
 
 heartflow = Heartflow()

--- a/src/chat/planner_actions/planner.py
+++ b/src/chat/planner_actions/planner.py
@@ -233,13 +233,19 @@ class ActionPlanner:
             target_message = None
 
             target_message_id = action_json.get("target_message_id")
+            target_id_fallback = False
             if target_message_id:
                 # 根据target_message_id查找原始消息
                 target_message = self.find_message_by_id(target_message_id, message_id_list)
                 if target_message is None:
-                    logger.warning(f"{self.log_prefix}无法找到target_message_id '{target_message_id}' 对应的消息")
-                    # 选择最新消息作为target_message
+                    available_ids = [item[0] for item in message_id_list[-10:]]
+                    logger.warning(
+                        f"{self.log_prefix}无法找到target_message_id '{target_message_id}' 对应的消息，"
+                        f"可用ID(最近10条): {available_ids}，将使用最新消息但禁用引用"
+                    )
+                    # 选择最新消息作为target_message，但标记为回退
                     target_message = message_id_list[-1][1]
+                    target_id_fallback = True
             else:
                 target_message = message_id_list[-1][1]
                 logger.debug(f"{self.log_prefix}动作'{action}'缺少target_message_id，使用最新消息作为target_message")
@@ -264,6 +270,10 @@ class ActionPlanner:
                     f"LLM 返回了当前不可用的动作 '{action}' (可用: {available_action_names})。原始理由: {reasoning}"
                 )
                 action = "no_reply"
+
+            # 如果target_message_id查找失败并回退到最新消息，禁用引用以避免错误引用
+            if target_id_fallback:
+                action_data["quote"] = False
 
             # 创建ActionPlannerInfo对象
             # 将列表转换为字典格式
@@ -511,8 +521,8 @@ class ActionPlanner:
             
             # 如果没有回复该消息，强制添加回复 action
             if not has_reply_to_force_message:
-                # 移除所有 no_reply action（如果有）
-                actions = [a for a in actions if a.action_type != "no_reply"]
+                # 移除所有 no_reply 和已有的 reply action，防止产生多个 reply 导致重复回复
+                actions = [a for a in actions if a.action_type not in ("no_reply", "reply")]
                 
                 # 创建强制回复 action
                 available_actions_dict = dict(current_available_actions)
@@ -526,7 +536,7 @@ class ActionPlanner:
                 )
                 # 将强制回复 action 放在最前面
                 actions.insert(0, force_reply_action)
-                logger.info(f"{self.log_prefix} 检测到强制回复消息，已添加回复动作")
+                logger.info(f"{self.log_prefix} 检测到强制回复消息，已替换已有reply并添加强制回复动作")
 
         logger.info(
             f"{self.log_prefix}Planner:{reasoning}。选择了{len(actions)}个动作: {' '.join([a.action_type for a in actions])}"


### PR DESCRIPTION
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:  
无
6. 请简要说明本次更新的内容和目的：  
本次更新聚焦修复“多次回复”和“错误回复引用”问题。  
- 在心流会话创建流程中增加按 chat_id 的并发锁，避免并发场景下重复创建聊天实例。  
- 当 target_message_id 未命中时，回退到最新消息并禁用引用，避免错误引用。  
- 强制回复场景下，移除已有 reply/no_reply 后再插入唯一强制 reply，避免重复回复。