### PR TITLE
fix:更正默认值，避免意料之外的内存占用

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import os
+
+
+_NATIVE_THREAD_ENV_DEFAULTS = {
+    "OMP_NUM_THREADS": "1",
+    "OPENBLAS_NUM_THREADS": "1",
+    "MKL_NUM_THREADS": "1",
+    "NUMEXPR_NUM_THREADS": "1",
+}
+
+for _name, _value in _NATIVE_THREAD_ENV_DEFAULTS.items():
+    os.environ.setdefault(_name, _value)


### PR DESCRIPTION
用 os.environ.setdefault 将原生库线程数（OMP_NUM_THREADS、OPENBLAS_NUM_THREADS、MKL_NUM_THREADS、NUMEXPR_NUM_THREADS）的默认值设置为 "1"。这样可以确保导入的代码默认不会过度占用 CPU 线程（以及巨量内存）

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:
7. 请简要说明本次更新的内容和目的：详见commit
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 优化了系统线程管理相关的默认环境变量配置，以改进应用性能和资源利用效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->