### PR TITLE
fix: 修复黑话 raw_content 异常数据导致管理页面报错的问题

### DIFF
--- a/src/webui/routers/jargon.py
+++ b/src/webui/routers/jargon.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any, Dict, List, Optional, Set
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
+from sqlalchemy.orm import defer
 from sqlmodel import Session, col, delete, select
 
 from src.common.database.database import get_db_session
@@ -60,6 +61,21 @@ def get_display_name_for_chat_id(chat_id_str: str, session: Session) -> str:
         return str(chat_session.group_id)
 
     return chat_session.session_id[:20]
+
+
+def _safe_raw_content(session: Session, jargon_id: int) -> Optional[str]:
+    """
+    单独读取 raw_content，避免坏数据在主查询阶段拖垮整页。
+
+    说明：
+    - 列表页和详情页主查询尽量不直接触碰 raw_content
+    - 如果单条记录的 raw_content 解码失败，仅记录日志并返回 None
+    """
+    try:
+        return session.exec(select(Jargon.raw_content).where(col(Jargon.id) == jargon_id)).first()
+    except Exception as exc:
+        logger.warning(f"读取黑话字段失败: id={jargon_id}, field=raw_content, error={exc}")
+        return None
 
 
 # ==================== 请求/响应模型 ====================
@@ -225,14 +241,14 @@ def build_session_id_dict_for_chat(chat_id: str, count: int = 1) -> str:
 
 
 def jargon_to_dict(jargon: Jargon, session: Session) -> Dict[str, Any]:
