### PR TITLE
fix: 默认关闭 A_Memorix 运行时

### DIFF
--- a/src/A_memorix/config_schema.json
+++ b/src/A_memorix/config_schema.json
@@ -74,7 +74,7 @@
         "enabled": {
           "name": "enabled",
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "是否启用 A_Memorix",
           "label": "启用 A_Memorix",
           "ui_type": "switch",
@@ -82,7 +82,7 @@
           "hidden": false,
           "disabled": false,
           "order": 1,
-          "hint": "关闭后 A_Memorix 不会参与长期记忆写入、检索与运维。",
+          "hint": "默认关闭以简化首次配置；开启前请先配置可用的 embedding 模型。关闭后 A_Memorix 不会参与长期记忆写入、检索与运维。",
           "choices": null
         }
       }

--- a/src/A_memorix/host_service.py
+++ b/src/A_memorix/host_service.py
@@ -48,6 +48,9 @@ class AMemorixHostService:
         self._config_cache: Dict[str, Any] | None = None
 
     async def start(self) -> None:
+        if not self.is_enabled():
+            logger.info("A_Memorix 未启用，跳过长期记忆运行时初始化")
+            return
         await self._ensure_kernel()
 
     async def stop(self) -> None:
@@ -57,9 +60,13 @@ class AMemorixHostService:
     async def reload(self) -> None:
         async with self._lock:
             await self._shutdown_locked()
-            self._config_cache = self._read_config()
+            self._config_cache = None
+            config = self._read_config()
 
-        await self._ensure_kernel()
+        if self._is_enabled_config(config):
+            await self._ensure_kernel()
+        else:
+            logger.info("A_Memorix 配置为未启用，运行时保持关闭")
 
     def get_config_path(self) -> Path:
         return config_path()
@@ -87,6 +94,16 @@ class AMemorixHostService:
 
     def get_config(self) -> Dict[str, Any]:
         return dict(self._read_config())
+
+    def is_enabled(self) -> bool:
+        return self._is_enabled_config(self._read_config())
+
+    @staticmethod
+    def _is_enabled_config(config: Dict[str, Any]) -> bool:
+        plugin_config = config.get("plugin") if isinstance(config, dict) else None
+        if not isinstance(plugin_config, dict):
+            return True
+        return bool(plugin_config.get("enabled", True))
 
     def _build_default_config(self) -> Dict[str, Any]:
         schema = self.get_config_schema()
@@ -172,6 +189,8 @@ class AMemorixHostService:
     async def invoke(self, component_name: str, args: Dict[str, Any] | None = None, *, timeout_ms: int = 30000) -> Any:
         del timeout_ms
         payload = args or {}
+        if not self.is_enabled():
+            return self._disabled_response(component_name)
         kernel = await self._ensure_kernel()
 
         if component_name == "search_memory":
@@ -279,6 +298,8 @@ class AMemorixHostService:
         async with self._lock:
             if self._kernel is None:
                 config = self._read_config()
+                if not self._is_enabled_config(config):
+                    raise RuntimeError("A_Memorix 未启用")
                 kernel = SDKMemoryKernel(plugin_root=repo_root(), config=config)
                 try:
                     await kernel.initialize()
@@ -310,6 +331,83 @@ class AMemorixHostService:
 
         self._config_cache = _to_builtin_data(loaded) if isinstance(loaded, dict) else {}
         return dict(self._config_cache)
+
+    @staticmethod
+    def _disabled_response(component_name: str) -> Dict[str, Any]:
+        reason = "a_memorix_disabled"
+        message = "A_Memorix 未启用，请在长期记忆配置中开启后再使用。"
+
+        if component_name == "search_memory":
+            return {
+                "success": True,
+                "disabled": True,
+                "reason": reason,
+                "summary": "",
+                "hits": [],
+                "filtered": False,
+            }
+
+        if component_name in {"ingest_summary", "ingest_text"}:
+            return {
+                "success": True,
+                "disabled": True,
+                "reason": reason,
+                "stored_ids": [],
+                "skipped_ids": [reason],
+                "detail": reason,
+            }
+
+        if component_name == "get_person_profile":
+            return {
+                "success": True,
+                "disabled": True,
+                "reason": reason,
+                "summary": "",
+                "traits": [],
+                "evidence": [],
+            }
+
+        if component_name == "memory_stats":
+            return {
+                "success": True,
+                "enabled": False,
+                "disabled": True,
+                "reason": reason,
+                "message": message,
+                "paragraph_count": 0,
+                "relation_count": 0,
+                "episode_count": 0,
+            }
+
+        if component_name == "memory_runtime_admin":
+            return {
+                "success": True,
+                "enabled": False,
+                "disabled": True,
+                "reason": reason,
+                "message": message,
+                "runtime_ready": False,
+                "embedding_degraded": False,
+                "embedding_dimension": 0,
+                "auto_save": False,
+                "data_dir": "",
+            }
+
+        if component_name == "enqueue_feedback_task":
+            return {
+                "success": True,
+                "queued": False,
+                "disabled": True,
+                "reason": reason,
+            }
+
+        return {
+            "success": False,
+            "enabled": False,
+            "disabled": True,
+            "reason": reason,
+            "error": message,
+        }
 
     async def _shutdown_locked(self) -> None:
         if self._kernel is None:


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [x] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:默认关闭记忆系统
7. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **配置变更**
  * A_Memorix 插件默认设置已更改为禁用状态

* **改进**
  * 优化了插件禁用时的处理流程，当插件处于禁用状态时系统将跳过内核初始化，提高应用效率

<!-- end of auto-generated comment: release notes by coderabbit.ai -->