### PR TITLE
fix: 为 Runtime 和 Loader 补充包式插件导入支持

### DIFF
--- a/src/plugin_runtime/runner/plugin_loader.py
+++ b/src/plugin_runtime/runner/plugin_loader.py
@@ -9,6 +9,7 @@
 from collections import deque
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+import contextlib
 import importlib
 import importlib.util
 import json
@@ -239,7 +240,19 @@ class PluginLoader:
 
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
-        spec.loader.exec_module(module)
+
+        plugin_parent_dir = os.path.dirname(plugin_dir)
+        inserted_plugin_parent = False
+        if plugin_parent_dir and plugin_parent_dir not in sys.path:
+            sys.path.insert(0, plugin_parent_dir)
+            inserted_plugin_parent = True
+
+        try:
+            spec.loader.exec_module(module)
+        finally:
+            if inserted_plugin_parent:
+                with contextlib.suppress(ValueError):
+                    sys.path.remove(plugin_parent_dir)
 
         # 优先使用新版 create_plugin 工厂函数
         create_plugin = getattr(module, "create_plugin", None)

--- a/src/plugin_runtime/runner/runner_main.py
+++ b/src/plugin_runtime/runner/runner_main.py
@@ -627,14 +627,19 @@ def _isolate_sys_path(plugin_dirs: List[str]) -> None:
             allowed.add(p)
 
     # 添加插件目录
-    for d in plugin_dirs:
-        allowed.add(os.path.normpath(d))
+    plugin_dir_paths = [os.path.normpath(d) for d in plugin_dirs]
+    for d in plugin_dir_paths:
+        allowed.add(d)
 
     # 添加项目根目录（使得 src.plugin_runtime / src.common 可导入）
     runtime_root = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
     allowed.add(runtime_root)
 
-    sys.path[:] = [p for p in sys.path if p in allowed]
+    preserved_paths = [p for p in sys.path if p in allowed]
+    for extra_path in [*plugin_dir_paths, runtime_root]:
+        if extra_path not in preserved_paths:
+            preserved_paths.append(extra_path)
+    sys.path[:] = preserved_paths
 
     # 安装 import 钩子，阻止插件导入主程序核心模块
     # 仅允许 src.plugin_runtime 和 src.common，拒绝其他 src.* 子包


### PR DESCRIPTION
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
无

6. 请简要说明本次更新的内容和目的：
修复新版插件运行时中，包式插件在 Runner / Loader 下无法稳定导入的问题。

当前插件系统已经支持以 `plugins/<plugin_name>/plugin.py` 作为入口，并通过 `create_plugin()` 加载插件。  
但在实际运行中，如果插件内部使用正常的包式导入，例如：

- `from grok_search_plugin.services.xxx import ...`

则在部分场景下会出现：

- `No module named 'grok_search_plugin'`

导致插件在真实 Runner 或 Loader 环境下加载失败。

问题原因主要包括：
- `runner_main.py` 中 `_isolate_sys_path()` 虽然把插件目录和项目根目录加入了允许集合，但没有稳定地把这些路径追加回实际 `sys.path`
- `plugin_loader.py` 在按文件路径动态执行 `plugin.py` 时，没有临时把插件父目录加入 `sys.path`，导致包式插件导入在 Loader 场景下仍可能失败

本次修复内容包括：
- 在 `src/plugin_runtime/runner/runner_main.py` 中，确保插件目录和项目根目录在隔离后真正保留到 `sys.path`
- 在 `src/plugin_runtime/runner/plugin_loader.py` 中，动态执行 `plugin.py` 前临时加入插件父目录，执行后再清理，保证包式导入在 Loader 场景下也能正常工作

本次改动的目标是：
- 支持插件使用更标准的包式目录结构
- 修复 `No module named '<plugin_name>'` 这类导入失败问题
- 保持现有插件隔离策略和导入限制不扩大范围

已在本地验证：
- 真实运行中的 `grok_search_plugin` 可以被插件运行时成功加载
- `PluginLoader` 可正常加载包式插件
- 插件真实功能联调通过，不再出现 `No module named 'grok_search_plugin'`

# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:
该修复主要针对新版插件系统对“包式插件”的导入支持问题，不涉及旧插件兼容层行为变更，也不改变插件系统现有的导入白名单策略。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了插件模块加载过程中的导入路径处理机制，确保路径在模块执行后正确清理。

* **Refactor**
  * 规范化了插件目录路径的处理方式，优化了系统路径的管理逻辑，以确保更稳定和可预测的模块加载行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->