### PR TITLE
fix: webui表达方式审核状态持久化到数据库

### DIFF
--- a/src/learners/expression_auto_check_task.py
+++ b/src/learners/expression_auto_check_task.py
@@ -17,9 +17,9 @@ from sqlmodel import select
 
 from src.common.database.database import get_db_session
 from src.common.database.database_model import Expression
+from src.common.database.database_model import ModifiedBy
 from src.common.logger import get_logger
 from src.config.config import global_config
-from src.learners.expression_review_store import get_review_state, set_review_state
 from src.learners.expression_utils import check_expression_suitability
 from src.manager.async_task_manager import AsyncTask
 
@@ -53,7 +53,7 @@ class ExpressionAutoCheckTask(AsyncTask):
                 statement = select(Expression)
                 all_expressions = session.exec(statement).all()
 
-            unevaluated_expressions = [expr for expr in all_expressions if not get_review_state(expr.id)["checked"]]
+            unevaluated_expressions = [expr for expr in all_expressions if not expr.checked]
 
             if not unevaluated_expressions:
                 logger.info("没有未检查的表达方式")
@@ -62,9 +62,7 @@ class ExpressionAutoCheckTask(AsyncTask):
             selected_count = min(count, len(unevaluated_expressions))
             selected = random.sample(unevaluated_expressions, selected_count)
 
-            logger.info(
-                f"从 {len(unevaluated_expressions)} 条未检查表达方式中随机选择了 {selected_count} 条"
-            )
+            logger.info(f"从 {len(unevaluated_expressions)} 条未检查表达方式中随机选择了 {selected_count} 条")
             return selected
 
         except Exception as e:
@@ -86,8 +84,17 @@ class ExpressionAutoCheckTask(AsyncTask):
             expression.style,
         )
 
+        if error:
+            logger.warning(f"表达方式评估时出现错误 [ID: {expression.id}]: {error}")
+            return False
         try:
-            set_review_state(expression.id, True, not suitable, "ai")
+            with get_db_session() as session:
+                expr = session.exec(select(Expression).where(Expression.id == expression.id)).first()
+                if expr:
+                    expr.checked = True
+                    expr.rejected = not suitable
+                    expr.modified_by = ModifiedBy.AI
+                    session.add(expr)
 
             status = "通过" if suitable else "不通过"
             # 保留这段注释，方便后续需要时恢复更详细的审核日志。
@@ -97,9 +104,6 @@ class ExpressionAutoCheckTask(AsyncTask):
             #     f"Style: {expression.style}... | "
             #     f"Reason: {reason[:50]}..."
             # )
-
-            if error:
-                logger.warning(f"表达方式评估时出现错误 [ID: {expression.id}]: {error}")
 
             logger.debug(f"表达方式 [ID: {expression.id}] 评估完成: {status}, reason={reason}")
             return suitable

--- a/src/webui/routers/expression.py
+++ b/src/webui/routers/expression.py
@@ -108,9 +108,9 @@ def expression_to_response(expression: Expression) -> ExpressionResponse:
         last_active_time=last_active_time,
         chat_id=expression.session_id or "",
         create_date=create_date,
-        checked=False,
-        rejected=False,
-        modified_by=None,
+        checked=expression.checked,
+        rejected=expression.rejected,
+        modified_by=expression.modified_by.value if expression.modified_by else None,
     )
 
 


### PR DESCRIPTION
## 问题
表达方式自动审核（LLM 评估）结果未持久化，WebUI 始终显示"未审核"。

## 根因
- `expression_to_response` 将 `checked`、`rejected`、`modified_by` 硬编码为 `False`/`None`
- 自动审核任务 `_evaluate_expression` 仅写入内存缓存 (`local_storage`)，未写数据库
- 筛选未检查表达方式时也读内存缓存而非数据库字段

## 修改
- **`src/webui/routers/expression.py`**: `expression_to_response` 直接读取 `expression.checked`、`expression.rejected`、`expression.modified_by` 数据库字段
- **`src/learners/expression_auto_check_task.py`**:
  - 评估结果写入数据库字段 (`checked`, `rejected`, `modified_by`)
  - 筛选未检查表达方式改用 `expr.checked` 数据库字段
  - 移除已不再需要的 `expression_review_store` 导入

## 测试
语法检查通过，无新增函数/方法，本地已测试修复。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

**Bug Fixes**
- 修复了表达式评估的筛选与持久化流程：未评估项现在能被正确识别并在评估时持久化为“已检查”或“已拒绝”状态，异常情况下会记录警告并中止写入。
- 修复了界面显示问题：表达式的“已检查”“已拒绝”状态及最后修改者信息现在准确展示，不再显示固定默认值或空白。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->