### PR TITLE
fix(A_memorix)：为人物画像添加可调节的最大token数量限制

### DIFF
--- a/src/A_memorix/CONFIG_REFERENCE.md
+++ b/src/A_memorix/CONFIG_REFERENCE.md
@@ -85,6 +85,7 @@ refresh_interval_minutes = 30
 active_window_hours = 72
 max_refresh_per_cycle = 50
 top_k_evidence = 12
+evidence_classification_max_tokens = 1200
 
 [memory]
 enabled = true
@@ -295,6 +296,7 @@ chats = ["group:123", "user:456", "stream:abc"]
 - `person_profile.active_window_hours` (默认 `72`)
 - `person_profile.max_refresh_per_cycle` (默认 `50`)
 - `person_profile.top_k_evidence` (默认 `12`)
+- `person_profile.evidence_classification_max_tokens` (默认 `1200`)
 
 ## 7. 记忆演化与回收
 

--- a/src/A_memorix/QUICK_START.md
+++ b/src/A_memorix/QUICK_START.md
@@ -110,6 +110,7 @@ refresh_interval_minutes = 30
 active_window_hours = 72
 max_refresh_per_cycle = 50
 top_k_evidence = 12
+evidence_classification_max_tokens = 1200
 
 [memory]
 enabled = true

--- a/src/A_memorix/config_schema.json
+++ b/src/A_memorix/config_schema.json
@@ -993,6 +993,23 @@
           "max": 200,
           "step": 1,
           "choices": null
+        },
+        "evidence_classification_max_tokens": {
+          "name": "evidence_classification_max_tokens",
+          "type": "integer",
+          "default": 1200,
+          "description": "证据分类输出 token 上限",
+          "label": "证据分类输出上限",
+          "ui_type": "number",
+          "required": false,
+          "hidden": false,
+          "disabled": false,
+          "order": 6,
+          "hint": "控制人物画像证据分类 LLM 调用的最大输出 token 数。",
+          "min": 128,
+          "max": 32768,
+          "step": 1,
+          "choices": null
         }
       }
     },

--- a/src/A_memorix/core/utils/person_profile_service.py
+++ b/src/A_memorix/core/utils/person_profile_service.py
@@ -76,6 +76,14 @@ class PersonProfileService:
                 return default
         return current
 
+    def _profile_classification_max_tokens(self) -> int:
+        """读取人物画像证据分类的最大输出 token 数。"""
+        raw_value = self._cfg("person_profile.evidence_classification_max_tokens", 1200)
+        try:
+            return max(128, int(raw_value or 1200))
+        except (TypeError, ValueError):
+            return 1200
+
     def _build_retriever(self) -> Optional[DualPathRetriever]:
         """按需构建检索器（无依赖时返回 None）。"""
         if not all(
@@ -700,7 +708,7 @@ class PersonProfileService:
                 PROFILE_CLASSIFICATION_REQUEST_TYPE,
                 prompt,
                 temperature=0.1,
-                max_tokens=1200,
+                max_tokens=self._profile_classification_max_tokens(),
             )
         except Exception as exc:
             logger.debug(f"人物画像证据分类模型调用失败: person_id={person_id}, err={exc}")

--- a/src/A_memorix/core/utils/person_profile_service.py
+++ b/src/A_memorix/core/utils/person_profile_service.py
@@ -80,7 +80,7 @@ class PersonProfileService:
         """读取人物画像证据分类的最大输出 token 数。"""
         raw_value = self._cfg("person_profile.evidence_classification_max_tokens", 1200)
         try:
-            return max(128, int(raw_value or 1200))
+            return min(32768, max(128, int(raw_value or 1200)))
         except (TypeError, ValueError):
             return 1200
 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -59,7 +59,7 @@ MODEL_CONFIG_PATH: Path = (CONFIG_DIR / "model_config.toml").resolve().absolute(
 LEGACY_ENV_PATH: Path = (PROJECT_ROOT / ".env").resolve().absolute()
 A_MEMORIX_LEGACY_CONFIG_PATH: Path = (CONFIG_DIR / "a_memorix.toml").resolve().absolute()
 MMC_VERSION: str = "1.0.0-pre.21"
-CONFIG_VERSION: str = "8.12.9"
+CONFIG_VERSION: str = "8.12.10"
 MODEL_CONFIG_VERSION: str = "1.17.0"
 
 logger = get_logger("config")

--- a/src/config/official_configs.py
+++ b/src/config/official_configs.py
@@ -1747,6 +1747,19 @@ class AMemorixPersonProfileConfig(ConfigBase):
     )
     """证据条数"""
 
+    evidence_classification_max_tokens: int = Field(
+        default=1200,
+        ge=128,
+        json_schema_extra={
+            "label": {
+                "zh_CN": "证据分类输出上限",
+                "en_US": "Evidence classification max tokens",
+                "ja_JP": "証拠分類の最大トークン数",
+            },
+        },
+    )
+    """人物画像证据分类最大输出 token 数"""
+
 
 class AMemorixMemoryEvolutionConfig(ConfigBase):
     """A_Memorix 记忆演化配置"""


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [x] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:
7. 请简要说明本次更新的内容和目的：为人物画像添加可调节的最大token数量限制
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 添加可配置参数 person_profile.evidence_classification_max_tokens（默认1200，最小128，最大32768）以限制人物画像证据分类的最大输出 token 数。

* **Documentation**
  * 在配置参考与快速开始示例中加入该配置项说明。

* **Chores**
  * 更新配置版本号以反映变更。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mai-with-u/MaiBot/pull/1708?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->