### PR TITLE
fix: 修复黑话 raw_content 异常数据导致管理页面报错的问题

### DIFF
--- a/src/webui/routers/jargon.py
+++ b/src/webui/routers/jargon.py
@@ -491,7 +491,24 @@ async def create_jargon(request: JargonCreateRequest):
 async def update_jargon(jargon_id: int, request: JargonUpdateRequest):
     """更新黑话（增量更新）"""
     try:
-        jargon = Jargon.get_or_none(Jargon.id == jargon_id)
+        # 更新接口同样避免直接读取 raw_content，防止坏数据在 ORM 解码阶段直接报错。
+        jargon = (
+            Jargon.select(
+                Jargon.id,
+                Jargon.content,
+                Jargon.meaning,
+                Jargon.chat_id,
+                Jargon.is_global,
+                Jargon.count,
+                Jargon.is_jargon,
+                Jargon.is_complete,
+                Jargon.inference_with_context,
+                Jargon.inference_content_only,
+            )
+            .where(Jargon.id == jargon_id)
+            .limit(1)
+            .first()
+        )
         if not jargon:
             raise HTTPException(status_code=404, detail="黑话不存在")
 
@@ -522,7 +539,13 @@ async def update_jargon(jargon_id: int, request: JargonUpdateRequest):
 async def delete_jargon(jargon_id: int):
     """删除黑话"""
     try:
-        jargon = Jargon.get_or_none(Jargon.id == jargon_id)
+        # 删除接口也避免直接读取 raw_content，防止坏数据在 ORM 解码阶段直接报错。
+        jargon = (
+            Jargon.select(Jargon.id, Jargon.content)
+            .where(Jargon.id == jargon_id)
+            .limit(1)
+            .first()
+        )
         if not jargon:
             raise HTTPException(status_code=404, detail="黑话不存在")
 

--- a/src/webui/routers/jargon.py
+++ b/src/webui/routers/jargon.py
@@ -66,6 +66,27 @@ def get_display_name_for_chat_id(chat_id_str: str) -> str:
     return ", ".join(names) if names else chat_id_str
 
 
+def _safe_raw_content(jargon_id: int) -> Optional[str]:
+    """
+    使用 Peewee 单独读取 raw_content，避免坏数据在主查询阶段拖垮整页。
+
+    说明：
+    - 列表页和详情页主查询尽量不直接触碰 raw_content
+    - 如果单条记录的 raw_content 解码失败，仅记录日志并返回 None
+    """
+    try:
+        row = (
+            Jargon.select(Jargon.raw_content)
+            .where(Jargon.id == jargon_id)
+            .limit(1)
+            .first()
+        )
+        return row.raw_content if row else None
+    except Exception as exc:
+        logger.warning(f"读取黑话字段失败: id={jargon_id}, field=raw_content, error={exc}")
+        return None
+
+
 # ==================== 请求/响应模型 ====================
 
 
@@ -182,18 +203,19 @@ class ChatListResponse(BaseModel):
 
 
 def jargon_to_dict(jargon: Jargon) -> dict:
-    """将 Jargon ORM 对象转换为字典"""
+    """将 Jargon ORM 对象转换为字典，并对 raw_content 做单条容错读取。"""
     # 解析 chat_id 获取显示名称和 stream_id
