### PR TITLE
fix: 修复表情包自动扫描跳过未注册表情包的问题

### DIFF
--- a/src/emoji_system/emoji_manager.py
+++ b/src/emoji_system/emoji_manager.py
@@ -1037,12 +1037,13 @@ class EmojiManager:
                 self._emoji_num < global_config.emoji.max_reg_num
                 or (self._emoji_num > global_config.emoji.max_reg_num and global_config.emoji.do_replace)
             ):
+                registered_paths = {Path(emoji.full_path).resolve() for emoji in self.emojis}
                 logger.info("[emoji_maintenance] Scanning data/emoji for new emojis...")
                 for emoji_file in EMOJI_DIR.iterdir():
                     if not emoji_file.is_file():
                         continue
                     resolved_file = emoji_file.absolute().resolve()
-                    if resolved_file in self._known_emoji_file_paths:
+                    if resolved_file in registered_paths:
                         continue
                     try:
                         register_status = await self.register_emoji_by_filename(emoji_file)


### PR DESCRIPTION
在 periodic_emoji_maintenance 的自动扫描循环中，
改用 self.emojis（仅包含已注册表情包）构建跳过集合，
替换原先的 _known_emoji_file_paths（包含未注册记录），
避免已有数据库记录但 is_registered=False 的表情包文件被永久跳过。

Closes: 表情包自动注册不触发，手动注册正常的问题

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
4. - [x] 本次更新是否经过测试
6. 请填写破坏性更新的具体内容（如有）:无

## 问题描述

  表情包放入 data/emoji/ 后一直不会被自动注册，WebUI 中可以看到文件且手动点"注册"能立即成功获取描述并注册。

  ## 根因分析

  periodic_emoji_maintenance 中的自动扫描循环使用 _known_emoji_file_paths 作为跳过集合。该集合由 check_emoji_file_integrity 构建，包含了所有数据库记录对应的文件路径，包括
  is_registered=False 的未注册记录。

  当一个表情包文件被尝试注册过（VLM 生成描述成功但后续入库失败）或数据库中存在未注册记录时，该文件路径会被加入跳过集合，导致后续的自动扫描永远跳过该文件。而 WebUI 手动注
  册直接修改数据库 is_registered 字段，不经过文件扫描，所以能成功。

  ## 修复内容
src/emoji_system/emoji_manager.py — 在自动扫描循环中，改用 self.emojis（仅包含已注册表情包对象）动态构建跳过集合，替换原先的 _known_emoji_file_paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **优化与重构**
  * 优化了表情符号系统的维护逻辑，改进了已注册文件的管理方式，提升系统效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->