### PR TITLE
fix: 修复 WebUI 表情包管理页列表加载

### DIFF
--- a/pytests/webui/test_emoji_routes.py
+++ b/pytests/webui/test_emoji_routes.py
@@ -58,7 +58,7 @@ def test_app(test_session):
             test_session.rollback()
             raise
 
-    with patch("src.webui.routers.emoji.get_db_session", override_get_db_session):
+    with patch("src.webui.routers.emoji.routes.get_db_session", override_get_db_session):
         yield app
 
 
@@ -135,7 +135,7 @@ def sample_emojis(test_session) -> list[Images]:
 @pytest.fixture(scope="function")
 def mock_token_verify():
     """Mock token verification to always succeed"""
-    with patch("src.webui.routers.emoji.verify_auth_token", return_value=True):
+    with patch("src.webui.routers.emoji.routes.verify_auth_token", return_value=True):
         yield
 
 
@@ -159,8 +159,10 @@ def test_list_emojis_basic(client, sample_emojis, mock_token_verify):
     emoji = data["data"][0]
     assert "id" in emoji
     assert "full_path" in emoji
+    assert "format" in emoji
     assert "emoji_hash" in emoji
     assert "description" in emoji
+    assert "usage_count" in emoji
     assert "query_count" in emoji
     assert "is_registered" in emoji
     assert "is_banned" in emoji
@@ -168,6 +170,35 @@ def test_list_emojis_basic(client, sample_emojis, mock_token_verify):
     assert "record_time" in emoji
     assert "register_time" in emoji
     assert "last_used_time" in emoji
+    assert emoji["format"] == "webp"
+    assert emoji["usage_count"] == 20
+
+
+def test_list_emojis_with_closed_session_still_returns_data(test_engine, sample_emojis, mock_token_verify):
+    app = FastAPI()
+    app.include_router(router)
+
+    @contextmanager
+    def override_get_db_session(auto_commit=True):
+        with Session(test_engine) as session:
+            try:
+                yield session
+                if auto_commit:
+                    session.commit()
+            except Exception:
+                session.rollback()
+                raise
+
+    with patch("src.webui.routers.emoji.routes.get_db_session", override_get_db_session):
+        client = TestClient(app)
+        response = client.get("/emoji/list?page=1&page_size=10")
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["success"] is True
+    assert data["total"] == 3
+    assert len(data["data"]) == 3
 
 
 def test_list_emojis_pagination(client, sample_emojis, mock_token_verify):
@@ -386,7 +417,7 @@ def test_batch_delete_empty_list(client, mock_token_verify):
 def test_auth_required_list(client):
     """测试未认证访问列表端点（401）"""
     # Without mock_token_verify fixture
-    with patch("src.webui.routers.emoji.verify_auth_token", return_value=False):
+    with patch("src.webui.routers.emoji.routes.verify_auth_token", return_value=False):
         client.get("/emoji/list")
         # verify_auth_token 返回 False 会触发 HTTPException
         # 但具体状态码取决于 verify_auth_token_from_cookie_or_header 的实现
@@ -395,7 +426,7 @@ def test_auth_required_list(client):
 
 def test_auth_required_update(client, sample_emojis):
     """测试未认证访问更新端点（401）"""
-    with patch("src.webui.routers.emoji.verify_auth_token", return_value=False):
+    with patch("src.webui.routers.emoji.routes.verify_auth_token", return_value=False):
         emoji_id = sample_emojis[0].id
         client.patch(f"/emoji/{emoji_id}", json={"description": "test"})
         # Should be unauthorized
@@ -403,7 +434,7 @@ def test_auth_required_update(client, sample_emojis):
 
 def test_emoji_to_response_field_mapping(sample_emojis):
     """测试 emoji_to_response 字段映射（image_hash -> emoji_hash）"""
-    from src.webui.routers.emoji import emoji_to_response
+    from src.webui.routers.emoji.schemas import emoji_to_response
 
     emoji = sample_emojis[0]
     response = emoji_to_response(emoji)
@@ -411,6 +442,8 @@ def test_emoji_to_response_field_mapping(sample_emojis):
     # 验证 API 字段名称
     assert hasattr(response, "emoji_hash")
     assert response.emoji_hash == emoji.image_hash
+    assert response.format == "png"
+    assert response.usage_count == emoji.query_count
 
     # 验证时间戳转换
     assert isinstance(response.record_time, float)

