### PR TITLE
fix: 支持 HTTP 协议和内网地址访问，修复聊天 URL 缺协议前缀问题

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "faiss-cpu>=1.11.0",
     "fastapi>=0.116.0",
     "google-genai>=1.39.1",
-    "httpx",
+    "httpx[socks]",
     "jieba>=0.42.1",
     "json-repair>=0.47.6",
     "maim-message>=0.6.2",

--- a/src/llm_models/openai_compat.py
+++ b/src/llm_models/openai_compat.py
@@ -26,12 +26,17 @@ class OpenAICompatibleRequestOverrides:
 def normalize_openai_base_url(base_url: str) -> str:
     """规范化 OpenAI 兼容接口的基础地址。
 
+    去掉尾部斜杠，且如果缺少协议前缀则自动补全 http://。
+
     Args:
         base_url: 原始基础地址。
 
     Returns:
-        str: 去掉尾部斜杠后的地址。
+        str: 规范化后的地址。
     """
+    base_url = base_url.strip()
+    if base_url and "://" not in base_url:
+        base_url = "http://" + base_url
     return base_url.rstrip("/")
 
 

--- a/src/webui/utils/network_security.py
+++ b/src/webui/utils/network_security.py
@@ -31,19 +31,19 @@ def _is_forbidden_ip_address(address: ipaddress.IPv4Address | ipaddress.IPv6Addr
             address.is_loopback,
             address.is_link_local,
             address.is_multicast,
-            address.is_private,
             address.is_reserved,
             address.is_unspecified,
-            getattr(address, "is_site_local", False),
         )
     )
 
 
-def validate_public_url(url: str, allowed_schemes: Iterable[str] = ("https",)) -> str:
+def validate_public_url(url: str, allowed_schemes: Iterable[str] = ("http", "https")) -> str:
     normalized_url = url.strip()
     if not normalized_url:
         raise ValueError("URL 不能为空")
 
+    if "://" not in normalized_url:
+        normalized_url = "http://" + normalized_url
     parsed = urlparse(normalized_url)
     allowed_scheme_set = {scheme.lower() for scheme in allowed_schemes}
     if parsed.scheme.lower() not in allowed_scheme_set:


### PR DESCRIPTION
## 修复内容

本次修复解决了以下四个问题：

1. **连通性测试（AI 供应商配置）仅支持 HTTPS 协议**  
   - 将 `validate_public_url` 的默认允许协议从 `("https",)` 改为 `("http", "https")`，允许用户配置 HTTP 的内网 API 服务。

2. **连通性测试无法解析无协议前缀的 URL**  
   - 在 `validate_public_url` 中增加自动补全逻辑：如果 URL 不含 `://`，自动在前面添加 `http://`。

3. **禁止访问非公网地址（内网 IP 被拦截）**  
   - 从 `_is_forbidden_ip_address` 中移除 `is_private` 和 `is_site_local` 检查，仅保留 loopback、link-local、multicast、reserved、unspecified 等安全拦截，允许访问内网地址。

4. **网页端聊天时报错 `Request URL is missing protocol`**  
   - 修复 `normalize_openai_base_url`，使其在缺少协议前缀时自动补全 `http://`，确保 LLM 客户端能正确解析用户配置的 base_url。

## 改动文件

- `src/webui/utils/network_security.py` — 协议白名单扩展、内网 IP 检查放宽、无协议 URL 自动补全
- `src/llm_models/openai_compat.py` — `normalize_openai_base_url` 增加协议自动补全
- `pyproject.toml` — 添加 `httpx[socks]` 依赖以支持 SOCKS 代理

## 检查清单

- [x] 提交到 `dev` 分支（非 `main`）
- [x] 已阅读贡献指南
- [x] 本次更新类型为：BUG修复
- [x] 已通过本地测试
- [x] 不涉及 `src/A_memorix` 修改

---

关联 Issue：无

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了SOCKS代理支持

* **改进**
  * 增强OpenAI兼容URL规范化处理，自动补全协议和移除多余空格
  * 改进URL验证逻辑，现已支持HTTP和HTTPS协议，自动补全缺失的协议前缀

<!-- end of auto-generated comment: release notes by coderabbit.ai -->