### PR TITLE
fix：修复图片与表情占位文本未被正确刷新导致视觉描述丢失

### DIFF
--- a/src/chat/message_receive/message.py
+++ b/src/chat/message_receive/message.py
@@ -26,6 +26,30 @@ install(extra_lines=3)
 logger = get_logger("chat_message")
 
 
+_UNRESOLVED_IMAGE_PLACEHOLDERS = {"[image]", "[图片]"}
+_UNRESOLVED_EMOJI_PLACEHOLDERS = {"[emoji]", "[表情包]"}
+
+
+def _normalize_placeholder_text(content: str | None) -> str:
+    """归一化消息组件中的占位文本，便于判断是否仍需补全。"""
+
+    return (content or "").strip().lower()
+
+
+def _is_unresolved_image_placeholder(content: str | None) -> bool:
+    """判断图片组件内容是否仍是适配器注入的占位文本。"""
+
+    normalized = _normalize_placeholder_text(content)
+    return not normalized or normalized in _UNRESOLVED_IMAGE_PLACEHOLDERS
+
+
+def _is_unresolved_emoji_placeholder(content: str | None) -> bool:
+    """判断表情组件内容是否仍是适配器注入的占位文本。"""
+
+    normalized = _normalize_placeholder_text(content)
+    return not normalized or normalized in _UNRESOLVED_EMOJI_PLACEHOLDERS
+
+
 class MsgIDMapping:
     """回复消息内容缓存。"""
 
@@ -230,7 +254,7 @@ class SessionMessage(MaiMessage):
         Returns:
             str: 图片组件对应的文本表示。
         """
-        if component.content:  # 先检查是否处理过
+        if component.content and not _is_unresolved_image_placeholder(component.content):
             return component.content
         from src.chat.image_system.image_manager import image_manager
 
@@ -263,7 +287,7 @@ class SessionMessage(MaiMessage):
         Returns:
             str: 表情包组件对应的文本表示。
         """
-        if component.content:  # 先检查是否处理过
+        if component.content and not _is_unresolved_emoji_placeholder(component.content):
             return component.content
         from src.emoji_system.emoji_manager import emoji_manager
 

--- a/src/maisaka/chat_history_visual_refresher.py
+++ b/src/maisaka/chat_history_visual_refresher.py
@@ -14,6 +14,10 @@ from .context_messages import LLMContextMessage, SessionBackedMessage
 
 logger = get_logger("maisaka_chat_history_visual_refresher")
 
+
+_UNRESOLVED_IMAGE_PLACEHOLDERS = {"", "[image]", "[图片]"}
+_UNRESOLVED_EMOJI_PLACEHOLDERS = {"", "[emoji]", "[表情包]"}
+
 BuildHistoryMessage = Callable[[SessionMessage, str], Awaitable[Optional[LLMContextMessage]]]
 BuildVisibleText = Callable[[SessionMessage], str]
 
@@ -90,13 +94,13 @@ def _refresh_pending_visual_components(components: list[object]) -> bool:
 def _should_refresh_image_component(component: ImageComponent) -> bool:
     """判断图片组件当前是否仍处于待补全文本的占位状态。"""
 
-    return not component.content or component.content == "[图片]"
+    return (component.content or "").strip().lower() in _UNRESOLVED_IMAGE_PLACEHOLDERS
 
 
 def _should_refresh_emoji_component(component: EmojiComponent) -> bool:
     """判断表情组件当前是否仍处于待补全文本的占位状态。"""
 
-    return not component.content or component.content == "[表情包]"
+    return (component.content or "").strip().lower() in _UNRESOLVED_EMOJI_PLACEHOLDERS
 
 
 def _lookup_cached_image_description(image_hash: str) -> str:


### PR DESCRIPTION
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支`
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
无

6. 请简要说明本次更新的内容和目的：
修复图片和表情消息中的占位文本识别问题。

此前适配器可能注入 `[image]`、`[emoji]` 这类英文占位文本，但消息处理与历史刷新逻辑只完整覆盖了中文占位文本，导致图片/表情在描述已生成后仍可能被误判为“已有内容”或“不需要刷新”，进而让规划器和回复器拿不到真实视觉描述。

本次修改：
- 在消息处理阶段统一识别中英文图片/表情占位文本，避免把占位内容当作真实内容直接返回
- 在聊天历史视觉刷新阶段补充对 `[image]`、`[emoji]` 的识别，并继续兼容 `[图片]`、`[表情包]`
- 将空字符串同样视为待刷新的未解析状态

这样可以让图片描述生成后的刷新链路正确接上，减少“实际上已经识别成功，但当前轮仍回答看不到图”的问题。

# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**: 已对相关 Python 文件完成语法校验

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了图片和emoji组件的占位符检测机制，现支持多种占位符格式识别，确保未解析的占位符内容能被正确处理和刷新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->