### PR TITLE
fix: WebUI 封禁表情包后未从内存列表移除

### DIFF
--- a/src/emoji_system/emoji_manager.py
+++ b/src/emoji_system/emoji_manager.py
@@ -738,6 +738,7 @@ class EmojiManager:
                     # 按 file_hash 从内存列表移除（MaiEmoji 未定义 __eq__，
                     # 依赖身份比较的 remove 在跨实例调用时静默失败）
                     self.emojis = [e for e in self.emojis if e.file_hash != emoji.file_hash]
+                    self._emoji_num = len(self.emojis)
                     logger.info(f"[封禁表情包] 成功封禁表情包: {emoji.file_name}")
                 else:
                     logger.warning(f"[封禁表情包] 未找到表情包记录: {emoji.file_name}")

--- a/src/emoji_system/emoji_manager.py
+++ b/src/emoji_system/emoji_manager.py
@@ -735,8 +735,9 @@ class EmojiManager:
                 if image_record := session.exec(statement).first():
                     image_record.is_banned = True
                     session.add(image_record)
-                    if emoji in self.emojis:
-                        self.emojis.remove(emoji)
+                    # 按 file_hash 从内存列表移除（MaiEmoji 未定义 __eq__，
+                    # 依赖身份比较的 remove 在跨实例调用时静默失败）
+                    self.emojis = [e for e in self.emojis if e.file_hash != emoji.file_hash]
                     logger.info(f"[封禁表情包] 成功封禁表情包: {emoji.file_name}")
                 else:
                     logger.warning(f"[封禁表情包] 未找到表情包记录: {emoji.file_name}")

--- a/src/webui/routers/emoji/routes.py
+++ b/src/webui/routers/emoji/routes.py
@@ -254,6 +254,7 @@ async def update_emoji(
                 emoji_manager.emojis = [
                     e for e in emoji_manager.emojis if e.file_hash != emoji.image_hash
                 ]
+                emoji_manager._emoji_num = len(emoji_manager.emojis)
 
             logger.info(f"表情包已更新: ID={emoji_id}, 字段: {list(update_data.keys())}")
 
@@ -455,6 +456,7 @@ async def ban_emoji(emoji_id: int, maibot_session: Optional[str] = Cookie(None))
             emoji_manager.emojis = [
                 e for e in emoji_manager.emojis if e.file_hash != emoji.image_hash
             ]
+            emoji_manager._emoji_num = len(emoji_manager.emojis)
 
             logger.info(f"表情包已禁用: ID={emoji_id}")
             return EmojiUpdateResponse(success=True, message="表情包禁用成功", data=emoji_to_response(emoji))

--- a/src/webui/routers/emoji/routes.py
+++ b/src/webui/routers/emoji/routes.py
@@ -246,6 +246,15 @@ async def update_emoji(
                 emoji.register_time = update_data["register_time"]
 
             session.add(emoji)
+
+            # 若通过更新接口封禁表情包，同步从内存列表移除
+            if update_data.get("is_banned"):
+                from src.emoji_system.emoji_manager import emoji_manager
+
+                emoji_manager.emojis = [
+                    e for e in emoji_manager.emojis if e.file_hash != emoji.image_hash
+                ]
+
             logger.info(f"表情包已更新: ID={emoji_id}, 字段: {list(update_data.keys())}")
 
             return EmojiUpdateResponse(
@@ -439,6 +448,13 @@ async def ban_emoji(emoji_id: int, maibot_session: Optional[str] = Cookie(None))
             emoji.is_banned = True
             emoji.is_registered = False
             session.add(emoji)
+
+            # 同步从内存列表移除，确保插件等消费者不会继续选中已封禁表情包
+            from src.emoji_system.emoji_manager import emoji_manager
+
+            emoji_manager.emojis = [
+                e for e in emoji_manager.emojis if e.file_hash != emoji.image_hash
+            ]
 
             logger.info(f"表情包已禁用: ID={emoji_id}")
             return EmojiUpdateResponse(success=True, message="表情包禁用成功", data=emoji_to_response(emoji))


### PR DESCRIPTION
## Summary
- WebUI 封禁/更新接口仅修改了数据库 `is_banned` 字段，未同步移除 `emoji_manager.emojis` 内存列表中的对应项，导致插件（如 emoji_text_selector）在服务重启前仍能选中已封禁的表情包发送
- `emoji_manager.ban_emoji()` 使用 `emoji in self.emojis` 依赖 `MaiEmoji.__eq__`，但该类未定义 `__eq__`，导致跨实例调用时 `remove` 静默失败

## Changes
- `emoji_manager.ban_emoji()`: 改为按 `file_hash` 过滤列表，不再依赖身份比较
- WebUI `POST /{emoji_id}/ban`: 数据库写入后同步过滤内存列表
- WebUI `PATCH /{emoji_id}`: 当 `is_banned=True` 时同步过滤内存列表

## Test Plan
- [ ] 通过 WebUI 封禁一个表情包后，插件 `select_emoji` 不再发送该表情包
- [ ] 通过 WebUI 更新接口设置 `is_banned=true` 后，效果同上
- [ ] 重启服务后封禁状态持久化正确（数据库层已正确，未被修改）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了表情符号禁用与更新流程：被标记为禁用的表情符号会同时从内存缓存中清除并刷新计数，确保禁用操作即时生效并提升系统一致性与稳定性。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mai-with-u/MaiBot/pull/1681)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->