### PR TITLE
fix(mcp-bridge): redact sensitive arguments in tool call trace logs (CWE-532)

### DIFF
--- a/plugins/MaiBot_MCPBridgePlugin/plugin.py
+++ b/plugins/MaiBot_MCPBridgePlugin/plugin.py
@@ -185,13 +185,49 @@ class ToolCallTracer:
         """清空记录"""
         self._records.clear()
     
+    # v1.4.x (CWE-532): Patterns of argument keys whose values may contain
+    # credentials or other sensitive data. Matched case-insensitively against
+    # any substring of the key name.
+    _SENSITIVE_KEY_PATTERNS = (
+        "password", "passwd", "secret", "token", "api_key", "apikey",
+        "access_key", "accesskey", "auth", "authorization", "credential",
+        "private_key", "privatekey", "session", "cookie",
+    )
+    _REDACTED_PLACEHOLDER = "[REDACTED]"
+
+    @classmethod
+    def _redact_sensitive(cls, value: Any) -> Any:
+        """递归脱敏: 将常见敏感字段（密码/令牌/密钥等）的值替换为占位符。
+
+        防止在追踪日志(trace.jsonl)中明文落盘 API Key、密码等凭据 (CWE-532)。
+        非敏感字段保持原样，便于排障。
+        """
+        if isinstance(value, dict):
+            redacted: Dict[Any, Any] = {}
+            for k, v in value.items():
+                key_str = str(k).lower()
+                if any(pat in key_str for pat in cls._SENSITIVE_KEY_PATTERNS):
+                    redacted[k] = cls._REDACTED_PLACEHOLDER
+                else:
+                    redacted[k] = cls._redact_sensitive(v)
+            return redacted
+        if isinstance(value, list):
+            return [cls._redact_sensitive(v) for v in value]
+        if isinstance(value, tuple):
+            return tuple(cls._redact_sensitive(v) for v in value)
+        return value
+
     def _write_to_log(self, record: ToolCallRecord) -> None:
         """写入 JSONL 日志文件"""
         try:
             if self._log_path:
                 self._log_path.parent.mkdir(parents=True, exist_ok=True)
+                # v1.4.x (CWE-532): 在落盘前脱敏 arguments 中的敏感字段
+                payload = asdict(record)
+                if isinstance(payload.get("arguments"), dict):
+                    payload["arguments"] = self._redact_sensitive(payload["arguments"])
                 with open(self._log_path, "a", encoding="utf-8") as f:
-                    f.write(json.dumps(asdict(record), ensure_ascii=False) + "\n")
+                    f.write(json.dumps(payload, ensure_ascii=False) + "\n")
         except Exception as e:
             logger.warning(f"写入追踪日志失败: {e}")
     

--- a/plugins/MaiBot_MCPBridgePlugin/plugin.py
+++ b/plugins/MaiBot_MCPBridgePlugin/plugin.py
@@ -224,7 +224,8 @@ class ToolCallTracer:
                 self._log_path.parent.mkdir(parents=True, exist_ok=True)
                 # v1.4.x (CWE-532): 在落盘前脱敏 arguments 中的敏感字段
                 payload = asdict(record)
-                if isinstance(payload.get("arguments"), dict):
+                # 无条件脱敏 arguments（dict/list/tuple 均递归处理），避免非字典形态绕过脱敏
+                if "arguments" in payload:
                     payload["arguments"] = self._redact_sensitive(payload["arguments"])
                 with open(self._log_path, "a", encoding="utf-8") as f:
                     f.write(json.dumps(payload, ensure_ascii=False) + "\n")


### PR DESCRIPTION
## Summary

Fixes a sensitive‑data‑in‑log issue (CWE‑532) in `plugins/MaiBot_MCPBridgePlugin/plugin.py`. When `tool_call_log_enabled` is set, `ToolCallTracer._write_to_log` serializes the full `ToolCallRecord` — including the raw `arguments` dict passed to MCP tools — as JSONL to `plugins/MaiBot_MCPBridgePlugin/logs/trace.jsonl`. MCP tools commonly accept credentials as parameters (e.g. `api_key`, `token`, `password`, `authorization`), so any such argument lands on disk in plaintext at a predictable path.

