### PR TITLE
fix: 修复快速审核结构化错误导致的 React #31

### DIFF
--- a/dashboard/src/lib/__tests__/api-error.test.ts
+++ b/dashboard/src/lib/__tests__/api-error.test.ts
@@ -42,4 +42,8 @@ describe('formatApiError', () => {
   it('falls back when response has no usable message', () => {
     expect(formatApiError({}, '默认错误')).toBe('默认错误')
   })
+
+  it('uses message when detail is empty', () => {
+    expect(formatApiError({ detail: '', message: '权限不足' }, '默认错误')).toBe('权限不足')
+  })
 })

--- a/dashboard/src/lib/__tests__/api-error.test.ts
+++ b/dashboard/src/lib/__tests__/api-error.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatApiError } from '../api-error'
+
+describe('formatApiError', () => {
+  it('returns string detail directly', () => {
+    expect(formatApiError({ detail: '请求失败' }, '默认错误')).toBe('请求失败')
+  })
+
+  it('formats FastAPI validation detail arrays as text', () => {
+    const error = formatApiError(
+      {
+        detail: [
+          {
+            type: 'int_parsing',
+            loc: ['query', 'exclude_ids', 0],
+            msg: 'Input should be a valid integer',
+            input: 'abc',
+          },
+        ],
+      },
+      '获取审核列表失败',
+    )
+
+    expect(error).toBe('query.exclude_ids.0: Input should be a valid integer')
+  })
+
+  it('formats object details without returning an object', () => {
+    const error = formatApiError(
+      {
+        detail: {
+          loc: ['body', 'items'],
+          msg: 'Field required',
+        },
+      },
+      '批量审核失败',
+    )
+
+    expect(error).toBe('body.items: Field required')
+  })
+
+  it('falls back when response has no usable message', () => {
+    expect(formatApiError({}, '默认错误')).toBe('默认错误')
+  })
+})

--- a/dashboard/src/lib/api-error.ts
+++ b/dashboard/src/lib/api-error.ts
@@ -1,0 +1,70 @@
+type ApiErrorDetail = {
+  loc?: unknown
+  msg?: unknown
+  message?: unknown
+  type?: unknown
+}
+
+function formatLocation(loc: unknown): string {
+  if (Array.isArray(loc)) {
+    return loc.map((item) => String(item)).join('.')
+  }
+  if (loc === null || loc === undefined || loc === '') {
+    return ''
+  }
+  return String(loc)
+}
+
+function formatDetailItem(item: unknown): string {
+  if (typeof item === 'string') {
+    return item
+  }
+
+  if (item && typeof item === 'object') {
+    const detail = item as ApiErrorDetail
+    const message = detail.msg ?? detail.message
+    const location = formatLocation(detail.loc)
+    if (message !== null && message !== undefined && message !== '') {
+      return location ? `${location}: ${String(message)}` : String(message)
+    }
+  }
+
+  try {
+    return JSON.stringify(item)
+  } catch {
+    return String(item)
+  }
+}
+
+export function formatApiError(errorData: unknown, fallback: string): string {
+  if (!errorData) {
+    return fallback
+  }
+
+  if (typeof errorData === 'string') {
+    return errorData || fallback
+  }
+
+  if (typeof errorData !== 'object') {
+    return String(errorData) || fallback
+  }
+
+  const data = errorData as { detail?: unknown; message?: unknown; error?: unknown }
+  const rawMessage = data.detail ?? data.message ?? data.error
+
+  if (Array.isArray(rawMessage)) {
+    const message = rawMessage.map(formatDetailItem).filter(Boolean).join('; ')
+    return message || fallback
+  }
+
+  if (rawMessage && typeof rawMessage === 'object') {
+    const message = formatDetailItem(rawMessage)
+    return message || fallback
+  }
+
+  if (rawMessage !== null && rawMessage !== undefined && rawMessage !== '') {
+    return String(rawMessage)
+  }
+
+  return fallback
+}

--- a/dashboard/src/lib/api-error.ts
+++ b/dashboard/src/lib/api-error.ts
@@ -5,6 +5,7 @@ type ApiErrorDetail = {
   type?: unknown
 }
 
