### PR TITLE
fix: 修复 WebUI 测试 Gemini 提供商连接时错误使用 Bearer 导致 API Key 被误判无效

### DIFF
--- a/src/webui/routers/model.py
+++ b/src/webui/routers/model.py
@@ -262,6 +262,7 @@ async def get_models_by_url(
 async def test_provider_connection(
     base_url: str = Query(..., description="提供商的基础 URL"),
     api_key: Optional[str] = Query(None, description="API Key（可选，用于验证 Key 有效性）"),
+    client_type: str = Query("openai", description="客户端类型 (openai | gemini)"),
     _auth: bool = Depends(require_auth),
 ):
     """
@@ -321,13 +322,19 @@ async def test_provider_connection(
         try:
             start_time = time.time()
             async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
-                headers = {
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                }
+                headers = {"Content-Type": "application/json"}
+                params = {}
+
+                if client_type == "gemini":
+                    # Gemini 使用 URL 参数传递 API Key
+                    params["key"] = api_key
+                else:
+                    # OpenAI 兼容格式使用 Authorization 头
+                    headers["Authorization"] = f"Bearer {api_key}"
+
                 # 尝试获取模型列表
                 models_url = f"{base_url}/models"
-                response = await client.get(models_url, headers=headers)
+                response = await client.get(models_url, headers=headers, params=params)
 
                 if response.status_code == 200:
                     result["api_key_valid"] = True
@@ -375,9 +382,14 @@ async def test_provider_connection_by_name(
 
     base_url = provider.get("base_url", "")
     api_key = provider.get("api_key", "")
+    client_type = provider.get("client_type", "openai")
 
     if not base_url:
         raise HTTPException(status_code=400, detail="提供商配置缺少 base_url")
 
     # 调用测试接口
-    return await test_provider_connection(base_url=base_url, api_key=api_key if api_key else None)
+    return await test_provider_connection(
+        base_url=base_url,
+        api_key=api_key if api_key else None,
+        client_type=client_type,
+    )


### PR DESCRIPTION
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
无

6. 请简要说明本次更新的内容和目的：
修复 WebUI 在测试 Gemini 提供商连接时，因错误使用 `Authorization: Bearer` 方式校验 API Key，导致有效的 Gemini API Key 被误判为无效的问题。

当前实现中，模型列表获取逻辑已经对 `gemini` 做了特殊处理：Gemini 通过 URL 查询参数传递 API Key，即 `?key=...`。但在 WebUI 的连接测试逻辑中，API Key 验证仍统一使用 `Authorization: Bearer <api_key>` 访问 `/models`，这对 OpenAI 兼容接口通常有效，但对 Gemini 不正确，因此会导致：
- WebUI 显示“连接正常但 Key 无效”
- 有效的 Gemini API Key 被误判为无效或已过期
- 前端测试结果与实际 Gemini API 可用性不一致

本次修复内容包括：
- 为连接测试接口增加 `client_type` 参数
- 当 `client_type == "gemini"` 时，改为使用查询参数 `key=...` 请求模型列表接口验证 API Key
- 对其他 OpenAI 兼容提供商，保持原有 `Authorization: Bearer ...` 的校验方式不变
- 在按提供商名称测试连接时，从配置中读取并透传 `client_type`
- 保持现有模型列表获取逻辑和其他提供商测试逻辑不变，仅修正 Gemini 的错误校验方式

本次改动的目标是：
- 修复 Gemini 提供商连接测试中的误报问题
- 让 WebUI 中提供商测试结果与实际 API 可用性保持一致
- 避免用户在 API Key 实际有效时被误导为“Key无效”
- 在不影响其他 OpenAI 兼容提供商逻辑的前提下，提高模型提供商测试功能的准确性

验证情况：
- 已使用有效 Gemini API Key 进行本地复现和验证
- 修复前：Gemini 提供商网络连接正常，但测试结果显示 `Key无效`
- 修复后：有效 Gemini API Key 可被正确识别，不再误报无效
- 已在本地手动测试通过

# 其他信息
- **关联 Issue**：Close #1557
- **截图/GIF**：
- **附加信息**:
本 PR 仅修复 WebUI 提供商连接测试中对 Gemini API Key 的错误校验逻辑，不涉及模型调用主链、模型列表解析逻辑或更通用的认证策略重构。