## Vulnerability

- **CWE:** 532 (Insertion of Sensitive Information into Log File)
- **File / function:** `plugins/MaiBot_MCPBridgePlugin/plugin.py` — `ToolCallTracer._write_to_log` (and the upstream `ToolCallRecord` constructed around line 665 from `parsed_args`)
- **Sink:** `json.dumps(asdict(record))` written to `trace.jsonl`
- **Source:** caller‑supplied tool `arguments` (an MCP tool invocation, e.g. one that takes an API key for an upstream service)
- **Severity:** Medium — exploitation requires log read access, but the data exposed is high‑value (long‑lived credentials), and the leak is deterministic once a credentialed tool is invoked.

### Data flow

`MCP tool call → parsed_args → ToolCallRecord(arguments=parsed_args) → ToolCallTracer._write_to_log → asdict(record) → json.dumps → trace.jsonl on disk`

There was no redaction or filtering on the path between the tool argument and the disk write.

### Preconditions for exploitation

1. Operator has enabled `tool_call_log_enabled` in the MCP bridge plugin (a supported, advertised feature).
2. At least one MCP tool is invoked with a credential‑bearing argument (very common — most third‑party MCP servers authenticate via API keys passed as arguments).
3. An attacker can read `plugins/MaiBot_MCPBridgePlugin/logs/trace.jsonl`. Realistic vectors include: another local user on a shared host, an unrelated path‑traversal/LFI bug, log shipping to a less‑trusted store, backups, or container image leakage.

None of these preconditions individually grant the attacker the credential, so the log write is the actual disclosure step.

## Fix

Adds a small recursive redactor (`ToolCallTracer._redact_sensitive`) that walks dicts/lists/tuples and replaces values whose key matches a case‑insensitive substring against a known list of sensitive patterns:

```
password, passwd, secret, token, api_key, apikey, access_key, accesskey,
auth, authorization, credential, private_key, privatekey, session, cookie
```

`_write_to_log` now redacts `arguments` via this helper before serialization. Non‑sensitive fields are preserved so the trace remains useful for debugging. The change is additive and local to `ToolCallTracer` — no public API or behavior change for callers.

Diff is +37/−1 in a single file.

## Testing

- Verified the unmodified path writes raw secrets to `trace.jsonl` (e.g. an `arguments={"api_key": "sk-..."}` argument is serialized verbatim).
- Verified the patched path produces `"api_key": "[REDACTED]"` and that nested structures (dicts inside dicts, dicts inside lists) are also redacted.
- Verified non‑sensitive keys (e.g. `query`, `limit`, `url`) pass through unchanged.
- Verified mixed‑case keys (`API_KEY`, `Authorization`) are matched.
- No regressions in `ToolCallTracer` record/clear behavior; the `_log_path = None` path still no‑ops as before.

## Adversarial review

Before submitting we tried to disprove the finding. We checked whether existing access controls, framework behavior, or a separate sanitizer already protected the log — they don't: the tracer is internal, runs on every successful tool invocation when the flag is on, and writes `asdict(record)` directly. We also checked whether the precondition (log read access) already implies credential access — it doesn't, since the credentials only enter the file *because* of this code path; an attacker with only file‑read on `logs/` would otherwise see operational metadata, not API keys. Finally, we considered whether the fix is meaningful given that `raw_result` / `processed_result` are also logged: those are tool *outputs* and only leak credentials if a specific tool happens to echo them back, whereas `arguments` deterministically contains caller‑supplied secrets. The fix removes the primary, deterministic leak. Hardening the result fields could be a reasonable follow‑up but is out of scope here.

## Notes for maintainers

- Pattern list is intentionally broad and substring‑based to catch common variants (`my_api_key`, `xAuthToken`, etc.). If you'd prefer an exact‑match allow/deny list or a configurable pattern set, happy to adjust.
- Redaction only touches the on‑disk trace; in‑memory records and the rest of the plugin are unaffected.

cc @lewiswigmore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 增强日志脱敏：在记录跟踪日志前递归地移除或替换密码、令牌等敏感信息，避免以明文泄露，提高数据安全与隐私保护。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->