### PR TITLE
fix: send_emoji 表情包子代理改用组件模型 (utils) 而非 planner/vlm

### DIFF
--- a/src/maisaka/builtin_tool/send_emoji.py
+++ b/src/maisaka/builtin_tool/send_emoji.py
@@ -281,21 +281,8 @@ def _build_send_emoji_monitor_metadata(
 
 
 def _resolve_emoji_selector_model_task_name() -> str:
-    """根据 planner 模型视觉能力选择表情选择子代理的模型任务。"""
-
-    model_config = config_manager.get_model_config()
-    planner_models = [
-        model_name
-        for model_name in model_config.model_task_config.planner.model_list
-        if str(model_name).strip()
-    ]
-    models_by_name = {model.name: model for model in model_config.models}
-    if planner_models and all(
-        model_name in models_by_name and models_by_name[model_name].visual
-        for model_name in planner_models
-    ):
-        return "planner"
-    return "vlm"
+    """返回表情选择子代理的模型任务名，始终使用组件模型（utils）。"""
+    return "utils"
 
 
 async def _select_emoji_with_sub_agent(


### PR DESCRIPTION
## 修复内容

修复 `send_emoji` 工具在选择表情包时错误调用 `planner` 或 `vlm` 模型的问题，现统一改用组件模型 (`utils`)。

### 具体修改

**文件:** `src/maisaka/builtin_tool/send_emoji.py`

- 修改函数 `_resolve_emoji_selector_model_task_name()` (第 283 行)
- **旧行为:** 读取 `planner` 模型列表，若所有 planner 模型都支持视觉，则返回 `"planner"`；否则返回 `"vlm"`。但实际上表情包选择是纯文本描述任务，不需要视觉能力。
- **新行为:** 固定返回 `"utils"`，与 WebUI 中 `utils`（组件模型）的职责说明一致 —— "组件使用的模型，例如表情包模块、取名模块、关系模块、麦麦的情绪变化等，是麦麦必须的模型"。
- 删除了原先读取 `model_config` 和判断 `visual` 属性的逻辑，函数简化为一行 `return "utils"`。

### 影响范围

- `send_emoji` 内置工具触发时，`_select_emoji_with_sub_agent()` 中调用 `run_sub_agent()` 的 `model_task_name` 参数将使用 `"utils"`。
- 不影响其他工具或模型分配逻辑。

### 修复原因

- 表情包选择只需文本模型理解上下文语气并选择序号，不需要视觉模型。
- 之前偶发调用到 VLM 模型，导致不必要的资源消耗。
- 现在与 WebUI 配置界面中 `utils` 模型的用途描述保持一致。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化了emoji选择功能的模型处理逻辑，确保更一致的性能表现。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->