+/** 将 FastAPI 校验错误中的 loc 路径转换为可读字段路径。 */
 function formatLocation(loc: unknown): string {
   if (Array.isArray(loc)) {
     return loc.map((item) => String(item)).join('.')
@@ -15,6 +16,7 @@ function formatLocation(loc: unknown): string {
   return String(loc)
 }
 
+/** 将单个错误详情转换为可安全渲染的字符串。 */
 function formatDetailItem(item: unknown): string {
   if (typeof item === 'string') {
     return item
@@ -36,6 +38,20 @@ function formatDetailItem(item: unknown): string {
   }
 }
 
+/** 判断候选错误字段是否包含可展示的信息。 */
+function hasUsableMessage(value: unknown): boolean {
+  if (value === null || value === undefined || value === '') {
+    return false
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0
+  }
+  return true
+}
+
+/**
+ * 将后端错误响应统一转换为字符串，避免将对象直接传给 React 渲染。
+ */
 export function formatApiError(errorData: unknown, fallback: string): string {
   if (!errorData) {
     return fallback
@@ -50,7 +66,7 @@ export function formatApiError(errorData: unknown, fallback: string): string {
   }
 
   const data = errorData as { detail?: unknown; message?: unknown; error?: unknown }
-  const rawMessage = data.detail ?? data.message ?? data.error
+  const rawMessage = [data.detail, data.message, data.error].find(hasUsableMessage)
 
   if (Array.isArray(rawMessage)) {
     const message = rawMessage.map(formatDetailItem).filter(Boolean).join('; ')

--- a/dashboard/src/lib/expression-api.ts
+++ b/dashboard/src/lib/expression-api.ts
@@ -2,6 +2,7 @@
  * 表达方式管理 API
  */
 import { fetchWithAuth } from '@/lib/fetch-with-auth'
+import { formatApiError } from '@/lib/api-error'
 import type {
   BatchReviewItem,
   BatchReviewResponse,
@@ -46,7 +47,7 @@ export async function getChatList(params: { include_legacy?: boolean } = {}): Pr
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '获取聊天列表失败',
+        error: formatApiError(errorData, '获取聊天列表失败'),
       }
     } catch {
       return {
@@ -92,7 +93,7 @@ export async function getExpressionChatTargets(
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '获取导入目标聊天流失败',
+        error: formatApiError(errorData, '获取导入目标聊天流失败'),
       }
     } catch {
       return {
@@ -137,7 +138,7 @@ export async function getExpressionGroups(
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '获取表达互通组失败',
+        error: formatApiError(errorData, '获取表达互通组失败'),
       }
     } catch {
       return {
@@ -196,7 +197,7 @@ export async function getExpressionList(params: {
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '获取表达方式列表失败',
+        error: formatApiError(errorData, '获取表达方式列表失败'),
       }
     } catch {
       return {
@@ -244,7 +245,7 @@ export async function exportExpressions(params: {
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '导出表达方式失败',
+        error: formatApiError(errorData, '导出表达方式失败'),
       }
     } catch {
       return {
@@ -285,7 +286,7 @@ export async function importExpressions(params: {
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '导入表达方式失败',
+        error: formatApiError(errorData, '导入表达方式失败'),
       }
     } catch {
       return {
@@ -325,7 +326,7 @@ export async function clearExpressions(params: {
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '清除表达方式失败',
+        error: formatApiError(errorData, '清除表达方式失败'),
       }
     } catch {
       return {
@@ -365,7 +366,7 @@ export async function previewLegacyExpressionImport(params: {
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '预览旧版导入失败',
+        error: formatApiError(errorData, '预览旧版导入失败'),
       }
     } catch {
       return {
@@ -407,7 +408,7 @@ export async function previewLegacyExpressionImportFile(
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '预览旧版导入失败',
+        error: formatApiError(errorData, '预览旧版导入失败'),
       }
     } catch {
       return {
@@ -448,7 +449,7 @@ export async function importLegacyExpressions(params: {
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '旧版导入失败',
+        error: formatApiError(errorData, '旧版导入失败'),
       }
     } catch {
       return {
@@ -485,7 +486,7 @@ export async function getExpressionDetail(expressionId: number): Promise<ApiResp
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '获取表达方式详情失败',
+        error: formatApiError(errorData, '获取表达方式详情失败'),
       }
     } catch {
       return {
@@ -533,7 +534,7 @@ export async function createExpression(
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '创建表达方式失败',
+        error: formatApiError(errorData, '创建表达方式失败'),
       }
     } catch {
       return {
@@ -582,7 +583,7 @@ export async function updateExpression(
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '更新表达方式失败',
+        error: formatApiError(errorData, '更新表达方式失败'),
       }
     } catch {
       return {
@@ -627,7 +628,7 @@ export async function deleteExpression(expressionId: number): Promise<ApiRespons
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '删除表达方式失败',
+        error: formatApiError(errorData, '删除表达方式失败'),
       }
     } catch {
       return {
@@ -673,7 +674,7 @@ export async function batchDeleteExpressions(expressionIds: number[]): Promise<A
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '批量删除表达方式失败',
+        error: formatApiError(errorData, '批量删除表达方式失败'),
       }
     } catch {
       return {
@@ -719,7 +720,7 @@ export async function getExpressionStats(params: { include_legacy?: boolean } = 
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '获取统计数据失败',
+        error: formatApiError(errorData, '获取统计数据失败'),
       }
     } catch {
       return {
@@ -763,7 +764,7 @@ export async function getReviewStats(): Promise<ApiResponse<ReviewStats>> {
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '获取审核统计失败',
+        error: formatApiError(errorData, '获取审核统计失败'),
       }
     } catch {
       return {
@@ -816,7 +817,7 @@ export async function getReviewList(params: {
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '获取审核列表失败',
+        error: formatApiError(errorData, '获取审核列表失败'),
       }
     } catch {
       return {
@@ -863,7 +864,7 @@ export async function batchReviewExpressions(
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '批量审核失败',
+        error: formatApiError(errorData, '批量审核失败'),
       }
     } catch {
       return {
@@ -909,7 +910,7 @@ export async function getExpressionReviewLogs(params: {
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '获取 AI 审核记录失败',
+        error: formatApiError(errorData, '获取 AI 审核记录失败'),
       }
     } catch {
       return {
@@ -945,7 +946,7 @@ export async function approveExpressionReviewLog(
       const errorData = await response.json()
       return {
         success: false,
-        error: errorData.detail || errorData.message || '恢复表达方式失败',
+        error: formatApiError(errorData, '恢复表达方式失败'),
       }
     } catch {
       return {


### PR DESCRIPTION
## 问题说明

在 WebUI 的“表达方式 / 快速审核”功能中，当后端接口返回 FastAPI/Pydantic 的校验错误对象时，前端会把该对象直接作为 Toast 文案渲染，最终触发 `Minified React error #31`，页面进入错误边界。

典型报错信息如下：

```text
页面出现了问题
应用程序遇到了意外错误。您可以尝试刷新页面或返回首页。
Error: Minified React error #31; visit https://react.dev/errors/31?args[]=object%20with%20keys%20%7Btype%2C%20loc%2C%20msg%2C%20input%7D for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
```

## 根因

`dashboard/src/lib/expression-api.ts` 在处理非 2xx 响应时，原先直接使用：

```ts
error: errorData.detail || errorData.message || '获取审核列表失败'
```

当 `detail` 为 FastAPI/Pydantic 返回的校验错误数组或对象时，后续 Toast `description` 收到的是对象而不是字符串，React 无法直接渲染普通对象，因此触发报错。

## 修复内容

- 新增 `formatApiError`，统一将后端错误响应转换为可展示字符串。
- 兼容字符串、FastAPI/Pydantic 校验错误数组、普通对象和兜底文案。
- 当 `detail` 为空字符串时，继续回退到 `message` 或 `error`，避免丢失后端原始错误信息。
- 将表达方式管理相关 API 的错误处理统一切换到该工具函数。
- 新增单元测试覆盖上述典型场景。

## 测试

- `npm run test -- src/lib/__tests__/api-error.test.ts --run`
- `npm run build`