### PR TITLE
fix(A_memorix): 修复知识导入清单失效逻辑

### DIFF
--- a/pytests/A_memorix_test/test_delete_manifest_invalidation.py
+++ b/pytests/A_memorix_test/test_delete_manifest_invalidation.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.A_memorix.core.runtime.sdk_memory_kernel import SDKMemoryKernel
+
+
+class _DummyImportTaskManager:
+    def __init__(self) -> None:
+        self.sources: list[str] = []
+
+    async def invalidate_manifest_for_sources(self, sources: list[str]) -> dict[str, Any]:
+        self.sources.extend(sources)
+        return {"removed_count": len(sources), "removed_keys": [f"key:{source}" for source in sources]}
+
+
+@pytest.mark.asyncio
+async def test_memory_delete_admin_execute_invalidates_import_manifest(monkeypatch) -> None:
+    kernel = SDKMemoryKernel(plugin_root=Path.cwd(), config={})
+    manager = _DummyImportTaskManager()
+    kernel.import_task_manager = manager  # type: ignore[assignment]
+
+    async def fake_initialize() -> None:
+        return None
+
+    async def fake_execute_delete_action(**kwargs):
+        assert kwargs["mode"] == "source"
+        assert kwargs["selector"] == {"sources": ["web_import:demo.txt"]}
+        return {"success": True, "sources": ["web_import:demo.txt"], "deleted_source_count": 1}
+
+    monkeypatch.setattr(kernel, "initialize", fake_initialize)
+    monkeypatch.setattr(kernel, "_execute_delete_action", fake_execute_delete_action)
+
+    result = await kernel.memory_delete_admin(
+        action="execute",
+        mode="source",
+        selector={"sources": ["web_import:demo.txt"]},
+    )
+
+    assert manager.sources == ["web_import:demo.txt"]
+    assert result["manifest_invalidation"]["removed_count"] == 1

--- a/pytests/A_memorix_test/test_web_import_manager_payloads.py
+++ b/pytests/A_memorix_test/test_web_import_manager_payloads.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
@@ -34,6 +35,13 @@ class _DummyMetadataStore:
 
     def set_relation_vector_state(self, rel_hash: str, state: str) -> None:
         del rel_hash, state
+
+    def get_live_paragraphs_by_source(self, source: str):
+        return [
+            paragraph
+            for paragraph in self.paragraphs
+            if paragraph.get("source") == source and not paragraph.get("is_deleted")
+        ]
 
 
 class _DummyGraphStore:
@@ -103,6 +111,78 @@ def _build_chunk(data) -> ProcessedChunk:
         chunk=ChunkContext(chunk_id="chunk-1", index=0, text="Alice 持有地图"),
         data=data,
     )
+
+
+def _test_manifest_path(name: str) -> Path:
+    path = Path("temp") / "web_import_manager_tests" / name
+    if path.exists():
+        path.unlink()
+    return path
+
+
+def test_manifest_hit_requires_existing_live_source() -> None:
+    manager, metadata_store = _build_manager()
+    manager._manifest_path = _test_manifest_path("manifest_hit.json")
+    manager._manifest_cache = None
+    file_record = ImportFileRecord(file_id="file-1", name="demo.txt", source_kind="paste", input_mode="text")
+    content_hash = "abc123"
+    manager._save_manifest(
+        {
+            "hash:abc123": {
+                "hash": content_hash,
+                "imported": True,
+                "name": "demo.txt",
+                "source_kind": "paste",
+            }
+        }
+    )
+
+    assert manager._is_manifest_hit(file_record, content_hash, "content_hash") is False
+    assert manager._load_manifest() == {}
+
+    metadata_store.paragraphs.append({"source": "web_import:demo.txt", "is_deleted": 0})
+    manager._save_manifest(
+        {
+            "hash:abc123": {
+                "hash": content_hash,
+                "imported": True,
+                "name": "demo.txt",
+                "source_kind": "paste",
+            }
+        }
+    )
+
+    assert manager._is_manifest_hit(file_record, content_hash, "content_hash") is True
+
+
+@pytest.mark.asyncio
+async def test_invalidate_manifest_for_sources_matches_recorded_imported_sources() -> None:
+    manager, _ = _build_manager()
+    manager._manifest_path = _test_manifest_path("invalidate_sources.json")
+    manager._manifest_cache = None
+    manager._save_manifest(
+        {
+            "hash:abc123": {
+                "hash": "abc123",
+                "imported": True,
+                "name": "custom.json",
+                "source_kind": "upload",
+                "sources": ["custom:knowledge"],
+            },
+            "hash:def456": {
+                "hash": "def456",
+                "imported": True,
+                "name": "other.txt",
+                "source_kind": "paste",
+            },
+        }
+    )
+
+    result = await manager.invalidate_manifest_for_sources(["custom:knowledge"])
+
+    assert result["removed_count"] == 1
+    assert result["removed_keys"] == ["hash:abc123"]
+    assert "hash:def456" in manager._load_manifest()
 
 
 @pytest.mark.asyncio

