### PR TITLE
fix: talk_value=0 时真正跳过回复判断，仅保留表达学习

### DIFF
--- a/src/common/utils/utils_config.py
+++ b/src/common/utils/utils_config.py
@@ -285,39 +285,21 @@ class ChatConfigUtils:
         if session_id:
             for rule in global_config.chat.talk_value_rules:
                 if not rule.platform and not rule.item_id:
-                    continue  # 一起留空表示全局
+                    continue
                 if not ChatConfigUtils.target_matches_session(rule, session_id, is_group_chat):
-                    continue  # 不匹配的会话 ID，跳过
-                parsed_range = ChatConfigUtils.parse_range(rule.time)
-                if not parsed_range:
-                    continue  # 无法解析的时间范围，跳过
-                start_min, end_min = parsed_range
-                in_range: bool = False
-                if start_min <= end_min:
-                    in_range = start_min <= now_min <= end_min
-                else:  # 跨天的时间范围
-                    in_range = now_min >= start_min or now_min <= end_min
-                if in_range:
-                    return rule.value or 0.0  # 如果规则生效但没有设置值，返回 0.0
+                    continue
+                if ChatConfigUtils._is_time_in_range(rule.time, now_min):
+                    return rule.value or 0.0
 
         # 没有匹配到会话相关的规则，继续匹配全局规则
         for rule in global_config.chat.talk_value_rules:
             if rule.platform or rule.item_id:
-                continue  # 只匹配全局规则
+                continue
             if is_group_chat is not None and (rule.rule_type == "group") != is_group_chat:
                 continue
-            parsed_range = ChatConfigUtils.parse_range(rule.time)
-            if not parsed_range:
-                continue  # 无法解析的时间范围，跳过
-            start_min, end_min = parsed_range
-            in_range: bool = False
-            if start_min <= end_min:
-                in_range = start_min <= now_min <= end_min
-            else:  # 跨天的时间范围
-                in_range = now_min >= start_min or now_min <= end_min
-            if in_range:
-                return rule.value or 0.0  # 如果规则生效但没有设置值，返回 0.0
-        return result  # 如果没有任何规则生效，返回默认值
+            if ChatConfigUtils._is_time_in_range(rule.time, now_min):
+                return rule.value or 0.0
+        return result
 
     @staticmethod
     def parse_range(range_str: str) -> Optional[tuple[int, int]]:
@@ -329,3 +311,16 @@ class ChatConfigUtils:
             return sh * 60 + sm, eh * 60 + em
         except Exception:
             return None
+
+    @staticmethod
+    def _is_time_in_range(time_str: str, now_min: int) -> bool:
+        """time 为空表示全时段生效；否则检查 now_min 是否在 HH:MM-HH:MM 范围内。"""
+        if not (time_str or "").strip():
+            return True
+        parsed = ChatConfigUtils.parse_range(time_str)
+        if not parsed:
+            return False
+        start_min, end_min = parsed
+        if start_min <= end_min:
+            return start_min <= now_min <= end_min
+        return now_min >= start_min or now_min <= end_min

--- a/src/maisaka/reasoning_engine.py
+++ b/src/maisaka/reasoning_engine.py
@@ -453,6 +453,16 @@ class MaisakaReasoningEngine:
                             self._build_wait_completed_message(has_new_messages=False)
                         )
 
+                if (
+                    cached_messages
+                    and self._runtime._get_effective_reply_frequency() <= 0
+                    and not self._runtime._has_forced_timing_trigger()
+                ):
+                    logger.debug(
+                        f"{self._runtime.log_prefix} talk_value=0，已完成学习，跳过 Timing Gate 和 Planner"
+                    )
+                    continue
+
                 try:
                     timing_gate_required = True
                     round_index = 0

--- a/src/maisaka/reasoning_engine.py
+++ b/src/maisaka/reasoning_engine.py
@@ -454,13 +454,14 @@ class MaisakaReasoningEngine:
                         )
 
                 if (
-                    cached_messages
-                    and self._runtime._get_effective_reply_frequency() <= 0
+                    self._runtime._get_effective_reply_frequency() <= 0
                     and not self._runtime._has_forced_timing_trigger()
                 ):