-    chat_name = get_display_name_for_chat_id(jargon.chat_id) if jargon.chat_id else None
-    stream_ids = parse_chat_id_to_stream_ids(jargon.chat_id) if jargon.chat_id else []
+    chat_id = jargon.chat_id or ""
+    chat_name = get_display_name_for_chat_id(chat_id) if chat_id else None
+    stream_ids = parse_chat_id_to_stream_ids(chat_id) if chat_id else []
     stream_id = stream_ids[0] if stream_ids else None
 
     return {
         "id": jargon.id,
         "content": jargon.content,
-        "raw_content": jargon.raw_content,
+        "raw_content": _safe_raw_content(jargon.id),
         "meaning": jargon.meaning,
-        "chat_id": jargon.chat_id,
+        "chat_id": chat_id,
         "stream_id": stream_id,
         "chat_name": chat_name,
         "is_global": jargon.is_global,
@@ -219,15 +241,26 @@ async def get_jargon_list(
 ):
     """获取黑话列表"""
     try:
-        # 构建查询
-        query = Jargon.select()
+        # 构建查询。列表页主查询不直接触碰 raw_content，避免坏数据在 ORM 解码阶段拖垮整页。
+        query = Jargon.select(
+            Jargon.id,
+            Jargon.content,
+            Jargon.meaning,
+            Jargon.chat_id,
+            Jargon.is_global,
+            Jargon.count,
+            Jargon.is_jargon,
+            Jargon.is_complete,
+            Jargon.inference_with_context,
+            Jargon.inference_content_only,
+        )
 
-        # 搜索过滤
+        # 搜索过滤。这里暂时不对 raw_content 做 contains，避免坏数据导致整页失败。
+        # raw_content 的读取在序列化阶段按单条记录单独处理。
         if search:
             query = query.where(
                 (Jargon.content.contains(search))
                 | (Jargon.meaning.contains(search))
-                | (Jargon.raw_content.contains(search))
             )
 
         # 按聊天ID筛选（使用 contains 匹配，因为 chat_id 是 JSON 格式）
@@ -256,8 +289,14 @@ async def get_jargon_list(
         query = query.order_by(Jargon.count.desc(), Jargon.id.desc())
         query = query.paginate(page, page_size)
 
-        # 转换为响应格式
-        data = [jargon_to_dict(j) for j in query]
+        # 转换为响应格式（单条坏数据不影响整页）
+        data = []
+        for j in query:
+            try:
+                data.append(jargon_to_dict(j))
+            except Exception as item_error:
+                logger.warning(f"跳过异常黑话记录: id={getattr(j, 'id', 'unknown')}, error={item_error}")
+                continue
 
         return JargonListResponse(
             success=True,
@@ -376,11 +415,34 @@ async def get_jargon_stats():
 async def get_jargon_detail(jargon_id: int):
     """获取黑话详情"""
     try:
-        jargon = Jargon.get_or_none(Jargon.id == jargon_id)
+        # 详情页也避免直接读取 raw_content，防止坏数据在 ORM 解码阶段直接报错。
+        jargon = (
+            Jargon.select(
+                Jargon.id,
+                Jargon.content,
+                Jargon.meaning,
+                Jargon.chat_id,
+                Jargon.is_global,
+                Jargon.count,
+                Jargon.is_jargon,
+                Jargon.is_complete,
+                Jargon.inference_with_context,
+                Jargon.inference_content_only,
+            )
+            .where(Jargon.id == jargon_id)
+            .limit(1)
+            .first()
+        )
         if not jargon:
             raise HTTPException(status_code=404, detail="黑话不存在")
 
-        return JargonDetailResponse(success=True, data=jargon_to_dict(jargon))
+        try:
+            data = jargon_to_dict(jargon)
+        except Exception as item_error:
+            logger.error(f"解析黑话详情失败: id={jargon_id}, error={item_error}")
+            raise HTTPException(status_code=500, detail="黑话记录损坏，无法读取详情") from item_error
+
+        return JargonDetailResponse(success=True, data=data)
 
     except HTTPException:
         raise


### PR DESCRIPTION
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
无

6. 请简要说明本次更新的内容和目的：
修复 WebUI 黑话管理中，当 `Jargon.raw_content` 含有历史脏数据 / 非 UTF-8 内容时，黑话列表页、详情页、更新和删除操作可能直接报错的问题。

当前实现中，`raw_content` 通过 Peewee 的 `TextField` 直接读取。当数据库中存在非法 UTF-8 的历史数据时，Peewee 在 ORM 解码阶段就可能抛出异常，导致：
- 黑话列表页整体获取失败
- 黑话详情页读取失败
- 在 WebUI 中更新或删除该条黑话时也可能失败

本次修复内容包括：
- 列表页主查询不直接选择 `raw_content`，避免坏数据在主查询阶段拖垮整页
- `raw_content` 改为按单条记录单独读取，并在读取失败时记录日志、返回 `None`
- 列表页逐条容错，单条坏记录不再影响整页返回
- 详情页避免直接在 ORM 解码阶段触碰坏的 `raw_content`
- 更新接口和删除接口同样避免直接读取坏的 `raw_content`，保证在 WebUI 中仍可对异常记录进行管理
- 全程保持 Peewee ORM 方式，不直接引入 sqlite3 执行 SQL 语句

本次改动的目标是：
- 避免单条坏的黑话记录导致黑话管理页整体报错
- 保证列表页、详情页、更新、删除等基础管理操作可继续工作
- 在日志中明确标出问题记录，方便后续清洗历史脏数据
- 在尽量不删减现有功能的前提下，提高黑话管理页的稳定性

验证情况：
- 已构造包含非法 UTF-8 字节的 `raw_content` 黑话记录进行复现
- 修复前：坏记录会导致黑话列表页和详情页报错
- 修复后：列表页不再整页失败，详情页可读取，且对坏记录的更新和删除操作也可以正常进行
- 已在本地手动测试通过

# 其他信息
- **关联 Issue**：Close #1537
- **截图/GIF**：
- **附加信息**:
本 PR 仅处理黑话管理页面对异常 `raw_content` 数据的读取容错问题，不包含黑话数据清洗、数据库结构调整或字段迁移。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 改进了数据处理的稳健性，防止损坏数据导致服务失败
* 增强了错误处理机制，单条记录的异常不再影响整体查询操作
* 优化了查询效率和数据筛选逻辑

<!-- end of auto-generated comment: release notes by coderabbit.ai -->