### PR TITLE
fix: 表达方式自动审核结果持久化到数据库

### DIFF
--- a/src/learners/expression_auto_check_task.py
+++ b/src/learners/expression_auto_check_task.py
@@ -17,9 +17,9 @@ from sqlmodel import select
 
 from src.common.database.database import get_db_session
 from src.common.database.database_model import Expression
+from src.common.database.database_model import ModifiedBy
 from src.common.logger import get_logger
 from src.config.config import global_config
-from src.learners.expression_review_store import get_review_state, set_review_state
 from src.learners.expression_utils import check_expression_suitability
 from src.manager.async_task_manager import AsyncTask
 
@@ -53,7 +53,7 @@ class ExpressionAutoCheckTask(AsyncTask):
                 statement = select(Expression)
                 all_expressions = session.exec(statement).all()
 
-            unevaluated_expressions = [expr for expr in all_expressions if not get_review_state(expr.id)["checked"]]
+            unevaluated_expressions = [expr for expr in all_expressions if not expr.checked]
 
             if not unevaluated_expressions:
                 logger.info("没有未检查的表达方式")
@@ -62,9 +62,7 @@ class ExpressionAutoCheckTask(AsyncTask):
             selected_count = min(count, len(unevaluated_expressions))
             selected = random.sample(unevaluated_expressions, selected_count)
 
-            logger.info(
-                f"从 {len(unevaluated_expressions)} 条未检查表达方式中随机选择了 {selected_count} 条"
-            )
+            logger.info(f"从 {len(unevaluated_expressions)} 条未检查表达方式中随机选择了 {selected_count} 条")
             return selected
 
         except Exception as e:
@@ -86,8 +84,18 @@ class ExpressionAutoCheckTask(AsyncTask):
             expression.style,
         )
 
+        if error:
+            logger.warning(f"表达方式评估时出现错误 [ID: {expression.id}]: {error}")
+            return False
+
         try:
-            set_review_state(expression.id, True, not suitable, "ai")
+            with get_db_session() as session:
+                expr = session.exec(select(Expression).where(Expression.id == expression.id)).first()
+                if expr:
+                    expr.checked = True
+                    expr.rejected = not suitable
+                    expr.modified_by = ModifiedBy.AI
+                    session.add(expr)
 
             status = "通过" if suitable else "不通过"
             # 保留这段注释，方便后续需要时恢复更详细的审核日志。
@@ -97,9 +105,6 @@ class ExpressionAutoCheckTask(AsyncTask):
             #     f"Style: {expression.style}... | "
             #     f"Reason: {reason[:50]}..."
             # )
-
-            if error:
-                logger.warning(f"表达方式评估时出现错误 [ID: {expression.id}]: {error}")
 
             logger.debug(f"表达方式 [ID: {expression.id}] 评估完成: {status}, reason={reason}")
             return suitable

--- a/src/webui/routers/expression.py
+++ b/src/webui/routers/expression.py
@@ -96,10 +96,7 @@ def get_chat_name_from_latest_message(chat_id: str, db_session: Any) -> Optional
     """从最近消息中解析聊天显示名称。"""
 
     statement = (
-        select(Messages)
-        .where(col(Messages.session_id) == chat_id)
-        .order_by(col(Messages.timestamp).desc())
-        .limit(1)
+        select(Messages).where(col(Messages.session_id) == chat_id).order_by(col(Messages.timestamp).desc()).limit(1)
     )
     message = db_session.exec(statement).first()
     if not message:
@@ -236,9 +233,7 @@ async def get_chat_list() -> ChatListResponse:
                     is_group=bool(chat_session.group_id),
                 )
 
-            expression_chat_ids = {
-                chat_id for chat_id in session.exec(select(Expression.session_id)).all() if chat_id
-            }
+            expression_chat_ids = {chat_id for chat_id in session.exec(select(Expression.session_id)).all() if chat_id}
             for session_id in expression_chat_ids:
                 if session_id in chat_by_id:
                     continue


### PR DESCRIPTION
## 问题
表达方式自动审核结果仅写入内存缓存，未持久化到数据库，导致 WebUI 始终显示“未审核”。

## 修改
- `_evaluate_expression` 将审核结果写入 `Expression` 数据库字段（`checked`、`rejected`、`modified_by`）
- `_select_expressions` 筛选未检查表达方式改用 `expr.checked` 数据库字段
- `check_expression_suitability` 返回错误时 early-return，不写入数据库
- 移除对 `expression_review_store` 内存缓存的依赖

## 验证
- 本地 ruff check / ruff format 通过
- 语法检查通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 改进了表达式评估时的异常处理机制

* **重构**
  * 优化了表达式检查的状态管理流程
  * 提升代码质量和可维护性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->