-                    logger.debug(
-                        f"{self._runtime.log_prefix} talk_value=0，已完成学习，跳过 Timing Gate 和 Planner"
-                    )
+                    if cached_messages:
+                        logger.debug(
+                            f"{self._runtime.log_prefix} talk_value=0，已完成学习，跳过 Timing Gate 和 Planner"
+                        )
+                    self._runtime._transition_to_idle()
                     continue
 
                 try:
@@ -769,10 +770,7 @@ class MaisakaReasoningEngine:
                             if not planner_interrupted:
                                 round_index += 1
                 finally:
-                    if self._runtime._agent_state == self._runtime._STATE_RUNNING:
-                        self._runtime._agent_state = self._runtime._STATE_STOP
-                    if self._runtime._running:
-                        self._runtime._update_stage_status("等待消息", "本轮处理结束")
+                    self._runtime._transition_to_idle()
         except asyncio.CancelledError:
             self._runtime._log_internal_loop_cancelled()
             raise

--- a/src/maisaka/runtime.py
+++ b/src/maisaka/runtime.py
@@ -56,6 +56,7 @@ from .tool_provider import MaisakaBuiltinToolProvider
 logger = get_logger("maisaka_runtime")
 
 MAX_INTERNAL_ROUNDS = 10
+_EFFECTIVELY_INFINITE_THRESHOLD = 10**9
 
 
 class MaisakaHeartFlowChatting:
@@ -235,7 +236,7 @@ class MaisakaHeartFlowChatting:
 
     def adjust_talk_frequency(self, frequency: float) -> None:
         """调整当前会话的回复频率倍率。"""