--- a/src/webui/routers/emoji/routes.py
+++ b/src/webui/routers/emoji/routes.py
@@ -98,6 +98,7 @@ async def get_emoji_list(
 
         with get_db_session() as session:
             emojis = session.exec(statement).all()
+            emoji_responses = [emoji_to_response(emoji) for emoji in emojis]
 
             count_statement = select(func.count()).select_from(Images).where(col(Images.image_type) == ImageType.EMOJI)
             if search:
@@ -115,7 +116,7 @@ async def get_emoji_list(
             total=total,
             page=page,
             page_size=page_size,
-            data=[emoji_to_response(emoji) for emoji in emojis],
+            data=emoji_responses,
         )
     except HTTPException:
         raise

--- a/src/webui/routers/emoji/schemas.py
+++ b/src/webui/routers/emoji/schemas.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Annotated, List, Optional
 
 from fastapi import File, Form, UploadFile
@@ -17,8 +18,10 @@ class EmojiResponse(BaseModel):
 
     id: int
     full_path: str
+    format: str
     emoji_hash: str
     description: str
+    usage_count: int
     query_count: int
     is_registered: bool
     is_banned: bool
@@ -128,8 +131,10 @@ def emoji_to_response(image: Images) -> EmojiResponse:
     return EmojiResponse(
         id=image.id if image.id is not None else 0,
         full_path=image.full_path,
+        format=Path(image.full_path).suffix.lower().lstrip(".") or "unknown",
         emoji_hash=image.image_hash,
         description=image.description,
+        usage_count=image.query_count,
         query_count=image.query_count,
         is_registered=image.is_registered,
         is_banned=image.is_banned,


### PR DESCRIPTION
  1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
  2. - [x] 我确认我阅读了贡献指南
  3. - [x] 本次更新类型为：BUG修复
     - [ ] 本次更新类型为：功能新增
  4. - [x] 本次更新是否经过测试
  5. 请填写破坏性更新的具体内容（如有）:
  无

  6. 请简要说明本次更新的内容和目的：
  修复 `r-dev` 分支 WebUI 表情包管理页面无法正常加载的问题。

  当前问题主要有两处：
  - 表情包列表接口 `/emoji/list` 在数据库 session 结束后才执行响应对象转换，导致 ORM 对象脱离 session 后再序列化，可能触发后端 `InternalServerError`
  - WebUI 前端表情包管理页依赖后端返回的 `format` 和 `usage_count` 字段，但当前接口响应中未提供这两个字段，进入 `/
  resource/emoji` 时会出现前端渲染错误，例如 `Cannot read properties of undefined (reading 'toUpperCase')`

  这会导致：
  - WebUI 点击“表情包管理”后页面加载失败
  - 后端表情包列表接口可能返回 500
  - 前端因字段缺失无法正确渲染表情包列表

  本次修复内容包括：
  - 在 `/emoji/list` 路由中，将 `emoji_to_response(...)` 的转换提前到数据库 session 生命周期内完成，避免 session 关闭后
  再访问 ORM 对象
  - 为 `EmojiResponse` 增加 `format` 字段，使用图片路径后缀推导表情包格式
  - 为 `EmojiResponse` 增加 `usage_count` 字段，并与现有 `query_count` 保持一致
  - 补充对应回归测试，覆盖列表接口在独立 session 生命周期下的响应序列化，以及 `format`、`usage_count` 字段返回行为

  本次改动的目标是：
  - 修复 WebUI 表情包管理页面无法打开的问题
  - 保证表情包列表接口在正常请求生命周期下稳定返回
  - 让后端返回字段与前端现有渲染逻辑保持一致
  - 以最小改动修复页面加载问题，不涉及表情包识图、注册、描述生成等逻辑

  验证情况：
  - 已在本地运行测试：
    - `uv run --python 3.11 pytest pytests/webui/test_emoji_routes.py -q`
  - 测试结果：
    - `22 passed`

  # 其他信息
  - **关联 Issue**：
  - **截图/GIF**：
  - **附加信息**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发行说明

* **新功能**
  * 表情符号列表API响应现在包含每个表情的文件格式信息
  * 表情符号列表API响应现在包含每个表情的使用次数统计数据

* **性能改进**
  * 优化了表情列表的加载和处理效率

* **测试**
  * 增强了表情符号API路由的测试覆盖范围
  * 添加了会话处理场景的验证测试

<!-- end of auto-generated comment: release notes by coderabbit.ai -->