### PR TITLE
fix:A_Memorix 缺失总结模型配置导致导入异常

### DIFF
--- a/pytests/A_memorix_test/test_summary_importer_model_config.py
+++ b/pytests/A_memorix_test/test_summary_importer_model_config.py
@@ -1,0 +1,48 @@
+import pytest
+
+from src.A_memorix.core.utils.summary_importer import SummaryImporter
+from src.config.model_configs import TaskConfig
+from src.services import llm_service as llm_api
+
+
+def _fake_available_models() -> dict[str, TaskConfig]:
+    return {
+        "replyer": TaskConfig(
+            model_list=["test-model"],
+            max_tokens=128,
+            temperature=0.7,
+            selection_strategy="priority",
+        )
+    }
+
+
+def test_resolve_summary_model_config_uses_auto_list_when_summarization_missing(monkeypatch):
+    monkeypatch.setattr(llm_api, "get_available_models", _fake_available_models)
+
+    importer = SummaryImporter(
+        vector_store=None,
+        graph_store=None,
+        metadata_store=None,
+        embedding_manager=None,
+        plugin_config={},
+    )
+
+    resolved = importer._resolve_summary_model_config()
+
+    assert resolved is not None
+    assert resolved.model_list == ["test-model"]
+
+
+def test_resolve_summary_model_config_rejects_legacy_string_selector(monkeypatch):
+    monkeypatch.setattr(llm_api, "get_available_models", _fake_available_models)
+
+    importer = SummaryImporter(
+        vector_store=None,
+        graph_store=None,
+        metadata_store=None,
+        embedding_manager=None,
+        plugin_config={"summarization": {"model_name": "auto"}},
+    )
+
+    with pytest.raises(ValueError, match="List\\[str\\]"):
+        importer._resolve_summary_model_config()

--- a/src/A_memorix/core/utils/summary_importer.py
+++ b/src/A_memorix/core/utils/summary_importer.py
@@ -136,7 +136,9 @@ class SummaryImporter:
         if not available_tasks:
             return None
 
-        raw_cfg = self.plugin_config.get("summarization", {}).get("model_name", "auto")
+        # vNext 要求该字段为 List[str]；当配置缺失时回退到 ["auto"]，
+        # 避免默认值本身触发类型校验异常。
+        raw_cfg = self.plugin_config.get("summarization", {}).get("model_name", ["auto"])
         selectors = self._normalize_summary_model_selectors(raw_cfg)
         default_task_name, default_task_cfg = self._pick_default_summary_task(available_tasks)
 

--- a/src/A_memorix/scripts/release_vnext_migrate.py
+++ b/src/A_memorix/scripts/release_vnext_migrate.py
@@ -472,7 +472,11 @@ def _migrate_config(config_doc: Dict[str, Any]) -> Dict[str, Any]:
 
     summary = _ensure_table(config_doc, "summarization")
     summary_model = summary.get("model_name", ["auto"])
-    if isinstance(summary_model, str):
+    if "model_name" not in summary:
+        normalized = ["auto"]
+        summary["model_name"] = normalized
+        changes["summarization.model_name"] = {"old": "<missing>", "new": normalized}
+    elif isinstance(summary_model, str):
         normalized = [summary_model.strip() or "auto"]
         summary["model_name"] = normalized
         changes["summarization.model_name"] = {"old": summary_model, "new": normalized}


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. 请填写破坏性更新的具体内容（如有）:
6. 请简要说明本次更新的内容和目的：修复默认值与迁移补写逻辑，并补充回归测试覆盖缺失与旧格式场景
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 变更概览

* **错误修复**
  * 改进了总结模型配置的默认值处理，优化了配置类型的一致性。
  * 增强了迁移脚本处理缺失配置项的能力。

* **测试**
  * 新增单元测试，验证模型配置解析的正确性和容错能力。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->