### PR TITLE
fix: sanitize blank OpenAI text blocks

### DIFF
--- a/src/llm_models/model_client/openai_client.py
+++ b/src/llm_models/model_client/openai_client.py
@@ -221,6 +221,17 @@ def _normalize_tool_argument_parse_mode(parse_mode: str | ToolArgumentParseMode)
         return ToolArgumentParseMode.AUTO
 
 
+def _normalize_openai_text_content(text: str, *, fallback_text: str = "[空白消息]") -> str:
+    """规范化 OpenAI 兼容文本，避免向严格 Provider 发送空文本块。
+
+    部分 OpenAI 兼容路由在转发 Anthropic Claude 时会拒绝空白 text block；
+    因此只在文本全为空白时替换为稳定占位符，非空文本保持原样。
+    """
+    if text.strip():
+        return text
+    return fallback_text
+
+
 def _build_text_content_part(text: str) -> ChatCompletionContentPartTextParam:
     """构建文本内容片段。
 
@@ -232,7 +243,7 @@ def _build_text_content_part(text: str) -> ChatCompletionContentPartTextParam:
     """
     return {
         "type": "text",
-        "text": text,
+        "text": _normalize_openai_text_content(text),
     }
 
 
@@ -362,13 +373,17 @@ def _convert_text_only_message_content(
     if not message.parts:
         return ""
     if len(message.parts) == 1 and isinstance(message.parts[0], TextMessagePart):
-        return message.parts[0].text
+        return _normalize_openai_text_content(message.parts[0].text)
 
     content: List[ChatCompletionContentPartTextParam] = []
     for part in message.parts:
         if not isinstance(part, TextMessagePart):
             raise ValueError(f"{message.role.value} 消息仅支持文本片段")
+        if not part.text.strip():
+            continue
         content.append(_build_text_content_part(part.text))
+    if not content:
+        return _normalize_openai_text_content("")
     return content
 
 
@@ -382,12 +397,13 @@ def _convert_user_message_content(message: Message) -> str | List[ChatCompletion
         str | List[ChatCompletionContentPartParam]: 用户消息内容结构。
     """
     if len(message.parts) == 1 and isinstance(message.parts[0], TextMessagePart):
-        return message.parts[0].text
+        return _normalize_openai_text_content(message.parts[0].text)
 
     content: List[ChatCompletionContentPartParam] = []
     for part in message.parts:
         if isinstance(part, TextMessagePart):
-            content.append(_build_text_content_part(part.text))
+            if part.text.strip():
+                content.append(_build_text_content_part(part.text))
             continue
 
         normalized_image = _normalize_image_part_for_openai(part)
@@ -404,6 +420,8 @@ def _convert_user_message_content(message: Message) -> str | List[ChatCompletion
                 },
             }
         )
+    if not content:
+        return _normalize_openai_text_content("")
     return content
 
 

--- a/tests/test_openai_message_conversion.py
+++ b/tests/test_openai_message_conversion.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.llm_models.model_client.openai_client import _convert_messages
+from src.llm_models.payload_content.message import Message, RoleType, TextMessagePart
+
+
+def test_openai_message_conversion_replaces_blank_text_string() -> None:
+    messages = [Message(role=RoleType.User, parts=[TextMessagePart("  \n")])]
+
+    converted_messages = _convert_messages(messages)
+
+    assert converted_messages[0]["content"] == "[空白消息]"
+
+
+def test_openai_message_conversion_skips_blank_text_blocks_in_mixed_content() -> None:
+    messages = [
+        Message(
+            role=RoleType.User,
+            parts=[TextMessagePart("开头"), TextMessagePart(" \t"), TextMessagePart("结尾")],
+        )
+    ]
+
+    converted_messages = _convert_messages(messages)
+
+    assert converted_messages[0]["content"] == [
+        {"type": "text", "text": "开头"},
+        {"type": "text", "text": "结尾"},
+    ]


### PR DESCRIPTION
### Motivation
- Some OpenAI-compatible providers (notably routes that forward to Anthropic/Claude) reject empty `text` content blocks, causing otherwise-good prompts to fail with `messages: text content blocks must be non-empty`.

### Description
- Add `_normalize_openai_text_content` helper to replace wholly-blank text with a stable placeholder (`[空白消息]`) while leaving non-empty text unchanged.
- Use the helper from `_build_text_content_part` so all text parts written for provider requests are normalized.
- Update `_convert_text_only_message_content` and `_convert_user_message_content` to skip whitespace-only `TextMessagePart` entries in multipart messages and to fall back to the placeholder when all parts would be empty.
- Add regression tests `tests/test_openai_message_conversion.py` to cover whitespace-only single-message and mixed multipart message scenarios.

### Testing
- Ran `python -m pytest tests/test_openai_message_conversion.py` and the new tests passed (`2 passed`).
- Verified `python -m py_compile src/llm_models/model_client/openai_client.py tests/test_openai_message_conversion.py` succeeded.
- Ran a combined subset `python -m pytest tests/test_openai_message_conversion.py tests/test_maisaka_voice_messages.py tests/test_tool_result_media_messages.py` where the new tests and voice tests passed but three pre-existing `tests/test_tool_result_media_messages.py` failed due to the test stub lacking `_runtime.log_prefix` when no event loop is running (this is an unrelated test-environment issue, not a regression of the message-sanitization change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a196ed10c508324acb91c36a90a16c2)