### PR TITLE
fix：修复单条消息触发多次 Timing Gate 导致重复回复的问题

### DIFF
--- a/src/maisaka/reasoning_engine.py
+++ b/src/maisaka/reasoning_engine.py
@@ -442,7 +442,7 @@ class MaisakaReasoningEngine:
                         )
                     await self._ingest_messages(cached_messages)
                     anchor_message = cached_messages[-1]
-                else:
+                elif timeout_triggered:
                     anchor_message = self._get_timeout_anchor_message()
                     if anchor_message is None:
                         logger.warning(f"{self._runtime.log_prefix} wait 超时后没有可复用的锚点消息，跳过本轮")
@@ -452,6 +452,9 @@ class MaisakaReasoningEngine:
                         self._runtime._chat_history.append(
                             self._build_wait_completed_message(has_new_messages=False)
                         )
+                else:
+                    logger.debug(f"{self._runtime.log_prefix} 无待处理消息，跳过本轮")
+                    continue
 
                 try:
                     timing_gate_required = True

--- a/src/maisaka/runtime.py
+++ b/src/maisaka/runtime.py
@@ -511,6 +511,7 @@ class MaisakaHeartFlowChatting:
 
     async def _schedule_deferred_message_turn(self, delay_seconds: float) -> None:
         """在预计满足空窗补偿条件时再次检查是否应触发循环。"""
+        current_task = asyncio.current_task()
         try:
             if delay_seconds > 0:
                 await asyncio.sleep(delay_seconds)
@@ -520,7 +521,8 @@ class MaisakaHeartFlowChatting:
         except asyncio.CancelledError:
             return
         finally:
-            self._deferred_message_turn_task = None
+            if self._deferred_message_turn_task is current_task:
+                self._deferred_message_turn_task = None
 
     def _update_message_trigger_state(self, message: SessionMessage) -> None:
         """补齐消息中的 @/提及 标记，并在命中时启用强制 continue。"""


### PR DESCRIPTION
## Summary

修复单条用户消息在短时间内触发多个 Timing Gate，导致每个 TG 各自拉起 Planner 再调用 Replyer，最终用户收到多条重复回复的 bug。

## 根因

两个问题共同导致：

1. **延迟任务竞态条件** (`runtime.py`)：`_schedule_deferred_message_turn` 的 `finally` 块无条件清除 `_deferred_message_turn_task`。当旧任务被 `_cancel_deferred_message_turn_task()` 取消后，旧 `finally` 在 event loop 后续迭代中执行，会覆盖掉这期间新建任务的引用。被孤立的任务无法取消，后续触发时向 `_internal_turn_queue` 注入多余的 `"message"` 触发器。

2. **空消息批次的放行逻辑过宽** (`reasoning_engine.py`)：`7bdbdec1` 引入的 wait 功能新增了 `else` 分支——当 `cached_messages` 为空时，用 `_get_timeout_anchor_message()` 取缓存中最后一条消息作为锚点继续处理。该分支本意是服务于 wait 超时（无新消息也应继续），但没有区分触发器类型。虚假的 `"message"` 触发器（来自竞态条件 1）也会落入此分支，导致对已处理过的消息重新执行 TG → Planner → Replyer 全链路。

## 修复

- **`runtime.py`**：`finally` 块改为仅在当前任务仍是已注册的延迟任务时（`is current_task`）才清除引用
- **`reasoning_engine.py`**：将备选分支限定为 `elif timeout_triggered`，对无待处理消息的 `"message"` 触发器恢复旧行为（`continue` 跳过）

## Test plan

- [x] `pytests/test_maisaka_timing_gate.py` 全部 12 个用例通过
- [x] ruff check 无告警

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进消息处理的超时控制机制，提高了系统稳定性。
  * 修复异步任务调度中的竞态条件，防止并发操作导致的状态不一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->