-    """将 Jargon ORM 对象转换为字典"""
+    """将 Jargon ORM 对象转换为字典，并对 raw_content 做单条容错读取。"""
     chat_id = get_primary_chat_id(jargon.session_id_dict)
     chat_name = get_display_name_for_chat_id(chat_id, session) if chat_id else None
 
     return {
         "id": jargon.id,
         "content": jargon.content,
-        "raw_content": jargon.raw_content,
+        "raw_content": _safe_raw_content(session, jargon.id),
         "meaning": jargon.meaning,
         "chat_id": chat_id,
         "stream_id": chat_id or None,
@@ -258,13 +274,12 @@ async def get_jargon_list(
 ):
     """获取黑话列表"""
     try:
-        statement = select(Jargon)
+        statement = select(Jargon).options(defer(Jargon.raw_content))
 
         if search:
             search_filter = (
                 (col(Jargon.content).contains(search))
                 | (col(Jargon.meaning).contains(search))
-                | (col(Jargon.raw_content).contains(search))
             )
             statement = statement.where(search_filter)
 
@@ -288,7 +303,13 @@ async def get_jargon_list(
             total = len(jargons)
             offset = (page - 1) * page_size
             page_jargons = jargons[offset : offset + page_size]
-            data = [jargon_to_dict(jargon, session) for jargon in page_jargons]
+            data = []
+            for jargon in page_jargons:
+                try:
+                    data.append(jargon_to_dict(jargon, session))
+                except Exception as item_error:
+                    logger.warning(f"跳过异常黑话记录: id={getattr(jargon, 'id', 'unknown')}, error={item_error}")
+                    continue
 
         return JargonListResponse(
             success=True,
@@ -308,7 +329,7 @@ async def get_chat_list():
     """获取所有有黑话记录的聊天列表"""
     try:
         with get_db_session() as session:
-            jargons = session.exec(select(Jargon)).all()
+            jargons = session.exec(select(Jargon).options(defer(Jargon.raw_content))).all()
 
         seen_stream_ids: Set[str] = set()
         for jargon in jargons:
@@ -351,7 +372,7 @@ async def get_jargon_stats():
     """获取黑话统计数据"""
     try:
         with get_db_session() as session:
-            jargons = session.exec(select(Jargon)).all()
+            jargons = session.exec(select(Jargon).options(defer(Jargon.raw_content))).all()
 
         total = len(jargons)
         confirmed_jargon = sum(jargon.is_jargon is True for jargon in jargons)
@@ -390,9 +411,18 @@ async def get_jargon_detail(jargon_id: int):
     """获取黑话详情"""
     try:
         with get_db_session() as session:
-            if not (jargon := session.exec(select(Jargon).where(col(Jargon.id) == jargon_id)).first()):
+            if not (
+                jargon := session.exec(
+                    select(Jargon).options(defer(Jargon.raw_content)).where(col(Jargon.id) == jargon_id)
+                ).first()
+            ):
                 raise HTTPException(status_code=404, detail="黑话不存在")
-            data = JargonResponse(**jargon_to_dict(jargon, session))
+
+            try:
+                data = JargonResponse(**jargon_to_dict(jargon, session))
+            except Exception as item_error:
+                logger.error(f"解析黑话详情失败: id={jargon_id}, error={item_error}")
+                raise HTTPException(status_code=500, detail="黑话记录损坏，无法读取详情") from item_error
 
         return JargonDetailResponse(success=True, data=data)
 
@@ -408,7 +438,9 @@ async def create_jargon(request: JargonCreateRequest):
     """创建黑话"""
     try:
         with get_db_session() as session:
-            same_content_jargons = session.exec(select(Jargon).where(col(Jargon.content) == request.content)).all()
+            same_content_jargons = session.exec(
+                select(Jargon).options(defer(Jargon.raw_content)).where(col(Jargon.content) == request.content)
+            ).all()
             existing = next(
                 (jargon for jargon in same_content_jargons if has_chat_id(jargon.session_id_dict, request.chat_id)),
                 None,
@@ -445,7 +477,9 @@ async def update_jargon(jargon_id: int, request: JargonUpdateRequest):
     """更新黑话（增量更新）"""
     try:
         with get_db_session() as session:
-            jargon = session.exec(select(Jargon).where(col(Jargon.id) == jargon_id)).first()
+            jargon = session.exec(
+                select(Jargon).options(defer(Jargon.raw_content)).where(col(Jargon.id) == jargon_id)
+            ).first()
             if not jargon:
                 raise HTTPException(status_code=404, detail="黑话不存在")
 
@@ -477,7 +511,9 @@ async def delete_jargon(jargon_id: int):
     """删除黑话"""
     try:
         with get_db_session() as session:
-            jargon = session.exec(select(Jargon).where(col(Jargon.id) == jargon_id)).first()
+            jargon = session.exec(
+                select(Jargon).options(defer(Jargon.raw_content)).where(col(Jargon.id) == jargon_id)
+            ).first()
             if not jargon:
                 raise HTTPException(status_code=404, detail="黑话不存在")
 
@@ -532,7 +568,7 @@ async def batch_set_jargon_status(
             raise HTTPException(status_code=400, detail="ID列表不能为空")
 
         with get_db_session() as session:
-            jargons = session.exec(select(Jargon).where(col(Jargon.id).in_(ids))).all()
+            jargons = session.exec(select(Jargon).options(defer(Jargon.raw_content)).where(col(Jargon.id).in_(ids))).all()
             for jargon in jargons:
                 jargon.is_jargon = is_jargon
                 session.add(jargon)

--- a/src/webui/routers/jargon.py
+++ b/src/webui/routers/jargon.py
@@ -248,7 +248,7 @@ def jargon_to_dict(jargon: Jargon, session: Session) -> Dict[str, Any]:
     return {
         "id": jargon.id,
         "content": jargon.content,
-        "raw_content": _safe_raw_content(session, jargon.id),
+        "raw_content": _safe_raw_content(session, jargon.id) if jargon.id is not None else None,
         "meaning": jargon.meaning,
         "chat_id": chat_id,
         "stream_id": chat_id or None,


### PR DESCRIPTION
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
无

6. 请简要说明本次更新的内容和目的：
修复 `r-dev` 分支 WebUI 黑话管理中，当 `Jargon.raw_content` 含有历史脏数据 / 非 UTF-8 内容时，黑话列表页、详情页以及部分管理操作可能直接报错的问题。

在 `r-dev` 当前实现中，`src/webui/routers/jargon.py` 已经基于 `SQLModel + SQLAlchemy ORM`，不再是 `dev` 分支早期的 Peewee 路由结构。因此本次修复沿用 `r-dev` 当前 ORM 技术栈，通过延迟加载和单条安全读取的方式处理坏 `raw_content`，而不是直接执行原生 SQL。

当前问题的根因是：
- `raw_content` 在 ORM 主查询阶段被直接加载
- 当数据库中存在非法 UTF-8 的历史数据时，SQLite / ORM 在字段解码阶段可能抛出异常
- 这会导致黑话列表页整页失败、详情页失败，甚至影响更新 / 删除等管理操作

本次修复内容包括：
- 列表页主查询使用延迟加载，避免在主查询阶段直接触碰 `raw_content`
- `raw_content` 改为按单条记录单独安全读取，读取失败时记录日志并返回 `None`
- 列表页逐条容错，单条坏记录不再拖垮整页结果
- 详情页避免在 ORM 主查询阶段直接加载损坏的 `raw_content`
- 更新、删除、批量状态设置等操作同样避免直接加载坏字段
- 保持 `r-dev` 当前 `SQLModel/SQLAlchemy` 结构，不额外引入原生 SQL 修复逻辑

本次改动的目标是：
- 避免单条坏的黑话记录导致黑话管理页整体报错
- 保证列表页、详情页、更新、删除等基础管理操作可继续工作
- 在日志中明确标出问题记录，方便后续清洗历史脏数据
- 在不破坏 `r-dev` 当前 ORM 架构的前提下，提高黑话管理页稳定性

验证情况：
- 已在当前 `r-dev` 环境中构造包含非法 UTF-8 字节的 `raw_content` 黑话记录进行复现
- 修复前：坏记录会导致黑话页接口在读取过程中触发解码异常
- 修复后：列表页不再整页失败，详情页可正常返回，坏记录的 `raw_content` 会降级为 `None`
- 已实际验证注入多条非法 UTF-8 黑话记录后，WebUI / 路由层不再因单条坏数据整体崩溃
- 已在本地手动测试通过

# 其他信息
- **关联 Issue**：Close #1537
- **截图/GIF**：
- **附加信息**:
该 PR 目标分支为 `r-dev`。此前关于 “`dev` 分支请优先使用 Peewee ORM、不要直接执行 SQL” 的 review 要求主要针对 `dev` 当时的实现结构；而 `r-dev` 当前黑话路由已迁移到 `SQLModel/SQLAlchemy`，因此本 PR 采用的是对 `r-dev` 现有 ORM 架构的兼容性修复，而非引入新的原生 SQL 方案。
