### PR TITLE
feat: 支持表情包纯文本选择模式，新增 emoji_selection_mode 配置

### DIFF
--- a/pytests/test_maisaka_monitor_protocol.py
+++ b/pytests/test_maisaka_monitor_protocol.py
@@ -220,10 +220,6 @@ async def test_reply_tool_puts_monitor_detail_into_metadata(monkeypatch: pytest.
 
 @pytest.mark.asyncio
 async def test_send_emoji_tool_puts_monitor_detail_into_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def _fake_build_emoji_candidate_message(emojis: list[Any]) -> object:
-        assert emojis
-        return SimpleNamespace()
-
     async def _fake_send_emoji_for_maisaka(**kwargs: Any) -> Any:
         selected_emoji, matched_emotion = await kwargs["emoji_selector"](
             kwargs["requested_emotion"],
@@ -242,8 +238,8 @@ async def test_send_emoji_tool_puts_monitor_detail_into_metadata(monkeypatch: py
             sent_message=None,
         )
 
-    monkeypatch.setattr(send_emoji_tool_module, "_build_emoji_candidate_message", _fake_build_emoji_candidate_message)
     monkeypatch.setattr(send_emoji_tool_module, "send_emoji_for_maisaka", _fake_send_emoji_for_maisaka)
+    monkeypatch.setattr(send_emoji_tool_module, "_get_emoji_selection_mode", lambda: "text")
     monkeypatch.setattr(
         send_emoji_tool_module.emoji_manager,
         "emojis",

--- a/pytests/test_runtime_business_hooks.py
+++ b/pytests/test_runtime_business_hooks.py
@@ -76,7 +76,7 @@ async def test_send_emoji_for_maisaka_can_be_aborted_by_hook(monkeypatch: pytest
     )
     monkeypatch.setattr(maisaka_tool, "_get_runtime_manager", lambda: fake_manager)
 
-    result = await maisaka_tool.send_emoji_for_maisaka(stream_id="stream-1", requested_emotion="开心")
+    result = await maisaka_tool.send_emoji_for_maisaka(stream_id="stream-1", requested_emotion="开心", emoji_selector=lambda *a, **kw: (None, ""))
 
     assert result.success is False
     assert result.message == "插件阻止了表情发送。"

--- a/src/config/official_configs.py
+++ b/src/config/official_configs.py
@@ -15,6 +15,12 @@ VISUAL_MODE_OPTION_DESCRIPTIONS = {
     "multimodal": "多模态模式，会向模型发送视觉输入",
 }
 
+
+EMOJI_SELECTION_MODE_OPTION_DESCRIPTIONS = {
+    "visual": "视觉选择 (VLM) - 使用视觉模型看图选择表情包",
+    "text": "文本选择 (描述匹配) - 使用纯文本模型根据描述选择表情包",
+}
+
 """
 须知：
 1. 本文件中记录了所有的配置项
@@ -1301,6 +1307,16 @@ class EmojiConfig(ConfigBase):
         },
     )
     """是否启用表情包过滤，只有符合该要求的表情包才会被保存"""
+
+    emoji_selection_mode: Literal["visual", "text"] = Field(
+        default="visual",
+        json_schema_extra={
+            "x-widget": "select",
+            "x-icon": "eye",
+            "x-option-descriptions": EMOJI_SELECTION_MODE_OPTION_DESCRIPTIONS,
+        },
+    )
+    """表情包选择模式：visual 使用视觉模型看图选择，text 使用纯文本模型根据描述选择"""
 
 
 class KeywordRuleConfig(ConfigBase):

--- a/src/maisaka/builtin_tool/send_emoji.py
+++ b/src/maisaka/builtin_tool/send_emoji.py
@@ -306,7 +306,123 @@ def _is_missing_visual_model_error(exc: Exception) -> bool:
     return _EMOJI_VLM_NOT_CONFIGURED_MESSAGE in error_text or "未找到名为 '' 的模型" in error_text
 
 
-async def _select_emoji_with_sub_agent(
+
+
+async def _select_emoji_with_text_sub_agent(
+    tool_ctx: BuiltinToolRuntimeContext,
+    requested_emotion: str,
+    reasoning: str,
+    context_texts: list[str],
+    sample_size: int,
+    selection_metadata: Optional[Dict[str, Any]] = None,
+) -> tuple[MaiEmoji | None, str]:
+    """通过纯文本子代理从候选表情包描述中选出一个结果。"""
+
+    del reasoning, context_texts, sample_size
+
+    available_emojis = list(emoji_manager.emojis)
+    if not available_emojis:
+        return None, ""
+
+    total_candidate_count = min(len(available_emojis), _get_emoji_candidate_count())
+    sampled_emojis = sample(available_emojis, total_candidate_count)
+
+    # 构建候选表情包的文本描述列表
+    candidate_descriptions: list[str] = []
+    for i, emoji in enumerate(sampled_emojis, start=1):
+        desc = emoji.description.strip() if emoji.description else "（无描述）"
+        candidate_descriptions.append(f"{i}. {desc}")
+
+    candidates_text = "\n".join(candidate_descriptions)
+
+    system_prompt = (
+        "你是 Maisaka 的临时表情包选择子代理。\n"
+        "你会收到一些候选表情包的文本描述，以及当前的对话上下文。\n"
+        f"一共有 {len(sampled_emojis)} 个候选表情包。\n"
+        "你的任务是根据上下文和当前语气，从这些候选表情包中选出最合适的一个。\n"
+        "你必须返回一个 JSON 对象，不要输出任何 JSON 之外的内容。\n"
+        '返回格式固定为：{"emoji_index":1,"reason":"简短理由"}'
+    )
+
+    emotion_hint = ""
+    if requested_emotion:
+        emotion_hint = f"\n期望表达的情绪：{requested_emotion}"
+
+    prompt_message = ReferenceMessage(
+        content=(
+            f"[选择任务]\n"
+            f"候选总数: {len(sampled_emojis)}\n"
+            f"{emotion_hint}\n"
+            f"候选表情包描述：\n{candidates_text}\n\n"
+            "请只输出 JSON。"
+        ),
+        timestamp=datetime.now(),
+        reference_type=ReferenceMessageType.TOOL_HINT,
+        remaining_uses_value=1,
+        display_prefix="[表情包选择任务]",
+    )
+
+    request_messages = [
+        MessageBuilder().set_role(RoleType.System).add_text_content(system_prompt).build(),
+    ]
+    prompt_llm_message = prompt_message.to_llm_message()
+    if prompt_llm_message is not None:
+        request_messages.append(prompt_llm_message)
+    serialized_request_messages = serialize_prompt_messages(request_messages)
+
+    selection_started_at = datetime.now()
+    response = await tool_ctx.runtime.run_sub_agent(
+        context_message_limit=_EMOJI_SUB_AGENT_CONTEXT_LIMIT,
+        system_prompt=system_prompt,
+        extra_messages=[prompt_message],
+        max_tokens=_EMOJI_SUB_AGENT_MAX_TOKENS,
+        model_task_name="utils",
+    )
+    selection_duration_ms = round((datetime.now() - selection_started_at).total_seconds() * 1000, 2)
+
+    selection_metrics: Dict[str, Any] = {
+        "prompt_tokens": response.prompt_tokens,
+        "completion_tokens": response.completion_tokens,
+        "total_tokens": response.total_tokens,
+        "overall_ms": selection_duration_ms,
+    }
+
+    try:
+        selection = EmojiSelectionResult.model_validate_json(response.content or "")
+    except Exception as exc:
+        logger.warning(f"{tool_ctx.runtime.log_prefix} 表情包子代理结果解析失败，将回退到候选首项: {exc}")
+        if selection_metadata is not None:
+            selection_metadata["monitor_detail"] = _build_send_emoji_monitor_detail(
+                request_messages=serialized_request_messages,
+                output_text=response.content or "",
+                metrics=selection_metrics,
+                extra_sections=[{
+                    "title": "解析异常",
+                    "content": str(exc),
+                }],
+            )
+        fallback_emoji = sampled_emojis[0] if sampled_emojis else None
+        return fallback_emoji, ""
+
+    if selection_metadata is not None:
+        selection_metadata["reason"] = selection.reason.strip()
+        selection_metadata["monitor_detail"] = _build_send_emoji_monitor_detail(
+            request_messages=serialized_request_messages,
+            reasoning_text=selection.reason,
+            output_text=response.content or "",
+            metrics=selection_metrics,
+        )
+
+    emoji_index = int(selection.emoji_index)
+    if emoji_index < 1 or emoji_index > len(sampled_emojis):
+        logger.warning(
+            f"{tool_ctx.runtime.log_prefix} 表情包子代理返回了无效序号: {emoji_index!r}，将回退到第 1 张"
+        )
+        emoji_index = 1
+
+    return sampled_emojis[emoji_index - 1], ""
+
+async def _select_emoji_with_visual_sub_agent(
     tool_ctx: BuiltinToolRuntimeContext,
     reasoning: str,
     context_texts: list[str],
@@ -416,6 +532,36 @@ async def _select_emoji_with_sub_agent(
     return sampled_emojis[emoji_index - 1], ""
 
 
+
+def _get_emoji_selection_mode() -> str:
+    """读取表情包选择模式配置。"""
+
+    mode = str(getattr(global_config.emoji, "emoji_selection_mode", "visual") or "").strip().lower()
+    if mode not in ("visual", "text"):
+        return "visual"
+    return mode
+
+
+async def _select_emoji(
+    tool_ctx: BuiltinToolRuntimeContext,
+    requested_emotion: str,
+    reasoning: str,
+    context_texts: list[str],
+    sample_size: int,
+    selection_metadata: Optional[Dict[str, Any]] = None,
+) -> tuple[MaiEmoji | None, str]:
+    """根据配置选择表情包选择模式。"""
+
+    mode = _get_emoji_selection_mode()
+    if mode == "text":
+        return await _select_emoji_with_text_sub_agent(
+            tool_ctx, requested_emotion, reasoning, context_texts, sample_size, selection_metadata
+        )
+    return await _select_emoji_with_visual_sub_agent(
+        tool_ctx, reasoning, context_texts, sample_size, selection_metadata
+    )
+
+
 async def handle_tool(
     tool_ctx: BuiltinToolRuntimeContext,
     invocation: ToolInvocation,
@@ -450,8 +596,9 @@ async def handle_tool(
             requested_emotion=requested_emotion,
             reasoning=tool_ctx.engine.last_reasoning_content,
             context_texts=context_texts,
-            emoji_selector=lambda _requested_emotion, reasoning, context_texts, sample_size: _select_emoji_with_sub_agent(
+            emoji_selector=lambda _requested_emotion, reasoning, context_texts, sample_size: _select_emoji(
                 tool_ctx,
+                _requested_emotion,
                 reasoning,
                 list(context_texts or []),
                 sample_size,

--- a/src/maisaka/builtin_tool/send_emoji.py
+++ b/src/maisaka/builtin_tool/send_emoji.py
@@ -536,10 +536,7 @@ async def _select_emoji_with_visual_sub_agent(
 def _get_emoji_selection_mode() -> str:
     """读取表情包选择模式配置。"""
 
-    mode = str(getattr(global_config.emoji, "emoji_selection_mode", "visual") or "").strip().lower()
-    if mode not in ("visual", "text"):
-        return "visual"
-    return mode
+    return global_config.emoji.emoji_selection_mode
 
 
 async def _select_emoji(


### PR DESCRIPTION
- 在 EmojiConfig 中添加 emoji_selection_mode 选项，支持 visual（默认）和 text 两种模式
- visual 模式保持原有 VLM 看图选择逻辑
- text 模式使用 utils 纯文本模型根据表情包描述进行选择，无需视觉模型
- 新增 _select_emoji 统一调度器，根据配置自动切换模式
- 修复相关测试并适配新的选择器签名
- 配置字段使用 Literal 类型以支持 WebUI 下拉选项

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
6. 请填写破坏性更新的具体内容（如有）: 无
7. 请简要说明本次更新的内容和目的：解决了用户不想用多模态/vlm模型选择表情包，而是使用表情包纯文本描述的问题
# 其他信息
新增表情包 **纯文本选择模式**，通过配置项 `emoji_selection_mode` 切换选择方式。
  - `visual`（默认）：保持原有 VLM 看图选择逻辑
  - `text`：使用 `utils` 纯文本模型根据表情包描述选择，无需视觉模型

## 改动文件

  - `src/config/official_configs.py`：`EmojiConfig` 新增 `emoji_selection_mode` 字段（Literal 类型，WebUI 下拉选择）
  - `src/maisaka/builtin_tool/send_emoji.py`：
    - 保留原视觉选择函数（`_select_emoji_with_visual_sub_agent`）
    - 新增文本选择函数（`_select_emoji_with_text_sub_agent`）
    - 新增配置读取 `_get_emoji_selection_mode` 和调度器 `_select_emoji`
  - `pytests/`：适配新函数签名

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 新增表情选择模式配置项，支持“视觉”与“文本”两种选择方式，运行时可切换并在界面提示中显示说明。
  * 增加基于文本的表情选择路径，提升在无法显示视觉候选时的可用性与容错能力。

* **Tests**
  * 测试已更新以覆盖新的选择模式和通过参数控制的表情发送行为，确保不同模式下的兼容性和回退逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->