### PR TITLE
feat: 支持 /pm config 编辑插件配置并添加指令别名支持

### DIFF
--- a/pytests/test_builtin_plugin_management.py
+++ b/pytests/test_builtin_plugin_management.py
@@ -1,6 +1,8 @@
 from src.plugin_runtime.host.component_registry import ComponentRegistry
 from src.config.official_configs import PluginConfig
+from src.plugin_runtime.capabilities.components import RuntimeComponentCapabilityMixin
 from src.plugins.built_in.plugin_management.plugin import (
+    PluginManagementConfig,
     _build_scoped_user_id,
     _normalize_permission_list,
     create_plugin,
@@ -50,3 +52,51 @@ def test_plugin_management_permission_uses_platform_scoped_user_id() -> None:
     assert _build_scoped_user_id("telegram", "alice") in permissions
     assert _build_scoped_user_id("", "123456") == ""
     assert "123456" not in permissions
+
+
+def test_plugin_management_command_registers_configured_aliases() -> None:
+    registry = ComponentRegistry()
+    plugin = create_plugin()
+    plugin.set_plugin_config(
+        {
+            "plugin": {"config_version": "1.1.0", "enabled": True},
+            "aliases": {
+                "management_prefixes": ["/插件管理"],
+                "command_aliases": {"plugin.list": ["/插件列表"]},
+            },
+        }
+    )
+    for component in plugin.get_components():
+        registry.register_component(
+            component["name"],
+            component["type"],
+            "builtin.plugin-management",
+            component["metadata"],
+        )
+
+    assert registry.find_command_by_text("/插件管理 help") is not None
+    assert registry.find_command_by_text("/插件列表") is not None
+    assert plugin._resolve_alias_command("/插件列表") == "/pm plugin list"
+
+
+def test_plugin_management_config_defaults_include_alias_section() -> None:
+    default_config = PluginManagementConfig().model_dump(mode="python")
+
+    assert default_config["plugin"]["config_version"] == "1.1.0"
+    assert default_config["aliases"]["management_prefixes"] == ["/插件管理"]
+
+
+def test_plugin_config_update_helper_keeps_command_alias_key_with_dot() -> None:
+    config_data: dict[str, object] = {"aliases": {"command_aliases": {}}}
+
+    RuntimeComponentCapabilityMixin._set_nested_plugin_config_value(
+        config_data,
+        "aliases.command_aliases.plugin.list",
+        ["/插件列表"],
+    )
+
+    aliases = config_data["aliases"]
+    assert isinstance(aliases, dict)
+    command_aliases = aliases["command_aliases"]
+    assert isinstance(command_aliases, dict)
+    assert command_aliases["plugin.list"] == ["/插件列表"]

--- a/src/plugin_runtime/capabilities/components.py
+++ b/src/plugin_runtime/capabilities/components.py
@@ -1,8 +1,11 @@
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Protocol, Sequence
 
+import tomlkit
+
 from src.common.logger import get_logger
 from src.plugin_runtime.host.component_timeout import resolve_component_rpc_timeout_ms
+from src.webui.utils.toml_utils import save_toml_with_format
 
 logger = get_logger("plugin_runtime.integration")
 
@@ -69,6 +72,22 @@ class _RuntimeComponentManagerProtocol(Protocol):
     async def load_plugin_globally(self, plugin_id: str, reason: str = "manual") -> bool: ...
 
     async def reload_plugins_globally(self, plugin_ids: Sequence[str], reason: str = "manual") -> bool: ...
+
+    def _get_plugin_path_for_supervisor(self, supervisor: Any, plugin_id: str) -> Optional[Path]: ...
+
+    def _find_supervisor_by_plugin_directory(self, plugin_id: str) -> Optional["PluginSupervisor"]: ...
+
+    def _resolve_plugin_config_path(self, plugin_id: str, plugin_path: Path) -> Path: ...
+
+    async def validate_plugin_config(self, plugin_id: str, config_data: Dict[str, Any]) -> Dict[str, Any] | None: ...
+
+    async def notify_plugin_config_updated(
+        self,
+        plugin_id: str,
+        config_data: Optional[Dict[str, Any]] = None,
+        config_version: str = "",
+        config_scope: str = "self",
+    ) -> bool: ...
 
 
 class RuntimeComponentCapabilityMixin:
@@ -524,6 +543,100 @@ class RuntimeComponentCapabilityMixin:
             "schema": registration.config_schema,
             "default_config": registration.default_config,
         }
