### PR TITLE
feat: A_Memorix自动写回可被插件拦截的hook

### DIFF
--- a/src/plugin_runtime/hook_catalog.py
+++ b/src/plugin_runtime/hook_catalog.py
@@ -24,6 +24,7 @@ def _get_builtin_hook_spec_registrars() -> List[HookSpecRegistrar]:
     from src.learners.expression_learner import register_expression_hook_specs
     from src.learners.jargon_miner import register_jargon_hook_specs
     from src.maisaka.chat_loop_service import register_maisaka_hook_specs
+    from src.services.memory_flow_service import register_memory_automation_hook_specs
     from src.services.send_service import register_send_service_hook_specs
 
     return [
@@ -31,6 +32,7 @@ def _get_builtin_hook_spec_registrars() -> List[HookSpecRegistrar]:
         register_emoji_hook_specs,
         register_jargon_hook_specs,
         register_expression_hook_specs,
+        register_memory_automation_hook_specs,
         register_send_service_hook_specs,
         register_maisaka_hook_specs,
     ]

--- a/src/services/memory_flow_service.py
+++ b/src/services/memory_flow_service.py
@@ -11,16 +11,98 @@ import time
 
 from json_repair import repair_json
 
-from src.services import memory_service as memory_service_module
 from src.chat.utils.utils import is_bot_self
 from src.common.logger import get_logger
 from src.common.message_repository import count_messages, find_messages
 from src.config.config import global_config
 from src.person_info.person_info import Person, get_person_id, store_person_memory_from_answer
-from src.services.memory_service import memory_service
+from src.plugin_runtime.hook_payloads import serialize_session_message
+from src.plugin_runtime.hook_schema_utils import build_object_schema
+from src.plugin_runtime.host.hook_spec_registry import HookSpec, HookSpecRegistry
+from src.services import memory_service as memory_service_module
 from src.services.llm_service import LLMServiceClient
+from src.services.memory_service import memory_service
 
 logger = get_logger("memory_flow_service")
+
+
+def register_memory_automation_hook_specs(registry: HookSpecRegistry) -> List[HookSpec]:
+    """注册长期记忆自动化内置 Hook 规格"""
+
+    return registry.register_hook_specs(
+        [
+            HookSpec(
+                name="memory.automation.before_enqueue",
+                description="在自动记忆写回任务入队前触发，可中止本次人物事实或聊天摘要写回",
+                parameters_schema=build_object_schema(
+                    {
+                        "message": {
+                            "type": "object",
+                            "description": "触发写回的序列化 SessionMessage",
+                        },
+                        "service_name": {
+                            "type": "string",
+                            "description": "任务名称：person_fact_writeback 或 chat_summary_writeback",
+                        },
+                        "session_id": {
+                            "type": "string",
+                            "description": "当前会话 ID",
+                        },
+                        "user_id": {
+                            "type": "string",
+                            "description": "当前私聊用户 ID",
+                        },
+                        "group_id": {
+                            "type": "string",
+                            "description": "当前群号",
+                        },
+                    },
+                    required=["message", "service_name", "session_id", "user_id", "group_id"],
+                ),
+                default_timeout_ms=5000,
+                allow_abort=True,
+                allow_kwargs_mutation=False,
+            ),
+        ]
+    )
+
+
+def _resolve_message_session_id(message: Any) -> str:
+    return str(
+        getattr(message, "session_id", "")
+        or getattr(getattr(message, "session", None), "session_id", "")
+        or ""
+    ).strip()
+
+
+def _extract_message_user_id(message: Any) -> str:
+    return str(
+        getattr(getattr(message, "session", None), "user_id", "")
+        or getattr(message, "user_id", "")
+        or ""
+    ).strip()
+
+
+def _extract_message_group_id(message: Any) -> str:
+    return str(
+        getattr(getattr(message, "session", None), "group_id", "")
+        or getattr(message, "group_id", "")
+        or ""
+    ).strip()
+
+
+def _serialize_message_for_hook(message: Any) -> dict[str, Any]:
+    try:
+        return serialize_session_message(message)
+    except Exception as exc:
+        logger.debug(f"自动记忆写回 Hook 消息序列化失败，使用最小载荷: {exc}")
+        return {
+            "message_id": str(getattr(message, "message_id", "") or "").strip(),
+            "session_id": _resolve_message_session_id(message),
+            "processed_plain_text": str(getattr(message, "processed_plain_text", "") or ""),
+            "user_id": _extract_message_user_id(message),
+            "group_id": _extract_message_group_id(message),
+        }
 
 
 class PersonFactWritebackService:
@@ -589,8 +671,44 @@ class MemoryAutomationService:
     async def on_message_sent(self, message: Any) -> None:
         if not self._started:
             await self.start()
-        await self.fact_writeback.enqueue(message)
-        await self.chat_summary_writeback.enqueue(message)
+        if await self._can_enqueue("person_fact_writeback", message):
+            await self.fact_writeback.enqueue(message)
+        if await self._can_enqueue("chat_summary_writeback", message):
+            await self.chat_summary_writeback.enqueue(message)
+
+    async def _can_enqueue(self, service_name: str, message: Any) -> bool:
+        """在写回任务入队前触发 Hook，允许插件暂停新任务。"""
+
+        session_id = _resolve_message_session_id(message)
+        user_id = _extract_message_user_id(message)
+        group_id = _extract_message_group_id(message)
+        try:
+            hook_result = await self._get_runtime_manager().invoke_hook(
+                "memory.automation.before_enqueue",
+                message=_serialize_message_for_hook(message),
+                service_name=service_name,
+                session_id=session_id,
+                user_id=user_id,
+                group_id=group_id,
+            )
+        except Exception as exc:
+            logger.warning(f"自动记忆写回入队 Hook 调用失败，继续入队: service={service_name} error={exc}")
+            return True
+
+        if not hook_result.aborted:
+            return True
+
+        logger.info(
+            f"自动记忆写回入队被 Hook 中止: service={service_name} session_id={session_id or 'unknown'} "
+            f"group_id={group_id or 'private/global'}"
+        )
+        return False
+
+    @staticmethod
+    def _get_runtime_manager() -> Any:
+        from src.plugin_runtime.integration import get_plugin_runtime_manager
+
+        return get_plugin_runtime_manager()
 
 
 memory_automation_service = MemoryAutomationService()


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [x] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）: 无，本次仅增 memory.automation.before_enqueue Hook，不改变现有自动写回默认行为；未注册处理器或处理器未中止时，人物事实写回和聊天摘要写回仍按原逻辑入队执行。
7. 请简要说明本次更新的内容和目的：新增 A_Memorix 自动写回入队前 Hook：memory.automation.before_enqueue，允许插件在人物事实写回、聊天摘要写回任务进入队列前进行拦截。主要用于睡眠、勿扰、低功耗等状态下暂停新触发的记忆整理任务，避免不必要的 LLM / A_Memorix 调用，同时不影响已经执行中的任务，降低副作用风险



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 内存自动化功能现已支持插件Hook机制，允许外部插件在内存操作入队前进行拦截和自定义处理。
  * 新增Hook规格注册机制，支持对人物信息记录和聊天摘要等内存写回操作进行细粒度控制。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mai-with-u/MaiBot/pull/1683)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->