### PR TITLE
fix: 修复工具空参数解析失败，并规范化模型标识符

### DIFF
--- a/pytests/config_test/test_model_info_normalization.py
+++ b/pytests/config_test/test_model_info_normalization.py
@@ -1,0 +1,11 @@
+from src.config.model_configs import ModelInfo
+
+
+def test_model_identifier_strips_surrounding_whitespace() -> None:
+    model_info = ModelInfo(
+        api_provider="test-provider",
+        model_identifier=" glm-5.1 ",
+        name="test-model",
+    )
+
+    assert model_info.model_identifier == "glm-5.1"

--- a/pytests/test_openai_client_toolless_request.py
+++ b/pytests/test_openai_client_toolless_request.py
@@ -1,14 +1,57 @@
 from types import SimpleNamespace
 
+import pytest
+
 from src.config.model_configs import APIProvider, ReasoningParseMode, ToolArgumentParseMode
 from src.llm_models.model_client.openai_client import (
     _OpenAIStreamAccumulator,
     _build_reasoning_key,
     _default_normal_response_parser,
+    _parse_tool_arguments,
     _sanitize_messages_for_toolless_request,
 )
 from src.llm_models.payload_content.message import Message, RoleType, TextMessagePart
 from src.llm_models.payload_content.tool_option import ToolCall
+
+
+@pytest.mark.parametrize("parse_mode", list(ToolArgumentParseMode))
+def test_parse_tool_arguments_treats_blank_arguments_as_empty_dict(parse_mode: ToolArgumentParseMode) -> None:
+    assert _parse_tool_arguments("", parse_mode, None) == {}
+    assert _parse_tool_arguments("   ", parse_mode, None) == {}
+
+
+def test_normal_response_parser_accepts_empty_string_arguments_for_parameterless_tool() -> None:
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                finish_reason="tool_calls",
+                message=SimpleNamespace(
+                    content=None,
+                    tool_calls=[
+                        SimpleNamespace(
+                            id="finish-call",
+                            type="function",
+                            function=SimpleNamespace(name="finish", arguments=""),
+                        )
+                    ],
+                ),
+            )
+        ],
+        usage=None,
+        model="glm-5.1",
+    )
+
+    api_response, usage_record = _default_normal_response_parser(
+        response,
+        reasoning_parse_mode=ReasoningParseMode.AUTO,
+        tool_argument_parse_mode=ToolArgumentParseMode.AUTO,
+        reasoning_key=None,
+    )
+
+    assert len(api_response.tool_calls) == 1
+    assert api_response.tool_calls[0].func_name == "finish"
+    assert api_response.tool_calls[0].args == {}
+    assert usage_record is None
 
 
 def test_sanitize_messages_for_toolless_request_drops_assistant_tool_call_without_parts() -> None:

--- a/src/config/model_configs.py
+++ b/src/config/model_configs.py
@@ -351,6 +351,7 @@ class ModelInfo(ConfigBase):
     Gemini 客户端会按自身支持的字段筛选并映射到 GenerateContentConfig、EmbedContentConfig 或音频请求配置中。"""
 
     def model_post_init(self, context: Any = None):
+        self.model_identifier = self.model_identifier.strip()
         if not self.model_identifier:
             raise ValueError(t("config.model_identifier_empty_generic"))
         if not self.name:

--- a/src/llm_models/model_client/openai_client.py
+++ b/src/llm_models/model_client/openai_client.py
@@ -585,6 +585,9 @@ def _parse_tool_arguments(
     Raises:
         RespParseException: 当参数无法解析为字典时抛出。
     """
+    if not raw_arguments.strip():
+        return {}
+
     try:
         if parse_mode == ToolArgumentParseMode.STRICT:
             arguments: Any = json.loads(raw_arguments)


### PR DESCRIPTION
Treat blank OpenAI-compatible tool call arguments as an empty dict so parameterless tools such as finish can execute with providers that return an empty string. Also trim model identifiers during config normalization to avoid leading whitespace leaking into requests and snapshots.

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:
7. 请简要说明本次更新的内容和目的：
8. 
9. 部分 OpenAI 兼容服务商，例如火山引擎 GLM，在调用无参数工具时会返回：
"arguments": ""
当前解析逻辑要求工具参数必须解析为 dict，导致 finish 等无参数工具触发 RespParseException，对话流程中断并进入重试。

请求快照中发现 model_identifier 可能带有首尾空格，例如：
"model_identifier": " glm-5.1"
该值会继续进入请求构造、快照记录和后续排查流程，可能导致模型识别异常，也会让日志与配置诊断变得混乱。

修复

将空字符串或纯空白工具参数归一化为 {}，兼容无参数工具调用。
在 ModelInfo.model_post_init 中对 model_identifier 执行 .strip()，统一清理配置输入中的首尾空格。
增加回归测试，覆盖：
所有 ToolArgumentParseMode 下空参数都解析为 {}。
finish(arguments="") 能正常解析为无参数工具调用。
model_identifier=" glm-5.1 " 会归一化为 "glm-5.1"。

# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 模型标识符现可正确处理并移除前后空白字符
  * 工具参数解析现支持空字符串处理，返回空参数字典而非抛出异常

* **Tests**
  * 新增模型标识符空白字符规范化测试
  * 新增工具参数解析空字符串场景测试

<!-- end of auto-generated comment: release notes by coderabbit.ai -->