+
+    async def _cap_component_update_plugin_config(
+        self: _RuntimeComponentManagerProtocol, plugin_id: str, capability: str, args: Dict[str, Any]
+    ) -> Any:
+        """更新指定插件的结构化配置项。
+
+        该能力仅授予插件管理内置插件使用：调用方通过权限校验后，可按点分隔路径
+        修改目标插件的 ``config.toml``，并通知运行时进行自配置热更新。
+        """
+
+        del capability
+        if plugin_id != "builtin.plugin-management":
+            return {"success": False, "error": "仅插件管理内置插件可以修改插件配置"}
+
+        target_plugin_id = str(args.get("plugin_name", "") or "").strip()
+        key = str(args.get("key", "") or "").strip()
+        if not target_plugin_id or not key:
+            return {"success": False, "error": "缺少必要参数 plugin_name 或 key"}
+
+        supervisor = self._get_supervisor_for_plugin(target_plugin_id) or self._find_supervisor_by_plugin_directory(
+            target_plugin_id
+        )
+        if supervisor is None:
+            return {"success": False, "error": f"未找到插件: {target_plugin_id}"}
+
+        plugin_path = self._get_plugin_path_for_supervisor(supervisor, target_plugin_id)
+        if plugin_path is None:
+            return {"success": False, "error": f"未找到插件目录: {target_plugin_id}"}
+
+        config_path = self._resolve_plugin_config_path(target_plugin_id, plugin_path)
+        config_data = self._load_component_plugin_config(config_path)
+        try:
+            self._set_nested_plugin_config_value(config_data, key, args.get("value"))
+            validated_config = await self.validate_plugin_config(target_plugin_id, config_data)
+            if isinstance(validated_config, dict):
+                config_data = validated_config
+        except ValueError as exc:
+            return {"success": False, "error": str(exc)}
+        except Exception as exc:
+            logger.error(f"插件 {target_plugin_id} 配置更新失败: {exc}", exc_info=True)
+            return {"success": False, "error": str(exc)}
+
+        try:
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            save_toml_with_format(config_data, str(config_path))
+        except Exception as exc:
+            logger.error(f"插件 {target_plugin_id} 配置写入失败: {exc}", exc_info=True)
+            return {"success": False, "error": f"配置写入失败: {exc}"}
+
+        delivered = await self.notify_plugin_config_updated(target_plugin_id, config_data=config_data)
+        return {
+            "success": True,
+            "plugin_name": target_plugin_id,
+            "key": key,
+            "hot_updated": delivered,
+        }
+
+    @staticmethod
+    def _load_component_plugin_config(config_path: Path) -> Dict[str, Any]:
+        if not config_path.exists():
+            return {}
+        with open(config_path, "r", encoding="utf-8") as file_obj:
+            loaded_config = tomlkit.load(file_obj).unwrap()
+        return loaded_config if isinstance(loaded_config, dict) else {}
+
+    @staticmethod
+    def _set_nested_plugin_config_value(config_data: Dict[str, Any], key: str, value: Any) -> None:
+        if key.startswith("aliases.command_aliases."):
+            command_key = key.removeprefix("aliases.command_aliases.").strip()
+            if not command_key:
+                raise ValueError("别名目标命令不能为空")
+            aliases_config = config_data.setdefault("aliases", {})
+            if not isinstance(aliases_config, dict):
+                raise ValueError("配置路径 aliases 已存在且不是配置节")
+            command_aliases = aliases_config.setdefault("command_aliases", {})
+            if not isinstance(command_aliases, dict):
+                raise ValueError("配置路径 aliases.command_aliases 已存在且不是配置节")
+            command_aliases[command_key] = value
+            return
+
+        parts = [part.strip() for part in key.split(".") if part.strip()]
+        if not parts:
+            raise ValueError("配置键不能为空")
+
+        current = config_data
+        for part in parts[:-1]:
+            next_value = current.get(part)
+            if next_value is None:
+                next_value = {}
+                current[part] = next_value
+            if not isinstance(next_value, dict):
+                raise ValueError(f"配置路径 {part} 已存在且不是配置节")
+            current = next_value
+        current[parts[-1]] = value
 
     async def _cap_component_list_loaded_plugins(
         self: _RuntimeComponentManagerProtocol, plugin_id: str, capability: str, args: Dict[str, Any]

--- a/src/plugin_runtime/capabilities/registry.py
+++ b/src/plugin_runtime/capabilities/registry.py
@@ -90,6 +90,7 @@ def register_capability_impls(manager: "PluginRuntimeManager", supervisor: Plugi
     _register("component.get_all_plugins", manager._cap_component_get_all_plugins)
     _register("component.get_plugin_info", manager._cap_component_get_plugin_info)
     _register("component.get_plugin_config_schema", manager._cap_component_get_plugin_config_schema)
+    _register("component.update_plugin_config", manager._cap_component_update_plugin_config)
     _register("component.list_loaded_plugins", manager._cap_component_list_loaded_plugins)
     _register("component.list_registered_plugins", manager._cap_component_list_registered_plugins)
     _register("component.enable", manager._cap_component_enable)

--- a/src/plugins/built_in/plugin_management/_manifest.json
+++ b/src/plugins/built_in/plugin_management/_manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "2.0.0",
+  "version": "2.1.0",
   "name": "插件和组件管理 (Plugin and Component Management)",
   "description": "通过系统 API 管理插件和组件的生命周期，包括加载、卸载、启用和禁用等操作。",
   "author": {
@@ -32,8 +32,10 @@
     "component.load_plugin",
     "component.unload_plugin",
     "component.reload_plugin",
+    "component.update_plugin_config",
     "send.text",
-    "config.get"
+    "config.get",
+    "config.get_plugin"
   ],
   "i18n": {
     "default_locale": "zh-CN",

--- a/src/plugins/built_in/plugin_management/plugin.py
+++ b/src/plugins/built_in/plugin_management/plugin.py
@@ -3,10 +3,36 @@
 通过 /pm 命令管理插件和组件的生命周期。
 """
 
-from maibot_sdk import Command, MaiBotPlugin
+from typing import Any, ClassVar, Dict, List
+
+import json
+import shlex
+
+from maibot_sdk import Command, Field, MaiBotPlugin, PluginConfigBase
 
 
 _VALID_COMPONENT_TYPES = ("tool", "command", "event_handler")
+
+
+_COMMAND_ALIAS_TARGETS: dict[str, str] = {
+    "help": "/pm help",
+    "plugin": "/pm plugin",
+    "plugin.help": "/pm plugin help",
+    "plugin.list": "/pm plugin list",
+    "plugin.list_enabled": "/pm plugin list_enabled",
+    "plugin.load": "/pm plugin load",
+    "plugin.unload": "/pm plugin unload",
+    "plugin.reload": "/pm plugin reload",
+    "component": "/pm component",
+    "component.help": "/pm component help",
+    "component.list": "/pm component list",
+    "component.enable": "/pm component enable",
+    "component.disable": "/pm component disable",
+    "config": "/pm config",
+    "config.help": "/pm config help",
+    "config.get": "/pm config get",
+    "config.set": "/pm config set",
+}
 
 
 def _build_scoped_user_id(platform: str, user_id: str) -> str:
@@ -33,7 +59,7 @@ HELP_ALL = (
     "/pm help 管理命令提示\n"
     "/pm plugin 插件管理命令\n"
     "/pm component 组件管理命令\n"
-    "使用 /pm plugin help 或 /pm component help 获取具体帮助"
+    "使用 /pm plugin help、/pm component help 或 /pm config help 获取具体帮助"
 )
 HELP_PLUGIN = (
     "插件管理命令帮助\n"
@@ -43,6 +69,14 @@ HELP_PLUGIN = (
     "/pm plugin load <plugin_name> 加载指定插件\n"
     "/pm plugin unload <plugin_name> 卸载指定插件\n"
     "/pm plugin reload <plugin_name> 重新加载指定插件\n"
+)
+HELP_CONFIG = (
+    "插件配置命令帮助\n"
+    "/pm config help 插件配置命令提示\n"
+    "/pm config get <plugin_name> [key] 读取指定插件配置或点分隔配置项\n"
+    "/pm config set <plugin_name> <key> <value_json> 修改指定插件配置项\n"
+    "  - <key> 使用点分隔路径，例如 plugin.enabled；命令别名可用 aliases.command_aliases.plugin.list\n"
+    "  - <value_json> 优先按 JSON 解析，例如 true、123、[\"/别名\"]；解析失败时按字符串保存"
 )
 HELP_COMPONENT = (
     "组件管理命令帮助\n"
@@ -61,8 +95,36 @@ HELP_COMPONENT = (
 )
 
 
+class PluginSectionConfig(PluginConfigBase):
+    """插件自身配置。"""
+
+    __ui_label__: ClassVar[str] = "基础设置"
+    config_version: str = Field(default="1.1.0", description="配置版本号")
+    enabled: bool = Field(default=True, description="是否启用插件管理内置插件")
+
+
+class AliasConfig(PluginConfigBase):
+    """插件管理命令别名配置。"""
+
+    __ui_label__: ClassVar[str] = "指令别名"
+    management_prefixes: List[str] = Field(default_factory=lambda: ["/插件管理"], description="/pm 主命令前缀别名")
+    command_aliases: Dict[str, List[str]] = Field(
+        default_factory=dict,
+        description="子命令别名映射，键名可用 plugin.list、plugin.reload、config.set 等",
+    )
+
+
+class PluginManagementConfig(PluginConfigBase):
+    """插件管理插件配置模型。"""
+
+    plugin: PluginSectionConfig = Field(default_factory=PluginSectionConfig, description="插件基础配置")
+    aliases: AliasConfig = Field(default_factory=AliasConfig, description="指令别名配置")
+
+
 class PluginManagementPlugin(MaiBotPlugin):
     """插件和组件管理插件"""
+
+    config_model = PluginManagementConfig
 
     async def on_load(self) -> None:
         """处理插件加载。"""
@@ -73,7 +135,7 @@ class PluginManagementPlugin(MaiBotPlugin):
     @Command(
         "management",
         description="管理插件和组件的生命周期",
-        pattern=r"(?P<manage_command>^/pm(?:\s+\S+)*\s*$)",
+        pattern=r"(?P<manage_command>^/pm(?:\s+.+)?\s*$)",
     )
     async def handle_management(
         self, stream_id: str = "", platform: str = "", user_id: str = "", matched_groups: dict | None = None, **kwargs
@@ -90,8 +152,10 @@ class PluginManagementPlugin(MaiBotPlugin):
         if not stream_id:
             return False, "无法获取聊天流信息", True
 
+        raw_text = str(kwargs.get("text", "") or "").strip()
         raw_command = (matched_groups or {}).get("manage_command", "").strip()
-        parts = raw_command.split() if raw_command else ["/pm"]
+        raw_command = self._resolve_alias_command(raw_command or raw_text)
+        parts = self._split_command(raw_command) if raw_command else ["/pm"]
         n = len(parts)
 
         # /pm
@@ -106,6 +170,8 @@ class PluginManagementPlugin(MaiBotPlugin):
                 await self.ctx.send.text(HELP_PLUGIN, stream_id)
             elif sub == "component":
                 await self.ctx.send.text(HELP_COMPONENT, stream_id)
+            elif sub == "config":
+                await self.ctx.send.text(HELP_CONFIG, stream_id)
             elif sub == "help":
                 await self.ctx.send.text(HELP_ALL, stream_id)
             else:
@@ -117,6 +183,12 @@ class PluginManagementPlugin(MaiBotPlugin):
         if n == 3:
             if parts[1] == "plugin":
                 await self._handle_plugin_3(parts[2], stream_id)
+            elif parts[1] == "config":
+                if parts[2] == "help":
+                    await self.ctx.send.text(HELP_CONFIG, stream_id)
+                else:
+                    await self.ctx.send.text("插件管理命令不合法", stream_id)
+                    return False, "命令不合法", True
             elif parts[1] == "component":
                 if parts[2] == "list":
                     await self._list_all_components(stream_id)
@@ -133,6 +205,8 @@ class PluginManagementPlugin(MaiBotPlugin):
         if n == 4:
             if parts[1] == "plugin":
                 await self._handle_plugin_4(parts[2], parts[3], stream_id)
+            elif parts[1] == "config":
+                await self._handle_config_get(parts[2], parts[3], "", stream_id)
             elif parts[1] == "component":
                 if parts[2] == "list":
                     await self._handle_component_list_4(parts[3], stream_id)
@@ -145,18 +219,24 @@ class PluginManagementPlugin(MaiBotPlugin):
             return True, "命令执行完成", True
 
         if n == 5:
-            if parts[1] != "component" or parts[2] != "list":
-                await self.ctx.send.text("插件管理命令不合法", stream_id)
-                return False, "命令不合法", True
-            await self._handle_component_list_5(parts[3], parts[4], stream_id)
-            return True, "命令执行完成", True
+            if parts[1] == "component" and parts[2] == "list":
+                await self._handle_component_list_5(parts[3], parts[4], stream_id)
+                return True, "命令执行完成", True
+            if parts[1] == "config" and parts[2] == "get":
+                await self._handle_config_get(parts[2], parts[3], parts[4], stream_id)
+                return True, "命令执行完成", True
+            await self.ctx.send.text("插件管理命令不合法", stream_id)
+            return False, "命令不合法", True
 
-        if n == 6:
-            if parts[1] != "component":
-                await self.ctx.send.text("插件管理命令不合法", stream_id)
-                return False, "命令不合法", True
-            await self._handle_component_toggle(parts[2], parts[3], parts[4], parts[5], stream_id)
-            return True, "命令执行完成", True
+        if n >= 6:
+            if parts[1] == "component" and n == 6:
+                await self._handle_component_toggle(parts[2], parts[3], parts[4], parts[5], stream_id)
+                return True, "命令执行完成", True
+            if parts[1] == "config" and parts[2] == "set" and n >= 6:
+                await self._handle_config_set(parts[3], parts[4], " ".join(parts[5:]), stream_id)
+                return True, "命令执行完成", True
+            await self.ctx.send.text("插件管理命令不合法", stream_id)
+            return False, "命令不合法", True
 
         await self.ctx.send.text("插件管理命令不合法", stream_id)
         return False, "命令不合法", True
@@ -197,6 +277,39 @@ class PluginManagementPlugin(MaiBotPlugin):
                 await self.ctx.send.text(msg, stream_id)
             case _:
                 await self.ctx.send.text("插件管理命令不合法", stream_id)
+
+    # ------ config 子命令 ------
+
+    async def _handle_config_get(self, action: str, plugin_name: str, key: str, stream_id: str):
+        if action != "get":
+            await self.ctx.send.text("插件管理命令不合法", stream_id)
+            return
+        config = await self.ctx.config.get_plugin(plugin_name)
+        if not config:
+            await self.ctx.send.text(f"未读取到插件配置: {plugin_name}", stream_id)
+            return
+        value = self._get_nested_value(config, key) if key else config
+        display_key = f".{key}" if key else ""
+        value_text = json.dumps(value, ensure_ascii=False)
+        await self.ctx.send.text(f"{plugin_name}{display_key} = {value_text}", stream_id)
+
+    async def _handle_config_set(self, plugin_name: str, key: str, raw_value: str, stream_id: str):
+        if not key.strip():
+            await self.ctx.send.text("配置键不能为空", stream_id)
+            return
+        value = self._parse_config_value(raw_value)
+        result = await self.ctx.call_capability(
+            "component.update_plugin_config",
+            plugin_name=plugin_name,
+            key=key,
+            value=value,
+        )
+        ok = result.get("success", False) if isinstance(result, dict) else bool(result)
+        if ok:
+            await self.ctx.send.text(f"插件配置已更新: {plugin_name}.{key}", stream_id)
+            return
+        error = result.get("error", "未知错误") if isinstance(result, dict) else "未知错误"
+        await self.ctx.send.text(f"插件配置更新失败: {error}", stream_id)
 
     # ------ component 子命令 ------
 
@@ -294,6 +407,117 @@ class PluginManagementPlugin(MaiBotPlugin):
                     components.extend(plugin_info.get("components", []))
             return components
         return []
+
+    def get_components(self) -> list[dict[str, Any]]:
+        """收集组件声明，并把配置中的命令别名写入管理命令。"""
+
+        components = super().get_components()
+        aliases = self._collect_configured_aliases()
+        for component in components:
+            if component.get("name") != "management":
+                continue
+            metadata = component.get("metadata")
+            if not isinstance(metadata, dict):
+                continue
+            existing_aliases = [str(alias).strip() for alias in metadata.get("aliases", []) if str(alias).strip()]
+            metadata["aliases"] = list(dict.fromkeys([*existing_aliases, *aliases]))
+        return components
+
+    def _collect_configured_aliases(self) -> list[str]:
+        config = self.get_plugin_config_data()
+        aliases_config = config.get("aliases") if isinstance(config, dict) else None
+        if not isinstance(aliases_config, dict):
+            return []
+
+        aliases: list[str] = []
+        prefixes = aliases_config.get("management_prefixes", [])
+        if isinstance(prefixes, list):
+            aliases.extend(str(alias).strip() for alias in prefixes if str(alias).strip())
+
+        command_aliases = aliases_config.get("command_aliases", {})
+        if isinstance(command_aliases, dict):
+            for alias_list in command_aliases.values():
+                if isinstance(alias_list, list):
+                    aliases.extend(str(alias).strip() for alias in alias_list if str(alias).strip())
+        return list(dict.fromkeys(aliases))
+
+    def _resolve_alias_command(self, raw_command: str) -> str:
+        normalized_command = raw_command.strip()
+        if not normalized_command or normalized_command.startswith("/pm"):
+            return normalized_command
+
+        alias_mapping = self._build_alias_mapping()
+        for alias, target in sorted(alias_mapping.items(), key=lambda item: len(item[0]), reverse=True):
+            if not self._command_startswith_alias(normalized_command, alias):
+                continue
+            suffix = normalized_command[len(alias) :].strip()
+            return f"{target} {suffix}".strip()
+        return normalized_command
+
+    def _build_alias_mapping(self) -> dict[str, str]:
+        config = self.get_plugin_config_data()
+        aliases_config = config.get("aliases") if isinstance(config, dict) else None
+        if not isinstance(aliases_config, dict):
+            return {}
+
+        mapping: dict[str, str] = {}
+        prefixes = aliases_config.get("management_prefixes", [])
+        if isinstance(prefixes, list):
+            for alias in prefixes:
+                normalized_alias = str(alias).strip()
+                if normalized_alias:
+                    mapping[normalized_alias] = "/pm"
+
+        command_aliases = aliases_config.get("command_aliases", {})
+        if isinstance(command_aliases, dict):
+            for command_key, alias_list in command_aliases.items():
+                target = _COMMAND_ALIAS_TARGETS.get(str(command_key).strip())
+                if not target or not isinstance(alias_list, list):
+                    continue
+                for alias in alias_list:
+                    normalized_alias = str(alias).strip()
+                    if normalized_alias:
+                        mapping[normalized_alias] = target
+        return mapping
+
+    @staticmethod
+    def _command_startswith_alias(command: str, alias: str) -> bool:
+        if not command.startswith(alias):
+            return False
+        return len(command) == len(alias) or command[len(alias)].isspace()
+
+    @staticmethod
+    def _split_command(raw_command: str) -> list[str]:
+        try:
+            return shlex.split(raw_command)
+        except ValueError:
+            return raw_command.split()
+
+    @staticmethod
+    def _parse_config_value(raw_value: str) -> object:
+        value_text = raw_value.strip()
+        try:
+            return json.loads(value_text)
+        except json.JSONDecodeError:
+            return value_text
+
+    @staticmethod
+    def _get_nested_value(config: dict[str, object], key: str) -> object:
+        if key.startswith("aliases.command_aliases."):
+            aliases = config.get("aliases")
+            if not isinstance(aliases, dict):
+                return None
+            command_aliases = aliases.get("command_aliases")
+            if not isinstance(command_aliases, dict):
+                return None
+            return command_aliases.get(key.removeprefix("aliases.command_aliases."))
+
+        current: object = config
+        for part in key.split("."):
+            if not isinstance(current, dict) or part not in current:
+                return None
+            current = current[part]
+        return current
 
     async def on_config_update(self, scope: str, config_data: dict[str, object], version: str) -> None:
         """处理配置热重载事件。


### PR DESCRIPTION
### Motivation

- 使系统内置的插件管理插件可以直接查看与修改其他插件的配置，提升运维便捷性；
- 允许为 `/pm` 管理命令添加可配置的前缀与子命令别名，以更好地适配中文化或定制化使用场景；
- 在修改配置时保证运行时校验与热重载通知，避免手工修改造成的不一致。

### Description

- 为内置插件管理插件新增结构化配置模型 `PluginManagementConfig`（含 `plugin` 与 `aliases` 子段），并把模型设置为插件的 `config_model`；
- 在 PM 插件中新增 `/pm config get <plugin_name> [key]` 与 `/pm config set <plugin_name> <key> <value_json>` 子命令，值优先按 JSON 解析并支持点分隔路径定位配置项；
- 支持在插件配置中声明别名：`aliases.management_prefixes`（主命令前缀别名）和 `aliases.command_aliases`（子命令别名映射），并在 `get_components()` 中将配置里的别名注入 `management` 命令组件元数据；
- 添加别名解析与命令重写逻辑（`_resolve_alias_command` / `_build_alias_mapping` / `_split_command` 等），在执行时把别名映射回规范 `/pm ...` 指令；
- 在宿主能力层新增能力 `component.update_plugin_config`，并在能力实现中实现：定位目标插件目录、按点路径修改 `config.toml`（保留 `aliases.command_aliases.*` 键名）、调用运行时的 `validate_plugin_config`、持久化到磁盘并通过运行时发送配置热更新通知；
- 更新内置插件 manifest（版本 `2.1.0`）以声明新增能力权限；
- 新增/修改单元测试以覆盖别名注入、默认配置项与点分隔别名键写入行为（`pytests/test_builtin_plugin_management.py`）。

### Testing

- 已运行单测: `python -m pytest pytests/test_builtin_plugin_management.py -q`，结果：`7 passed`（测试通过，伴随少量 Pydantic deprecation 警告）。
- 已运行静态与语法检查: `python -m ruff check ...` 与 `python -m py_compile ...`，均通过（无语法/ruff 错误）。
- 说明：在部分环境尝试使用 `uv run pytest` 时因配置的 PyPI 镜像下载依赖失败（`pyasn1-modules`）导致虚拟环境构建受限；但针对本次改动的本地单测与静态检查均已成功通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1912d55aa88324aa6412d4bbd355e3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 插件管理命令支持自定义命令别名配置
  * 新增插件配置管理子命令（`config get`/`set`），支持点分隔路径访问嵌套配置项
  * 插件管理版本升级至 2.1.0

* **Tests**
  * 增强了插件管理配置处理的测试覆盖

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mai-with-u/MaiBot/pull/1764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->