--- a/src/A_memorix/core/runtime/sdk_memory_kernel.py
+++ b/src/A_memorix/core/runtime/sdk_memory_kernel.py
@@ -1966,20 +1966,24 @@ class SDKMemoryKernel:
 
         if act == "delete":
             source = str(kwargs.get("source", "") or "").strip()
-            return await self._execute_delete_action(
+            result = await self._execute_delete_action(
                 mode="source",
                 selector={"sources": [source]},
                 requested_by=str(kwargs.get("requested_by", "") or "memory_source_admin"),
                 reason=str(kwargs.get("reason", "") or "source_delete"),
             )
+            await self._invalidate_import_manifest_for_sources(result)
+            return result
 
         if act == "batch_delete":
-            return await self._execute_delete_action(
+            result = await self._execute_delete_action(
                 mode="source",
                 selector={"sources": list(kwargs.get("sources") or [])},
                 requested_by=str(kwargs.get("requested_by", "") or "memory_source_admin"),
                 reason=str(kwargs.get("reason", "") or "source_batch_delete"),
             )
+            await self._invalidate_import_manifest_for_sources(result)
+            return result
 
         return {"success": False, "error": f"不支持的 source action: {act}"}
 
@@ -2441,12 +2445,14 @@ class SDKMemoryKernel:
         if act == "preview":
             return await self._preview_delete_action(mode=mode, selector=selector)
         if act == "execute":
-            return await self._execute_delete_action(
+            result = await self._execute_delete_action(
                 mode=mode,
                 selector=selector,
                 requested_by=requested_by,
                 reason=reason,
             )
+            await self._invalidate_import_manifest_for_sources(result)
+            return result
         if act == "restore":
             return await self._restore_delete_action(
                 mode=mode,
@@ -6512,6 +6518,23 @@ class SDKMemoryKernel:
             conn.rollback()
             logger.warning(f"delete_admin execute 失败: {exc}")
             return self._build_standard_delete_result(mode=act_mode, error=str(exc))
+
+    async def _invalidate_import_manifest_for_sources(self, result: Dict[str, Any]) -> None:
+        if not isinstance(result, dict) or not result.get("success"):
+            return
+        manager = self.import_task_manager
+        if manager is None:
+            return
+        sources = self._tokens(result.get("sources"))
+        if not sources:
+            return
+        try:
+            manifest_result = await manager.invalidate_manifest_for_sources(sources)
+        except Exception as exc:
+            logger.warning(f"删除来源后清理导入清单失败: sources={sources}, err={exc}")
+            result["manifest_invalidation"] = {"success": False, "error": str(exc), "sources": sources}
+            return
+        result["manifest_invalidation"] = manifest_result
 
     async def _restore_delete_action(
         self,

--- a/src/A_memorix/core/utils/web_import_manager.py
+++ b/src/A_memorix/core/utils/web_import_manager.py
@@ -285,6 +285,7 @@ class ImportFileRecord:
     source_path: Optional[str] = None
     inline_content: Optional[str] = None
     content_hash: str = ""
+    imported_sources: List[str] = field(default_factory=list)
     retry_chunk_indexes: List[int] = field(default_factory=list)
     retry_mode: str = ""
     warning_count: int = 0
@@ -309,6 +310,7 @@ class ImportFileRecord:
             "updated_at": self.updated_at,
             "source_path": self.source_path or "",
             "content_hash": self.content_hash or "",
+            "imported_sources": list(self.imported_sources or []),
             "retry_chunk_indexes": list(self.retry_chunk_indexes or []),
             "retry_mode": self.retry_mode or "",
             "warning_count": int(self.warning_count),
@@ -681,6 +683,9 @@ class ImportTaskManager:
         item_kind = str(item.get("source_kind") or "").strip().lower()
         item_name = str(item.get("name") or "").strip()
         item_path_norm = self._normalize_manifest_path(item.get("source_path") or "")
+        item_sources = self._dedupe_sources(item.get("sources") if isinstance(item.get("sources"), list) else [])
+        if any(source_text.lower() == item_source.lower() for item_source in item_sources):
+            return True
 
         if source_kind in {"raw_scan", "lpmm_openie"}:
             source_path_norm = self._normalize_manifest_path(source_value)
@@ -766,6 +771,67 @@ class ImportTaskManager:
             return f"path:{Path(file_record.source_path).as_posix().lower()}"
         return f"hash:{content_hash}"
 
+    def _dedupe_sources(self, sources: List[Any]) -> List[str]:
+        normalized: List[str] = []
+        seen = set()
+        for raw in sources or []:
+            source = str(raw or "").strip()
+            if not source:
+                continue
+            key = source.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            normalized.append(source)
+        return normalized
+
+    def _default_sources_for_file(self, file_record: ImportFileRecord) -> List[str]:
+        imported_sources = getattr(file_record, "imported_sources", None)
+        if imported_sources:
+            return self._dedupe_sources(imported_sources)
+        if file_record.source_path:
+            return [f"{file_record.source_kind}:{file_record.source_path}"]
+        return [f"web_import:{file_record.name}"]
+
+    def _manifest_item_sources(self, file_record: ImportFileRecord, item: Dict[str, Any]) -> List[str]:
+        imported_sources = item.get("sources")
+        if isinstance(imported_sources, list):
+            sources = self._dedupe_sources(imported_sources)
+            if sources:
+                return sources
+
+        source_kind = str(item.get("source_kind") or file_record.source_kind or "").strip()
+        source_path = str(item.get("source_path") or file_record.source_path or "").strip()
+        name = str(item.get("name") or file_record.name or "").strip()
+        sources: List[str] = []
+        if source_path:
+            sources.append(f"{source_kind}:{source_path}")
+        if source_kind in {"upload", "paste"} and name:
+            sources.append(f"web_import:{name}")
+        if source_kind == "lpmm_openie" and name:
+            sources.append(f"lpmm_openie:{name}")
+        sources.extend(self._default_sources_for_file(file_record))
+        return self._dedupe_sources(sources)
+
+    def _source_has_live_paragraphs(self, source: str) -> bool:
+        metadata_store = getattr(self.plugin, "metadata_store", None)
+        if metadata_store is None:
+            return False
+
+        try:
+            if hasattr(metadata_store, "get_live_paragraphs_by_source"):
+                return bool(metadata_store.get_live_paragraphs_by_source(source))
+            if hasattr(metadata_store, "get_paragraphs_by_source"):
+                rows = metadata_store.get_paragraphs_by_source(source)
+                return any(not bool(row.get("is_deleted", 0)) for row in rows if isinstance(row, dict))
+        except Exception as exc:
+            logger.warning(f"校验导入清单来源失败: source={source}, err={exc}")
+        return False
+
+    def _manifest_item_has_live_sources(self, file_record: ImportFileRecord, item: Dict[str, Any]) -> bool:
+        sources = self._manifest_item_sources(file_record, item)
+        return any(self._source_has_live_paragraphs(source) for source in sources)
+
     def _is_manifest_hit(
         self,
         file_record: ImportFileRecord,
@@ -777,7 +843,18 @@ class ImportTaskManager:
         item = manifest.get(key)
         if not isinstance(item, dict):
             return False
-        return str(item.get("hash") or "") == content_hash and bool(item.get("imported"))
+        if str(item.get("hash") or "") != content_hash or not bool(item.get("imported")):
+            return False
+        if self._manifest_item_has_live_sources(file_record, item):
+            return True
+
+        logger.info(
+            "导入清单命中但未找到对应 live 段落，清理清单并继续导入: "
+            f"key={key} sources={self._manifest_item_sources(file_record, item)}"
+        )
+        manifest.pop(key, None)
+        self._save_manifest(manifest)
+        return False
 
     def _record_manifest_import(
         self,
@@ -796,6 +873,7 @@ class ImportTaskManager:
             "name": file_record.name,
             "source_path": file_record.source_path or "",
             "source_kind": file_record.source_kind,
+            "sources": self._dedupe_sources(getattr(file_record, "imported_sources", []) or self._default_sources_for_file(file_record)),
         }
         self._save_manifest(manifest)
 
@@ -3094,6 +3172,7 @@ class ImportTaskManager:
                                 knowledge_type=k_type,
                                 time_meta=unit.get("time_meta"),
                             )
+                            self._record_file_source(file_record, source)
                             vector_result = await self._write_paragraph_vector_or_enqueue(
                                 paragraph_hash=para_hash,
                                 content=content,
@@ -3162,6 +3241,17 @@ class ImportTaskManager:
             return f"{file_record.source_kind}:{file_record.source_path}"
         return f"web_import:{file_record.name}"
 
+    def _record_file_source(self, file_record: ImportFileRecord, source: str) -> None:
+        source_text = str(source or "").strip()
+        if not source_text:
+            return
+        imported_sources = getattr(file_record, "imported_sources", None)
+        if imported_sources is None:
+            imported_sources = []
+            setattr(file_record, "imported_sources", imported_sources)
+        if source_text not in imported_sources:
+            imported_sources.append(source_text)
+
     async def _ensure_embedding_runtime_ready(self) -> None:
         report = await ensure_runtime_self_check(self.plugin)
         if bool(report.get("ok", False)):
@@ -3192,12 +3282,14 @@ class ImportTaskManager:
             logger.warning(f"跳过疑似哈希段落写入: source={self._source_label(file_record)} preview={content[:32]}")
             return
         data = _coerce_import_data_dict(processed.data, context="分块抽取结果")
+        source = self._source_label(file_record)
         para_hash = self.plugin.metadata_store.add_paragraph(
             content=content,
-            source=self._source_label(file_record),
+            source=source,
             knowledge_type=_storage_type_from_strategy(processed.type),
             time_meta=time_meta,
         )
+        self._record_file_source(file_record, source)
 
         vector_result = await self._write_paragraph_vector_or_enqueue(
             paragraph_hash=para_hash,


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [x] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:修复知识导入清单失效逻辑,优化提取参考
7. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 删除源时现在会自动清理关联的导入清单，确保数据一致性。

* **测试**
  * 新增清单失效处理的测试用例。
  * 新增清单命中逻辑和源匹配验证的测试用例。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mai-with-u/MaiBot/pull/1741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->