### PR TITLE
fix(person_info): 修复 group_cardname 迁移过程中的兼容问题

### DIFF
--- a/src/common/data_models/person_info_data_model.py
+++ b/src/common/data_models/person_info_data_model.py
@@ -60,7 +60,20 @@ class MaiPersonInfo(BaseDatabaseDataModel[PersonInfo]):
     @classmethod
     def from_db_instance(cls, db_record: "PersonInfo"):
         nickname_json = json.loads(db_record.group_cardname) if db_record.group_cardname else None
-        group_cardname_list = [GroupCardnameInfo(**item) for item in nickname_json] if nickname_json else None
+        if isinstance(nickname_json, list):
+            normalized_group_cardname_list = []
+            for item in nickname_json:
+                if not isinstance(item, dict):
+                    continue
+                normalized_group_cardname_list.append(
+                    GroupCardnameInfo(
+                        group_id=str(item.get("group_id", "")),
+                        group_cardname=str(item.get("group_cardname", item.get("group_nick_name", ""))),
+                    )
+                )
+            group_cardname_list = normalized_group_cardname_list
+        else:
+            group_cardname_list = None
         memory_points = json.loads(db_record.memory_points) if db_record.memory_points else None
         return cls(
             is_known=db_record.is_known,

--- a/src/person_info/person_info.py
+++ b/src/person_info/person_info.py
@@ -486,13 +486,26 @@ class Person:
                     else:
                         self.memory_points = []
 
-                    # 处理group_nick_name字段（JSON格式的列表）
+                    # 处理 group_cardname 字段（JSON 格式的列表）
                     if record.group_cardname:
                         try:
                             loaded_group_nick_names = json.loads(record.group_cardname)
-                            # 确保是列表格式
+                            # 兼容旧结构 [{"group_id": str, "group_nick_name": str}]
+                            # 统一归一化为内部使用的 [{"group_id": str, "group_nick_name": str}]
                             if isinstance(loaded_group_nick_names, list):
-                                self.group_nick_name = loaded_group_nick_names
+                                normalized_group_nick_names = []
+                                for item in loaded_group_nick_names:
+                                    if not isinstance(item, dict):
+                                        continue
+                                    normalized_group_nick_names.append(
+                                        {
+                                            "group_id": str(item.get("group_id", "")),
+                                            "group_nick_name": str(
+                                                item.get("group_nick_name", item.get("group_cardname", ""))
+                                            ),
+                                        }
+                                    )
+                                self.group_nick_name = normalized_group_nick_names
                             else:
                                 self.group_nick_name = []
                         except (json.JSONDecodeError, TypeError):
@@ -520,8 +533,17 @@ class Person:
                 if self.memory_points
                 else json.dumps([], ensure_ascii=False)
             )
-            group_nickname_value = (
-                json.dumps(self.group_nick_name, ensure_ascii=False)
+            group_cardname_value = (
+                json.dumps(
+                    [
+                        {
+                            "group_id": item.get("group_id", ""),
+                            "group_cardname": item.get("group_cardname", item.get("group_nick_name", "")),
+                        }
+                        for item in self.group_nick_name
+                    ],
+                    ensure_ascii=False,
+                )
                 if self.group_nick_name
                 else json.dumps([], ensure_ascii=False)
             )
@@ -544,7 +566,7 @@ class Person:
                     record.first_known_time = first_known_time
                     record.last_known_time = last_known_time
                     record.memory_points = memory_points_value
-                    record.group_nickname = group_nickname_value
+                    record.group_cardname = group_cardname_value
                     session.add(record)
                     logger.debug(f"已同步用户 {self.person_id} 的信息到数据库")
                 else:
@@ -560,7 +582,7 @@ class Person:
                         first_known_time=first_known_time,
                         last_known_time=last_known_time,
                         memory_points=memory_points_value,
-                        group_nickname=group_nickname_value,
+                        group_cardname=group_cardname_value,
                     )
                     session.add(record)
                     logger.debug(f"已创建用户 {self.person_id} 的信息到数据库")


### PR DESCRIPTION
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
无

6. 请简要说明本次更新的内容和目的：
修复 `PersonInfo` 中群昵称字段从旧结构向新结构迁移时的兼容问题。

当前项目中，数据库字段已经使用 `group_cardname`，但运行时和历史数据中仍可能存在以下旧命名或旧结构：
- 字段名：`group_nickname`
- JSON 键名：`group_nick_name`

这会导致人物信息在读写数据库时出现兼容性问题，例如：
- 写入时访问不存在的 `group_nickname` 字段
- 读取旧数据时无法正确解析群昵称内容
- 不同代码路径下新旧结构混用，增加后续迁移风险

本次修复内容包括：
- 在 `src/person_info/person_info.py` 中统一写库时的字段映射，改为写入 `group_cardname`
- 在 `src/person_info/person_info.py` 中增加读取兼容，将旧结构 `group_nick_name` 和新结构 `group_cardname` 统一归一化
- 在 `src/common/data_models/person_info_data_model.py` 中增加旧数据结构兼容，避免 `MaiPersonInfo.from_db_instance()` 直接按新结构解析时失败

本次改动的目标是保证：
- 新字段结构可正常使用
- 历史旧数据不会因为字段迁移而解析失败
- 迁移过程中的数据兼容性更完整

# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:
本 PR 仅处理 `group_cardname` 迁移兼容问题，不包含进一步统一运行时内部字段命名或调整 WebUI 接口字段命名的改动。
该修复对应项目根目录 `代码备忘.md` 中关于 `PersonInfo` 群昵称字段迁移的待办项。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **Bug Fixes**
  * 改进了团体卡牌名称数据的加载和保存逻辑，现在能正确处理遗留数据格式。
  * 增强了数据验证机制，确保团体ID和卡牌名称字段被正确规范化处理。
  * 优化了数据库读写过程中的容错能力，自动跳过无效数据条目。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->