-        self._talk_frequency_adjust = max(0.01, float(frequency))
+        self._talk_frequency_adjust = float(frequency)
         self._schedule_message_turn()
 
     def append_sent_message_to_chat_history(
@@ -350,17 +351,14 @@ class MaisakaHeartFlowChatting:
             self._schedule_message_turn()
 
     def _get_effective_reply_frequency(self) -> float:
-        """返回当前会话生效的回复频率。"""
-        talk_value = max(
-            0.01,
-            float(
-                ChatConfigUtils.get_talk_value(
-                    self.session_id,
-                    is_group_chat=self.chat_stream.is_group_session,
-                )
-            ),
+        """返回当前会话生效的回复频率（允许为 0 表示完全静默）。"""
+        talk_value = float(
+            ChatConfigUtils.get_talk_value(
+                self.session_id,
+                is_group_chat=self.chat_stream.is_group_session,
+            )
         )
-        return max(0.01, talk_value * self._talk_frequency_adjust)
+        return talk_value * self._talk_frequency_adjust
 
     async def track_reply_effect(
         self,
@@ -442,8 +440,10 @@ class MaisakaHeartFlowChatting:
         return snapshot
 
     def _get_message_trigger_threshold(self) -> int:
-        """根据回复频率折算出触发一轮循环所需的消息数。"""
+        """根据回复频率折算出触发一轮循环所需的消息数（频率为 0 时视为无限大）。"""
         effective_frequency = min(1.0, self._get_effective_reply_frequency())
+        if effective_frequency <= 0:
+            return _EFFECTIVELY_INFINITE_THRESHOLD
         return max(1, int(ceil(1.0 / effective_frequency)))
 
     def _get_pending_message_count(self) -> int:
@@ -958,6 +958,12 @@ class MaisakaHeartFlowChatting:
             self._internal_turn_queue.put_nowait("message")
             return
 
+        if self._get_effective_reply_frequency() <= 0:
+            if self._is_expression_learning_due():
+                self._message_turn_scheduled = True
+                self._internal_turn_queue.put_nowait("message")
+            return
+
         trigger_threshold = self._get_message_trigger_threshold()
         if pending_count >= trigger_threshold or self._should_trigger_message_turn_by_idle_compensation(
             pending_count=pending_count,
@@ -1113,18 +1119,25 @@ class MaisakaHeartFlowChatting:
 
         return True
 
-    async def _trigger_expression_learning(self, messages: list[SessionMessage]) -> None:
-        """触发表达方式学习"""
+    def _is_expression_learning_due(self) -> bool:
+        """检查表达学习是否满足触发条件。"""
+        if not self._enable_expression_learning:
+            return False
         pending_count = self._expression_learner.get_pending_count(self.message_cache)
-        if not self._should_trigger_learning(
+        return self._should_trigger_learning(
             enabled=self._enable_expression_learning,
             feature_name="表达学习",
             last_extraction_time=self._last_expression_extraction_time,
             pending_count=pending_count,
             min_messages_for_extraction=self._expression_learner.min_messages_for_extraction,
-        ):
+        )
+
+    async def _trigger_expression_learning(self, messages: list[SessionMessage]) -> None:
+        """触发表达方式学习"""
+        if not self._is_expression_learning_due():
             return
 
+        pending_count = self._expression_learner.get_pending_count(self.message_cache)
         self._last_expression_extraction_time = time.time()
         logger.info(
             f"{self.log_prefix} 触发表达方式学习: "

--- a/src/maisaka/runtime.py
+++ b/src/maisaka/runtime.py
@@ -1039,6 +1039,13 @@ class MaisakaHeartFlowChatting:
         self._pending_wait_tool_call_id = None
         self._cancel_wait_timeout_task()
 
+    def _transition_to_idle(self) -> None:
+        """将 agent 重置为待机状态并更新阶段信息，幂等。"""
+        if self._agent_state == self._STATE_RUNNING:
+            self._agent_state = self._STATE_STOP
+        if self._running:
+            self._update_stage_status("等待消息", "本轮处理结束")
+
     def _enter_wait_state(self, seconds: Optional[float] = None, tool_call_id: Optional[str] = None) -> None:
         """切换到等待状态。"""
         self._agent_state = self._STATE_WAIT


### PR DESCRIPTION
## 问题

WebUI 中将群聊 `talk_value` 配置为 0 后，消息仍会频繁进入 Timing Gate 产生 LLM 调用。根因有三个：

1. `_get_effective_reply_frequency()` 将频率钳位在 `max(0.01, ...)`，导致 talk_value=0 实际生效为 0.01
2. 空闲补偿机制 `_should_trigger_message_turn_by_idle_compensation()` 可将空窗时间折算为等效消息数，绕过阈值
3. **`get_talk_value()` 中 `time=""`（WebUI 显示「全天」）被 `parse_range()` 丢弃，导致会话专属规则静默失效**。用户将群聊频率设为 0，但因规则被跳过而回退到基础 `talk_value=0.8`，频率检查 `<=0` 从未触发

## 修复

- 移除 `_get_effective_reply_frequency()` 和 `adjust_talk_frequency()` 中的 0.01 钳位
- `_get_message_trigger_threshold()` 频率为 0 时返回 `_EFFECTIVELY_INFINITE_THRESHOLD` 避免除零
- `_schedule_message_turn()` 频率为 0 时仅在学习条件满足时调度 turn
- `run_loop()` 频率为 0 且非强制触发时，学习完成后跳过 Timing Gate 和 Planner
- **`_is_time_in_range()`: time 为空视为全时段生效**，修复 WebUI「全天」规则被跳过的问题
- 提取 `_is_expression_learning_due()` 消除调度与执行阶段的守卫重复
- 提取 `_transition_to_idle()` 消除 `run_loop` 两处相同的状态重置代码
- @强制回复不受 `talk_value=0` 影响

## 测试

- 现有 12 个 timing gate 测试全部通过
- ruff 检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增完全静默模式，当对话频率设置为零时，Agent 可正确进入静默状态。

* **改进**
  * 优化消息处理流程，缓存消息检测时跳过不必要的处理步骤，提升效率。
  * 重构对话时间触发逻辑，统一处理时间范围判断。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mai-with-u/MaiBot/pull/1667)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->