### PR TITLE
fix(plugin_runtime): handle unsupported signal handlers on Windows

### DIFF
--- a/src/plugin_runtime/runner/runner_main.py
+++ b/src/plugin_runtime/runner/runner_main.py
@@ -668,7 +668,12 @@ async def _async_main() -> None:
 
     loop = asyncio.get_event_loop()
     for sig in (signal.SIGTERM, signal.SIGINT):
-        loop.add_signal_handler(sig, _mark_runner_shutting_down)
+        try:
+            loop.add_signal_handler(sig, _mark_runner_shutting_down)
+        except NotImplementedError:
+            logger.warning(f"当前平台/事件循环不支持 signal handler，跳过注册信号 {sig!s}")
+        except RuntimeError as exc:
+            logger.warning(f"注册信号处理器失败，跳过信号 {sig!s}: {exc}")
 
     await runner.run()
 


### PR DESCRIPTION
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
无

6. 请简要说明本次更新的内容和目的：
修复 `plugin_runtime` 在 Windows 环境下启动 Runner 子进程时，因 `asyncio` 事件循环不支持 `loop.add_signal_handler(...)` 而直接崩溃的问题。

当前 `src/plugin_runtime/runner/runner_main.py` 在启动时会无条件为 `SIGTERM` 和 `SIGINT` 注册事件循环 signal handler。在部分 Windows 环境下，当前事件循环不支持 `add_signal_handler()`，会直接抛出 `NotImplementedError`，导致 Runner 子进程启动失败，进而影响插件运行时工作。

本次修复在 signal handler 注册处增加兼容保护：
- 支持 signal handler 的平台保持原行为不变
- 对不支持的平台捕获 `NotImplementedError`
- 对运行时异常额外捕获 `RuntimeError`
- 跳过 signal 注册并继续启动 Runner

本次改动的目标是：
- 避免 Runner 在 Windows 环境下启动阶段直接崩溃
- 提高 `plugin_runtime` 的跨平台兼容性
- 不改变其他现有 Runtime 行为

已在本地验证：
- Runner 不再因 `loop.add_signal_handler(...)` 不支持而在启动时崩溃
- 插件运行时链路可继续工作

# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:
该修复为最小范围兼容补丁，仅处理 Windows 下 signal handler 不支持的情况，不包含其他 Runtime 行为调整。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 增强应用稳定性：改进信号处理的错误处理机制。在不支持或信号处理失败的环境中，应用现在会记录警告日志而非崩溃。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->