### PR TITLE
fix: preserve voice messages in Maisaka prompts

### DIFF
--- a/src/maisaka/context_messages.py
+++ b/src/maisaka/context_messages.py
@@ -417,6 +417,12 @@ def _build_message_from_sequence(
             )
             continue
 
+        if isinstance(component, VoiceComponent):
+            voice_text = component.content.strip() if component.content else "[语音消息]"
+            builder.add_text_content(voice_text)
+            has_content = True
+            continue
+
         if isinstance(component, AtComponent):
             has_content = _append_at_component(builder, component) or has_content
             continue

--- a/src/maisaka/message_adapter.py
+++ b/src/maisaka/message_adapter.py
@@ -13,6 +13,7 @@ from src.common.data_models.message_component_data_model import (
     MessageSequence,
     ReplyComponent,
     TextComponent,
+    VoiceComponent,
 )
 
 SPEAKER_PREFIX_PATTERN = re.compile(
@@ -56,6 +57,15 @@ def _render_at_component_text(component: AtComponent) -> str:
     return f"@{target_name}".strip()
 
 
+def _render_voice_component_text(component: VoiceComponent) -> str:
+    """将 VoiceComponent 渲染为文本。"""
+
+    normalized_content = component.content.strip()
+    if normalized_content:
+        return normalized_content
+    return "[语音消息]"
+
+
 def build_visible_text_from_sequence(message_sequence: MessageSequence) -> str:
     """从消息片段序列提取可见文本。"""
 
@@ -96,6 +106,10 @@ def build_visible_text_from_sequence(message_sequence: MessageSequence) -> str:
 
         if isinstance(component, ImageComponent):
             append_visible_part(component.content.strip() or "[图片，识别中.....]")
+            continue
+
+        if isinstance(component, VoiceComponent):
+            append_visible_part(_render_voice_component_text(component))
             continue
 
         if isinstance(component, AtComponent):

--- a/tests/test_maisaka_voice_messages.py
+++ b/tests/test_maisaka_voice_messages.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.common.data_models.message_component_data_model import MessageSequence, TextComponent, VoiceComponent
+from src.llm_models.payload_content.message import RoleType
+from src.maisaka.context_messages import _build_message_from_sequence
+from src.maisaka.history_utils import build_prefixed_message_sequence
+from src.maisaka.message_adapter import build_visible_text_from_sequence
+
+
+def test_visible_text_keeps_transcribed_voice_content() -> None:
+    message_sequence = MessageSequence(
+        [
+            TextComponent("[msg_id:voice-1][用户]"),
+            VoiceComponent(binary_hash="voice-hash", content="[语音: 麦麦睡了吗？]"),
+        ]
+    )
+
+    assert build_visible_text_from_sequence(message_sequence) == "[msg_id:voice-1][用户][语音: 麦麦睡了吗？]"
+
+
+def test_prefixed_voice_message_reaches_llm_text_content() -> None:
+    message_sequence = MessageSequence(
+        [VoiceComponent(binary_hash="voice-hash", content="[语音: 麦麦睡了吗？]")]
+    )
+    prefixed_sequence = build_prefixed_message_sequence(
+        message_sequence,
+        "[msg_id]voice-1\n[时间]04:21:36\n[用户名]用户\n[发言内容]\n",
+    )
+
+    llm_message = _build_message_from_sequence(
+        RoleType.User,
+        prefixed_sequence,
+        fallback_text="",
+        enable_visual_message=False,
+    )
+
+    assert llm_message is not None
+    assert llm_message.get_text_content().endswith("[发言内容]\n[语音: 麦麦睡了吗？]")
+
+
+def test_empty_voice_message_uses_stable_placeholder() -> None:
+    message_sequence = MessageSequence([VoiceComponent(binary_hash="voice-hash")])
+
+    assert build_visible_text_from_sequence(message_sequence) == "[语音消息]"
+
+    llm_message = _build_message_from_sequence(
+        RoleType.User,
+        message_sequence,
+        fallback_text="",
+        enable_visual_message=False,
+    )
+    assert llm_message is not None
+    assert llm_message.get_text_content() == "[语音消息]"


### PR DESCRIPTION
### Motivation
- 修复在构建 Maisaka 可见文本和 LLM 消息时丢弃 `VoiceComponent` 转写内容的问题，导致日志中有语音转写但注入 Prompt 的发言内容为空（Issue #1762）。

### Description
- 在 `src/maisaka/message_adapter.py` 中引入 `VoiceComponent` 并新增 `_render_voice_component_text`，使 `build_visible_text_from_sequence` 对 `VoiceComponent` 输出转写文本或稳定占位符 `"[语音消息]"`。 
- 在 `src/maisaka/context_messages.py` 的 `_build_message_from_sequence` 中处理 `VoiceComponent`，将语音文本追加到构建的 LLM 文本内容，确保 planner 前缀后的语音转写不会被跳过。 
- 新增回归测试 `tests/test_maisaka_voice_messages.py`，覆盖已转写语音保留、带 planner 前缀时转写进入 LLM 文本，以及空语音使用占位符三种场景。
- 变更旨在关闭相关问题：`Closes #1762`。

### Testing
- 运行 `python -m pytest tests/test_maisaka_voice_messages.py`，新增语音测试全部通过（3 passed）。
- 对两个受影响模块执行 `python -m py_compile` 和 `python -m ruff check`，均通过静态检查。 
- 在组合运行 `python -m pytest tests/test_maisaka_voice_messages.py tests/test_tool_result_media_messages.py` 时出现现有测试文件 `tests/test_tool_result_media_messages.py` 的失败（3 failures），失败原因为测试构造的 `SimpleNamespace` 在无事件循环路径下缺少 `_runtime.log_prefix` 导致触发 AttributeError，与本 PR 中新增的语音处理逻辑无直接功能性冲突。 
- 尝试使用 `uv run pytest` 安装依赖时遭遇 PyPI 镜像下载网络错误，导致依赖安装步骤未完成（与代码变更无关）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19052f82448324ae6e3ab050b826d4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **新功能**
  * 语音消息内容现已正确显示在消息序列中，空的语音消息将显示占位符。
  * 改进了语音消息在输入处理流程中的集成能力。

* **测试**
  * 新增语音消息显示与处理的测试用例覆盖。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mai-with-u/MaiBot/pull/1763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->