### PR TITLE
fix: 修复 WebUI 测试 Gemini 提供商连接时错误使用 Bearer 导致 API Key 被误判无效

### DIFF
--- a/pytests/webui/test_model_routes.py
+++ b/pytests/webui/test_model_routes.py
@@ -1,0 +1,187 @@
+"""模型路由测试
+
+验证 Gemini 提供商连接测试会使用查询参数传递 API Key，
+并且不会回退到 OpenAI 兼容接口使用的 Bearer 认证方式。
+"""
+
+import importlib
+import sys
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+
+def load_model_routes(monkeypatch: pytest.MonkeyPatch):
+    """在导入路由前 stub 配置与认证依赖模块，避免测试时触发真实初始化。"""
+    config_module = ModuleType("src.config.config")
+    config_module.__dict__["CONFIG_DIR"] = "."
+    monkeypatch.setitem(sys.modules, "src.config.config", config_module)
+
+    dependencies_module = ModuleType("src.webui.dependencies")
+
+    async def require_auth():
+        return "test-token"
+
+    dependencies_module.__dict__["require_auth"] = require_auth
+    monkeypatch.setitem(sys.modules, "src.webui.dependencies", dependencies_module)
+
+    sys.modules.pop("src.webui.routers.model", None)
+    return importlib.import_module("src.webui.routers.model")
+
+
+class FakeResponse:
+    """简化版 HTTP 响应对象。"""
+
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+
+def build_async_client_factory(
+    responses: list[FakeResponse],
+    calls: list[dict[str, Any]],
+):
+    """构造一个可记录请求参数的 AsyncClient 替身。"""
+
+    response_iter = iter(responses)
+
+    class FakeAsyncClient:
+        def __init__(self, *args: Any, **kwargs: Any):
+            self.args = args
+            self.kwargs = kwargs
+
+        async def __aenter__(self) -> "FakeAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def get(
+            self,
+            url: str,
+            headers: dict[str, Any] | None = None,
+            params: dict[str, Any] | None = None,
+        ) -> FakeResponse:
+            calls.append(
+                {
+                    "url": url,
+                    "headers": headers or {},
+                    "params": params or {},
+                }
+            )
+            return next(response_iter)
+
+    return FakeAsyncClient
+
+
+@pytest.mark.asyncio
+async def test_test_provider_connection_uses_query_api_key_for_gemini(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gemini 连接测试应通过查询参数传递 API Key。"""
+    model_routes = load_model_routes(monkeypatch)
+    calls: list[dict[str, Any]] = []
+    fake_client_class = build_async_client_factory(
+        responses=[FakeResponse(200), FakeResponse(200)],
+        calls=calls,
+    )
+    monkeypatch.setattr(model_routes.httpx, "AsyncClient", fake_client_class)
+
+    result = await model_routes.test_provider_connection(
+        base_url="https://generativelanguage.googleapis.com/v1beta",
+        api_key="valid-gemini-key",
+        client_type="gemini",
+    )
+
+    assert result["network_ok"] is True
+    assert result["api_key_valid"] is True
+    assert len(calls) == 2
+
+    network_call = calls[0]
+    validation_call = calls[1]
+
+    assert network_call["url"] == "https://generativelanguage.googleapis.com/v1beta"
+    assert network_call["headers"] == {}
+    assert network_call["params"] == {}
+
+    assert validation_call["url"] == "https://generativelanguage.googleapis.com/v1beta/models"
+    assert validation_call["params"] == {"key": "valid-gemini-key"}
+    assert validation_call["headers"] == {"Content-Type": "application/json"}
+    assert "Authorization" not in validation_call["headers"]
+
+
+@pytest.mark.asyncio
+async def test_test_provider_connection_uses_bearer_auth_for_openai_compatible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """非 Gemini 提供商连接测试应继续使用 Bearer 认证。"""
+    model_routes = load_model_routes(monkeypatch)
+    calls: list[dict[str, Any]] = []
+    fake_client_class = build_async_client_factory(
+        responses=[FakeResponse(200), FakeResponse(200)],
+        calls=calls,
+    )
+    monkeypatch.setattr(model_routes.httpx, "AsyncClient", fake_client_class)
+
+    result = await model_routes.test_provider_connection(
+        base_url="https://example.com/v1",
+        api_key="valid-openai-key",
+        client_type="openai",
+    )
+
+    assert result["network_ok"] is True
+    assert result["api_key_valid"] is True
+    assert len(calls) == 2
+
+    validation_call = calls[1]
+
+    assert validation_call["url"] == "https://example.com/v1/models"
+    assert validation_call["params"] == {}
+    assert validation_call["headers"]["Content-Type"] == "application/json"
+    assert validation_call["headers"]["Authorization"] == "Bearer valid-openai-key"
+
+
+@pytest.mark.asyncio
+async def test_test_provider_connection_by_name_forwards_provider_client_type(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """按提供商名称测试连接时，应透传配置中的 client_type。"""
+    model_routes = load_model_routes(monkeypatch)
+    config_path = tmp_path / "model_config.toml"
+    config_path.write_text(
+        """
+[[api_providers]]
+name = "Gemini"
+base_url = "https://generativelanguage.googleapis.com/v1beta"
+api_key = "valid-gemini-key"
+client_type = "gemini"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(model_routes, "CONFIG_DIR", str(tmp_path))
+
+    captured_kwargs: dict[str, Any] = {}
+
+    async def fake_test_provider_connection(**kwargs: Any) -> dict[str, Any]:
+        captured_kwargs.update(kwargs)
+        return {
+            "network_ok": True,
+            "api_key_valid": True,
+            "latency_ms": 12.34,
+            "error": None,
+            "http_status": 200,
+        }
+
+    monkeypatch.setattr(model_routes, "test_provider_connection", fake_test_provider_connection)
+
+    result = await model_routes.test_provider_connection_by_name(provider_name="Gemini")
+
+    assert result["network_ok"] is True
+    assert result["api_key_valid"] is True
+    assert captured_kwargs == {
+        "base_url": "https://generativelanguage.googleapis.com/v1beta",
+        "api_key": "valid-gemini-key",
+        "client_type": "gemini",
+    }

--- a/src/webui/routers/model.py
+++ b/src/webui/routers/model.py
@@ -252,6 +252,7 @@ async def get_models_by_url(
 async def test_provider_connection(
     base_url: str = Query(..., description="提供商的基础 URL"),
     api_key: Optional[str] = Query(None, description="API Key（可选，用于验证 Key 有效性）"),
+    client_type: str = Query("openai", description="客户端类型 (openai | gemini)"),
 ):
     """
     测试提供商连接状态
@@ -315,13 +316,19 @@ async def test_provider_connection(
         try:
             start_time = time.time()
             async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
-                headers = {
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                }
+                headers = {"Content-Type": "application/json"}
+                params = {}
+
+                if client_type == "gemini":
+                    # Gemini 使用 URL 参数传递 API Key
+                    params["key"] = api_key
+                else:
+                    # OpenAI 兼容格式使用 Authorization 头
+                    headers["Authorization"] = f"Bearer {api_key}"
+
                 # 尝试获取模型列表
                 models_url = f"{base_url}/models"
-                response = await client.get(models_url, headers=headers)
+                response = await client.get(models_url, headers=headers, params=params)
 
                 if response.status_code == 200:
                     result["api_key_valid"] = True
@@ -364,9 +371,14 @@ async def test_provider_connection_by_name(
 
     base_url = provider.get("base_url", "")
     api_key = provider.get("api_key", "")
+    client_type = provider.get("client_type", "openai")
 
     if not base_url:
         raise HTTPException(status_code=400, detail="提供商配置缺少 base_url")
 
     # 调用测试接口
-    return await test_provider_connection(base_url=base_url, api_key=api_key or None)
+    return await test_provider_connection(
+        base_url=base_url,
+        api_key=api_key if api_key else None,
+        client_type=client_type,
+    )


### PR DESCRIPTION
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
无

6. 请简要说明本次更新的内容和目的：
修复 `r-dev` 分支 WebUI 在测试 Gemini 提供商连接时，因错误使用 `Authorization: Bearer` 方式校验 API Key，导致有效的 Gemini API Key 被误判为无效的问题。

当前实现中，模型列表获取逻辑已经对 `gemini` 做了特殊处理：Gemini 通过 URL 查询参数传递 API Key，即 `?key=...`。但在 WebUI 的连接测试逻辑中，API Key 验证仍统一使用 `Authorization: Bearer <api_key>` 访问 `/models`，这对 OpenAI 兼容接口通常有效，但对 Gemini 不正确，因此会导致：
- WebUI 显示“连接正常但 Key 无效”
- 有效的 Gemini API Key 被误判为无效或已过期
- 前端测试结果与实际 Gemini API 可用性不一致

本次修复内容包括：
- 为连接测试接口增加 `client_type` 参数
- 当 `client_type == "gemini"` 时，改为使用查询参数 `key=...` 请求模型列表接口验证 API Key
- 对其他 OpenAI 兼容提供商，保持原有 `Authorization: Bearer ...` 的校验方式不变
- 在按提供商名称测试连接时，从配置中读取并透传 `client_type`
- 保持 `r-dev` 当前模型列表获取逻辑与路由结构不变，仅修正 Gemini 的错误校验方式

本次改动的目标是：
- 修复 Gemini 提供商连接测试中的误报问题
- 让 WebUI 中提供商测试结果与实际 API 可用性保持一致
- 避免用户在 API Key 实际有效时被误导为“Key无效”
- 在不影响其他 OpenAI 兼容提供商逻辑的前提下，提高模型提供商测试功能的准确性

验证情况：
- 已在本地复现 `upstream/r-dev` 原版逻辑对 Gemini 的误判行为
- 在模拟 Gemini 上游仅接受 `?key=...`、不接受 `Authorization: Bearer` 的条件下：
  - 原版 `r-dev` 测试结果为：`network_ok=True`、`api_key_valid=False`
  - 修复后测试结果为：`network_ok=True`、`api_key_valid=True`
- 同时已在本地实际使用有效 Gemini API Key 手动验证，修复后不再出现“连接正常但 Key 无效”的误报
- 已在本地手动测试通过

# 其他信息
- **关联 Issue**：Close #1557 
- **截图/GIF**：
- **附加信息**:
该 PR 目标分支为 `r-dev`。本次改动沿用 `r-dev` 当前 `src/webui/routers/model.py` 的实现结构，仅对 Gemini 提供商测试连接时的 API Key 校验方式进行最小修复，不涉及模型调用主链、模型列表解析逻辑或更通用的认证策略重构。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **新功能**
  * 添加客户端类型配置，支持Gemini和OpenAI兼容的提供商。Gemini客户端通过URL参数传递API密钥，OpenAI客户端使用授权头。

* **测试**
  * 新增模型路由连接测试套件，验证不同客户端类型的凭证传递和网络连通性检查。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->