### PR TITLE
fix(mcp)：兼容向 stdout 写横幅且未实现 list_resource_templates 的 stdio server

### DIFF
--- a/src/mcp_module/connection.py
+++ b/src/mcp_module/connection.py
@@ -40,8 +40,13 @@ try:
     except ImportError:
         from mcp import StdioServerParameters  # type: ignore[attr-defined]
 
-    from mcp.client.stdio import stdio_client
     from mcp.client.streamable_http import streamable_http_client
+    from mcp.shared.exceptions import McpError
+
+    try:
+        from .stdio_filter import tolerant_stdio_client
+    except ImportError:
+        tolerant_stdio_client = None  # type: ignore[assignment]
 
     try:
         from mcp.client.sse import sse_client
@@ -60,9 +65,10 @@ except ImportError:
     ClientSession = None  # type: ignore[assignment,misc]
     StdioServerParameters = None  # type: ignore[assignment,misc]
     mcp_types = None  # type: ignore[assignment]
-    stdio_client = None  # type: ignore[assignment]
     streamable_http_client = None  # type: ignore[assignment]
     sse_client = None  # type: ignore[assignment]
+    tolerant_stdio_client = None  # type: ignore[assignment]
+    McpError = Exception  # type: ignore[assignment,misc]
 
 
 class MCPConnection:
@@ -161,7 +167,7 @@ class MCPConnection:
             tuple[Any, Any]: 读写流对象。
         """
 
-        if StdioServerParameters is None or stdio_client is None:
+        if StdioServerParameters is None or tolerant_stdio_client is None:
             raise RuntimeError("当前环境未安装可用的 MCP stdio 客户端")
         if not self.config.command:
             raise ValueError(f"MCP 服务器 '{self.config.name}' 缺少 stdio command 配置")
@@ -171,7 +177,8 @@ class MCPConnection:
             args=self.config.args,
             env=self.config.env,
         )
-        return await self._exit_stack.enter_async_context(stdio_client(params))
+        # 容错包装：丢弃违规 server 写到 stdout 的非 JSON 噪声以防 initialize 失败；详见 stdio_filter.py。
+        return await self._exit_stack.enter_async_context(tolerant_stdio_client(params))
 
     async def _connect_streamable_http(self) -> tuple[Any, Any]:
         """建立 Streamable HTTP 传输连接。
@@ -383,9 +390,19 @@ class MCPConnection:
         self.tools = await self._list_tools() if self.supports_tools() else []
         self.prompts = await self._list_prompts() if self.supports_prompts() else []
         self.resources = await self._list_resources() if self.supports_resources() else []
