### PR TITLE
security: harden MCP Bridge Plugin (SSRF, prompt injection, log redaction)

### DIFF
--- a/plugins/MaiBot_MCPBridgePlugin/plugin.py
+++ b/plugins/MaiBot_MCPBridgePlugin/plugin.py
@@ -77,9 +77,11 @@ import fnmatch
 import hashlib
 import json
 import re
+import socket
 import time
 import uuid
 from collections import OrderedDict, deque
+from urllib.parse import urlparse
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type
@@ -185,13 +187,36 @@ class ToolCallTracer:
         """清空记录"""
         self._records.clear()
     
+    # 匹配到这些模式的键名时，值将被脱敏
+    _SENSITIVE_KEY_PATTERNS = re.compile(
+        r"(token|key|secret|password|passwd|auth|credential|api_key|apikey|access_key|private)",
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def _redact_sensitive(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        """对字典中匹配敏感模式的键值进行脱敏"""
+        redacted: Dict[str, Any] = {}
+        for k, v in data.items():
+            if cls._SENSITIVE_KEY_PATTERNS.search(k):
+                redacted[k] = "***REDACTED***"
+            elif isinstance(v, dict):
+                redacted[k] = cls._redact_sensitive(v)
+            else:
+                redacted[k] = v
+        return redacted
+
     def _write_to_log(self, record: ToolCallRecord) -> None:
-        """写入 JSONL 日志文件"""
+        """写入 JSONL 日志文件（敏感字段已脱敏）"""
         try:
             if self._log_path:
                 self._log_path.parent.mkdir(parents=True, exist_ok=True)
+                record_dict = asdict(record)
+                # 对 arguments 字段进行脱敏处理
+                if "arguments" in record_dict and isinstance(record_dict["arguments"], dict):
+                    record_dict["arguments"] = self._redact_sensitive(record_dict["arguments"])
                 with open(self._log_path, "a", encoding="utf-8") as f:
-                    f.write(json.dumps(asdict(record), ensure_ascii=False) + "\n")
+                    f.write(json.dumps(record_dict, ensure_ascii=False) + "\n")
         except Exception as e:
             logger.warning(f"写入追踪日志失败: {e}")
     
@@ -810,6 +835,27 @@ class MCPToolProxy(BaseTool):
         return await self.execute(function_args)
 
 
+def _sanitize_tool_name(name: str) -> str:
+    """清理工具名称，仅保留字母、数字和下划线（防止注入）"""
+    sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+    # 移除连续下划线并去除首尾下划线
+    sanitized = re.sub(r"_+", "_", sanitized).strip("_")
+    # 限制长度
+    return sanitized[:128] if sanitized else "unnamed_tool"
+
+
+def _sanitize_tool_description(description: str, max_length: int = 1024) -> str:
+    """清理工具描述，移除潜在的 prompt 注入内容并限制长度"""
+    # 移除可能用于 prompt 注入的控制序列
+    sanitized = re.sub(r"<\|.*?\|>", "", description)
+    # 移除 markdown 标题（常见注入载体）以外的过度格式化
+    sanitized = re.sub(r"(#{4,})", "####", sanitized)
+    # 截断到合理长度
+    if len(sanitized) > max_length:
+        sanitized = sanitized[:max_length] + "..."
+    return sanitized
+
+
 def create_mcp_tool_class(
     tool_key: str,
     tool_info: MCPToolInfo,
@@ -819,10 +865,14 @@ def create_mcp_tool_class(
     """根据 MCP 工具信息动态创建 BaseTool 子类"""
     parameters = parse_mcp_parameters(tool_info.input_schema)
     
-    class_name = f"MCPTool_{tool_info.server_name}_{tool_info.name}".replace("-", "_").replace(".", "_")
-    tool_name = tool_key.replace("-", "_").replace(".", "_")
+    # 安全: 仅允许字母数字和下划线，防止通过名称注入
+    safe_server_name = _sanitize_tool_name(tool_info.server_name)
+    safe_tool_name = _sanitize_tool_name(tool_info.name)
+    class_name = f"MCPTool_{safe_server_name}_{safe_tool_name}"
+    tool_name = _sanitize_tool_name(tool_key.replace("-", "_").replace(".", "_"))
     
-    description = tool_info.description
+    # 安全: 清理描述内容，防止 prompt 注入
+    description = _sanitize_tool_description(tool_info.description)
     if not description.endswith(f"[来自 MCP 服务器: {tool_info.server_name}]"):
         description = f"{description} [来自 MCP 服务器: {tool_info.server_name}]"
     
@@ -913,12 +963,69 @@ class MCPReadResourceTool(BaseTool):
     ]
     available_for_llm = True
     
+    # 允许的 URI scheme 白名单（排除 file:// 等危险协议）
+    _ALLOWED_SCHEMES = {"http", "https"}
+    # 禁止访问的内网 / 云元数据 IP 段
+    _BLOCKED_CIDRS = [
+        "127.0.0.0/8",
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+        "169.254.0.0/16",   # AWS / cloud metadata
+        "100.64.0.0/10",    # Carrier-grade NAT
+        "0.0.0.0/8",
+        "::1/128",
+        "fc00::/7",
+        "fe80::/10",
+    ]
+
+    @classmethod
+    def _is_uri_safe(cls, uri: str) -> Tuple[bool, str]:
+        """检查 URI 是否安全（防止 SSRF）。返回 (is_safe, reason)。"""
+        try:
+            parsed = urlparse(uri)
+        except Exception:
+            return False, "URI 格式无效"
+
+        scheme = (parsed.scheme or "").lower()
+
+        # 无 scheme 的 MCP 自定义 URI（如 "mydb://table/row"）放行，
+        # 由 MCP 服务器自身处理；仅拦截已知危险协议。
+        if scheme == "file":
+            return False, "不允许使用 file:// 协议"
+
+        # 对 http/https 做主机解析检查
+        if scheme in ("http", "https"):
+            hostname = parsed.hostname or ""
+            if not hostname:
+                return False, "缺少主机名"
+            # DNS 解析并检查是否为内网地址
+            try:
+                import ipaddress
+                addrinfos = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+                for _family, _type, _proto, _canonname, sockaddr in addrinfos:
+                    ip = ipaddress.ip_address(sockaddr[0])
+                    if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+                        return False, f"目标地址 {ip} 属于内网/保留地址段，已拦截"
+            except socket.gaierror:
+                return False, f"无法解析主机名: {hostname}"
+            except Exception as e:
+                return False, f"地址检查失败: {e}"
+
+        return True, ""
+
     async def execute(self, function_args: Dict[str, Any]) -> Dict[str, Any]:
         uri = function_args.get("uri", "")
         server_name = function_args.get("server_name")
         
         if not uri:
             return {"name": self.name, "content": "❌ 请提供资源 URI"}
+
+        # SSRF 防护：校验 URI 安全性
+        is_safe, reason = self._is_uri_safe(uri)
+        if not is_safe:
+            logger.warning(f"MCPReadResourceTool SSRF 拦截: uri={uri}, reason={reason}")
+            return {"name": self.name, "content": f"❌ 资源 URI 被拦截: {reason}"}
         
         result = await mcp_manager.read_resource(uri, server_name)
         

--- a/plugins/MaiBot_MCPBridgePlugin/plugin.py
+++ b/plugins/MaiBot_MCPBridgePlugin/plugin.py
@@ -78,6 +78,7 @@ import hashlib
 import json
 import re
 import socket
+import ipaddress
 import time
 import uuid
 from collections import OrderedDict, deque
@@ -195,16 +196,31 @@ class ToolCallTracer:
 
     @classmethod
     def _redact_sensitive(cls, data: Dict[str, Any]) -> Dict[str, Any]:
-        """对字典中匹配敏感模式的键值进行脱敏"""
+        """对字典中匹配敏感模式的键值进行脱敏（递归处理嵌套 dict 与 list）"""
         redacted: Dict[str, Any] = {}
         for k, v in data.items():
             if cls._SENSITIVE_KEY_PATTERNS.search(k):
                 redacted[k] = "***REDACTED***"
             elif isinstance(v, dict):
                 redacted[k] = cls._redact_sensitive(v)
+            elif isinstance(v, list):
+                redacted[k] = cls._redact_sensitive_list(v)
             else:
                 redacted[k] = v
         return redacted
+
+    @classmethod
+    def _redact_sensitive_list(cls, items: list) -> list:
+        """递归脱敏列表中的字典元素"""
+        result = []
+        for item in items:
+            if isinstance(item, dict):
+                result.append(cls._redact_sensitive(item))
+            elif isinstance(item, list):
+                result.append(cls._redact_sensitive_list(item))
+            else:
+                result.append(item)
+        return result
 
     def _write_to_log(self, record: ToolCallRecord) -> None:
         """写入 JSONL 日志文件（敏感字段已脱敏）"""
@@ -873,8 +889,10 @@ def create_mcp_tool_class(
     
     # 安全: 清理描述内容，防止 prompt 注入
     description = _sanitize_tool_description(tool_info.description)
-    if not description.endswith(f"[来自 MCP 服务器: {tool_info.server_name}]"):
-        description = f"{description} [来自 MCP 服务器: {tool_info.server_name}]"
+    sanitized_server_label = _sanitize_tool_name(tool_info.server_name)
+    suffix = f"[来自 MCP 服务器: {sanitized_server_label}]"
+    if not description.endswith(suffix):
+        description = f"{description} {suffix}"
     
     tool_class = type(
         class_name,
@@ -965,20 +983,6 @@ class MCPReadResourceTool(BaseTool):
     
     # 允许的 URI scheme 白名单（排除 file:// 等危险协议）
     _ALLOWED_SCHEMES = {"http", "https"}
-    # 禁止访问的内网 / 云元数据 IP 段
-    _BLOCKED_CIDRS = [
-        "127.0.0.0/8",
-        "10.0.0.0/8",
-        "172.16.0.0/12",
-        "192.168.0.0/16",
-        "169.254.0.0/16",   # AWS / cloud metadata
-        "100.64.0.0/10",    # Carrier-grade NAT
-        "0.0.0.0/8",
-        "::1/128",
-        "fc00::/7",
-        "fe80::/10",
-    ]
-
     @classmethod
     def _is_uri_safe(cls, uri: str) -> Tuple[bool, str]:
         """检查 URI 是否安全（防止 SSRF）。返回 (is_safe, reason)。"""
@@ -1001,7 +1005,6 @@ class MCPReadResourceTool(BaseTool):
                 return False, "缺少主机名"
             # DNS 解析并检查是否为内网地址
             try:
-                import ipaddress
                 addrinfos = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
                 for _family, _type, _proto, _canonname, sockaddr in addrinfos:
                     ip = ipaddress.ip_address(sockaddr[0])
@@ -1027,6 +1030,10 @@ class MCPReadResourceTool(BaseTool):
             logger.warning(f"MCPReadResourceTool SSRF 拦截: uri={uri}, reason={reason}")
             return {"name": self.name, "content": f"❌ 资源 URI 被拦截: {reason}"}
         
+        # NOTE: If the underlying MCP HTTP transport follows 3xx redirects,
+        # the redirected target is NOT re-validated here.  A future improvement
+        # should either disable automatic redirects in the MCP HTTP client or
+        # hook into the redirect chain to re-run _is_uri_safe on each hop.
         result = await mcp_manager.read_resource(uri, server_name)
         
         if result.success:

--- a/plugins/MaiBot_MCPBridgePlugin/plugin.py
+++ b/plugins/MaiBot_MCPBridgePlugin/plugin.py
@@ -868,7 +868,7 @@ def _sanitize_tool_description(description: str, max_length: int = 1024) -> str:
     sanitized = re.sub(r"(#{4,})", "####", sanitized)
     # 截断到合理长度
     if len(sanitized) > max_length:
-        sanitized = sanitized[:max_length] + "..."
+        sanitized = sanitized[:max_length - 3] + "..."
     return sanitized
 
 
@@ -984,8 +984,11 @@ class MCPReadResourceTool(BaseTool):
     # 允许的 URI scheme 白名单（排除 file:// 等危险协议）
     _ALLOWED_SCHEMES = {"http", "https"}
     @classmethod
-    def _is_uri_safe(cls, uri: str) -> Tuple[bool, str]:
-        """检查 URI 是否安全（防止 SSRF）。返回 (is_safe, reason)。"""
+    async def _is_uri_safe(cls, uri: str) -> Tuple[bool, str]:
+        """检查 URI 是否安全（防止 SSRF）。返回 (is_safe, reason)。
+
+        DNS 解析通过 loop.getaddrinfo 异步执行，避免阻塞事件循环。
+        """
         try:
             parsed = urlparse(uri)
         except Exception:
@@ -999,13 +1002,14 @@ class MCPReadResourceTool(BaseTool):
             return False, "不允许使用 file:// 协议"
 
         # 对 http/https 做主机解析检查
-        if scheme in ("http", "https"):
+        if scheme in cls._ALLOWED_SCHEMES:
             hostname = parsed.hostname or ""
             if not hostname:
                 return False, "缺少主机名"
-            # DNS 解析并检查是否为内网地址
+            # 异步 DNS 解析并检查是否为内网地址
             try:
-                addrinfos = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+                loop = asyncio.get_event_loop()
+                addrinfos = await loop.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
                 for _family, _type, _proto, _canonname, sockaddr in addrinfos:
                     ip = ipaddress.ip_address(sockaddr[0])
                     if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
@@ -1025,7 +1029,7 @@ class MCPReadResourceTool(BaseTool):
             return {"name": self.name, "content": "❌ 请提供资源 URI"}
 
         # SSRF 防护：校验 URI 安全性
-        is_safe, reason = self._is_uri_safe(uri)
+        is_safe, reason = await self._is_uri_safe(uri)
         if not is_safe:
             logger.warning(f"MCPReadResourceTool SSRF 拦截: uri={uri}, reason={reason}")
             return {"name": self.name, "content": f"❌ 资源 URI 被拦截: {reason}"}


### PR DESCRIPTION
## Summary

This PR addresses three security concerns in the MCP Bridge Plugin (`plugins/MaiBot_MCPBridgePlugin/plugin.py`). All changes are minimal and follow the existing code style.

---

### 1. SSRF via `MCPReadResourceTool` (CWE-918, Medium)

**Problem:** The `mcp_read_resource` tool passes user-controlled URIs directly to `mcp_manager.read_resource()` without validation. An attacker who can influence LLM tool arguments (through crafted chat messages) could target internal services, cloud metadata endpoints (`169.254.169.254`), or local files (`file:///etc/passwd`).

**Fix:** Added `_is_uri_safe()` class method that:
- Blocks `file://` URIs outright
- For `http`/`https` URIs, resolves the hostname via DNS and rejects targets pointing to private, loopback, link-local, or reserved addresses
- Allows custom MCP-specific URI schemes (e.g. `mydb://...`) to pass through to the MCP server as intended

### 2. Prompt injection via MCP tool names & descriptions (CWE-94, Medium)

**Problem:** `create_mcp_tool_class()` uses MCP-server-controlled `name` and `description` values to dynamically create tool classes via `type()`. A malicious or compromised MCP server could inject crafted names containing special characters or descriptions containing prompt injection payloads that get presented to the LLM.

**Fix:** Added two sanitization helpers:
- `_sanitize_tool_name()` — strips all characters except `[a-zA-Z0-9_]`, collapses consecutive underscores, limits to 128 chars
- `_sanitize_tool_description()` — removes `<|...|>` control tokens (common prompt injection vector), normalizes excessive markdown headings, truncates to 1024 chars

### 3. Sensitive data in trace logs (CWE-532, Low)

**Problem:** When `trace_log_enabled` is true, `_write_to_log()` writes full tool call arguments (which may contain API keys, tokens, or passwords passed as tool parameters) as plaintext JSON to a predictable log file path.

**Fix:** Added `_redact_sensitive()` class method that masks values for dictionary keys matching common sensitive patterns (`token`, `key`, `secret`, `password`, `auth`, `credential`, `api_key`, `access_key`, `private`). Applied to the `arguments` field before writing to the log file. Recursively handles nested dicts.

---

### Testing

- All three fixes are syntax-verified (`ast.parse`)
- Functional unit tests confirm:
  - Name sanitization strips special chars, handles empty strings and long inputs
  - Description sanitization removes control tokens and truncates
  - `file://` URIs are blocked; `http://127.0.0.1`, `http://169.254.169.254`, `http://192.168.x.x` are blocked; custom MCP URIs pass through
  - Sensitive keys are redacted while normal keys are preserved
- No changes outside the plugin file; no new dependencies (uses only stdlib `socket`, `ipaddress`, `urllib.parse`)

---

*Found during a routine security review. Happy to adjust the approach if you have preferences on any of these patterns.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **安全改进**
  * 日志写入时对敏感字段进行递归脱敏（如令牌、密钥、密码等），以防泄露。
  * 动态生成的工具名称和描述进行了规范化与清洗，防止注入性内容并限制长度。
  * 访问外部资源时增加 URI 安全校验（方案白名单、DNS/IP 检查），拦截不安全或内部网络地址的请求。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->