### PR TITLE
fix: 修复自动审核表达式在 WebUI 中错误显示为"人工"

### DIFF
--- a/src/webui/routers/expression.py
+++ b/src/webui/routers/expression.py
@@ -368,7 +368,7 @@ def expression_to_response(expression: Expression, db_session: Optional[Any] = N
         create_date=create_date,
         checked=expression.checked,
         rejected=expression.rejected,
-        modified_by=expression.modified_by.value if expression.modified_by else None,
+        modified_by=expression.modified_by.value.lower() if expression.modified_by else None,
     )
 
 


### PR DESCRIPTION
## Summary
- 修复自动审核（AI）表达式在 WebUI 中错误显示为"人工"的问题
- 根因：`ModifiedBy` 枚举值为大写 `"AI"`/`"USER"`，序列化时未转小写，前端 `getModifierBadge` 比较的是小写 `'ai'`，导致所有表达式落入 else 分支一律显示"人工"

## Fix
`src/webui/routers/expression.py:168` — 序列化时 `.value` 追加 `.lower()` 转为小写

## Test plan
- [x] WebUI 表达式审核页面，AI 自动审核的表达式应显示 `AI` 标记而非 `人工`
- [x] 手动审核的表达式仍正确显示 `人工` 标记

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes（错误修复）**
  * 修改了表达式响应中"修改者"字段的格式，现已统一为小写显示。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mai-with-u/MaiBot/pull/1674)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->