-        self.resource_templates = (
-            await self._list_resource_templates() if self.supports_resources() else []
-        )
+        self.resource_templates = []
+        if self.supports_resources():
+            # list_resource_templates 在 MCP spec 中是 OPTIONAL，部分 server（如 moegirl-wiki-mcp）
+            # 仅实现 list_resources，遇到 METHOD_NOT_FOUND 时按空集合处理避免毁掉整个连接。
+            try:
+                self.resource_templates = await self._list_resource_templates()
+            except McpError as exc:
+                if exc.error.code != mcp_types.METHOD_NOT_FOUND:
+                    raise
+                console.print(
+                    f"[warning]⚠️ MCP 服务器 '{self.config.name}' 未实现 "
+                    f"list_resource_templates，按空集合处理[/warning]"
+                )
 
     def supports_tools(self) -> bool:
         """判断服务端是否声明支持 Tools。

--- a/src/mcp_module/stdio_filter.py
+++ b/src/mcp_module/stdio_filter.py
@@ -1,0 +1,170 @@
+"""容错版 MCP stdio 客户端包装。
+
+MCP stdio 协议规定 stdout 仅可承载 JSON-RPC 消息，所有日志/状态/调试输出
+必须写到 stderr（参见 https://modelcontextprotocol.io/specification/server/transports#stdio）。
+
+但部分第三方 MCP 服务器（典型如 ``moegirl-wiki-mcp`` 等 npm 包）会把启动横幅
+直接打印到 stdout，污染协议流。``mcp.client.stdio.stdio_client`` 遇到这类
+非 JSON 行时会把 ``Exception`` 对象写回 read_stream，使 ``ClientSession``
+将其视为致命错误并终止 ``initialize`` 协商。
+
+本模块提供 :func:`tolerant_stdio_client`：行为与官方 ``stdio_client`` 完全一致，
+唯一差异在于在解析层先按 JSON 起始符做廉价预筛、解析失败的行只记录告警后丢弃，
+不向上层流注入异常。这样违规服务器仍可正常握手，合规服务器行为不变。
+
+注意：本模块依赖 ``mcp.client.stdio`` 中的若干非公开符号
+(``_create_platform_compatible_process``、``_get_executable_command``、
+``_terminate_process_tree``、``PROCESS_TERMINATION_TIMEOUT``)。
+SDK 升级若调整这些符号，此处会在首次连接时立刻报错暴露问题。
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TextIO
+import logging
+import sys
+
+from anyio.streams.text import TextReceiveStream
+import anyio
+import anyio.lowlevel
+
+from mcp import types
+from mcp.client.stdio import (
+    PROCESS_TERMINATION_TIMEOUT,
+    StdioServerParameters,
+    _create_platform_compatible_process,
+    _get_executable_command,
+    _terminate_process_tree,
+    get_default_environment,
+)
+from mcp.shared.message import SessionMessage
+
+logger = logging.getLogger(__name__)
+
+_MAX_GARBAGE_PREVIEW = 200
+
+
+@asynccontextmanager
+async def tolerant_stdio_client(
+    server: StdioServerParameters,
+    errlog: TextIO = sys.stderr,
+):
+    """官方 ``stdio_client`` 的容错替代实现。
+
+    Args:
+        server: stdio 子进程启动参数。
+        errlog: 子进程 stderr 透传目标，默认 ``sys.stderr``。
+
+    Yields:
+        tuple[Any, Any]: ``(read_stream, write_stream)``，与官方实现接口一致。
+
+    实现差异：
+        - 仅对以 ``{`` 或 ``[`` 开头的非空行尝试 JSON-RPC 解析。
+        - 预筛失败或 pydantic 校验失败的行通过 ``logger.warning`` 记录后直接丢弃，
+          不会以 ``Exception`` 对象的形式注入 read_stream。
+        - 进程生命周期、stdin 关闭流程、平台兼容的进程组终止策略与官方实现完全一致。
+    """
+
+    read_stream_writer, read_stream = anyio.create_memory_object_stream(0)
+    write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
+
+    try:
+        command = _get_executable_command(server.command)
+        process = await _create_platform_compatible_process(
+            command=command,
+            args=server.args,
+            env=(
+                {**get_default_environment(), **server.env}
+                if server.env is not None
+                else get_default_environment()
+            ),
+            errlog=errlog,
+            cwd=server.cwd,
+        )
+    except OSError:
+        await read_stream.aclose()
+        await write_stream.aclose()
+        await read_stream_writer.aclose()
+        await write_stream_reader.aclose()
+        raise
+
+    async def stdout_reader() -> None:
+        assert process.stdout, "Opened process is missing stdout"
+        try:
+            async with read_stream_writer:
+                buffer = ""
+                async for chunk in TextReceiveStream(
+                    process.stdout,
+                    encoding=server.encoding,
+                    errors=server.encoding_error_handler,
+                ):
+                    lines = (buffer + chunk).split("\n")
+                    buffer = lines.pop()
+                    for line in lines:
+                        stripped = line.strip()
+                        if not stripped:
+                            continue
+                        # JSON-RPC 2.0 消息总是 JSON 对象（'{'）或批量数组（'['）；
+                        # 任何其他起始字符都可以无歧义判定为协议违规噪声。
+                        if stripped[0] not in ("{", "["):
+                            logger.warning(
+                                "Dropped non-JSON line from MCP stdio server "
+                                "(violates MCP spec — stdout must carry JSON-RPC only): %r",
+                                line[:_MAX_GARBAGE_PREVIEW],
+                            )
+                            continue
+                        try:
+                            message = types.JSONRPCMessage.model_validate_json(line)
+                        except Exception:
+                            logger.warning(
+                                "Dropped malformed JSON-RPC line from MCP stdio server: %r",
+                                line[:_MAX_GARBAGE_PREVIEW],
+                            )
+                            continue
+                        await read_stream_writer.send(SessionMessage(message))
+        except anyio.ClosedResourceError:
+            await anyio.lowlevel.checkpoint()
+
+    async def stdin_writer() -> None:
+        assert process.stdin, "Opened process is missing stdin"
+        try:
+            async with write_stream_reader:
+                async for session_message in write_stream_reader:
+                    json_payload = session_message.message.model_dump_json(
+                        by_alias=True, exclude_none=True
+                    )
+                    await process.stdin.send(
+                        (json_payload + "\n").encode(
+                            encoding=server.encoding,
+                            errors=server.encoding_error_handler,
+                        )
+                    )
+        except anyio.ClosedResourceError:
+            await anyio.lowlevel.checkpoint()
+
+    async with (
+        anyio.create_task_group() as tg,
+        process,
+    ):
+        tg.start_soon(stdout_reader)
+        tg.start_soon(stdin_writer)
+        try:
+            yield read_stream, write_stream
+        finally:
+            if process.stdin:
+                try:
+                    await process.stdin.aclose()
+                except Exception:
+                    pass
+            try:
+                with anyio.fail_after(PROCESS_TERMINATION_TIMEOUT):
+                    await process.wait()
+            except TimeoutError:
+                await _terminate_process_tree(process)
+            except ProcessLookupError:
+                pass
+            await read_stream.aclose()
+            await write_stream.aclose()
+            await read_stream_writer.aclose()
+            await write_stream_reader.aclose()


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:
7. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增对 stdio 传输的容错包装器，提高与子进程通信的稳定性并保证资源清理。

* **错误修复**
  * 功能发现时对缺失功能改为记录警告而非中断流程，避免连接中断。
  * 对非 JSON-RPC 格式或损坏的输出更宽容，丢弃异常行并记录警告，提升鲁棒性。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mai-with-u/MaiBot/pull/1671)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->