### PR TITLE
fix(db): set expire_on_commit=False on SessionLocal

### DIFF
--- a/src/common/database/database.py
+++ b/src/common/database/database.py
@@ -52,11 +52,17 @@ engine = create_engine(
 )
 
 # 创建会话工厂（使用 sqlmodel.Session）
+# 说明: 设置 expire_on_commit=False，避免在 with get_db_session() 块自动 commit 时，
+# 已加载到内存中的 ORM 实例属性被标记为过期。否则会话关闭后实例进入 detached 状态，
+# 任何属性访问都会触发刷新而抛出
+# "Instance ... is not bound to a Session; attribute refresh operation cannot proceed".
+# 当前数据库模型不包含 SQLAlchemy Relationship，因此不会引入 lazy-load 副作用。
 SessionLocal = sessionmaker(
     autocommit=False,
     autoflush=False,
     bind=engine,
     class_=Session,
+    expire_on_commit=False,
 )
 _migration_bootstrapper = create_database_migration_bootstrapper(engine)
 


### PR DESCRIPTION
## Summary

Set `expire_on_commit=False` on `SessionLocal` in `src/common/database/database.py` to avoid SQLAlchemy detached-instance errors when ORM attributes are accessed after `with get_db_session()` exits.

With the default `expire_on_commit=True`, the automatic commit on context exit marks all loaded attributes as expired. After `session.close()` the instance is detached, and the next attribute access triggers a refresh that fails with:

```
Instance <PersonInfo at 0x...> is not bound to a Session;
attribute refresh operation cannot proceed
(Background on this error at: https://sqlalche.me/e/20/bhk3)
```

The current database models declare no SQLAlchemy `Relationship`, so disabling expire-on-commit does not introduce lazy-load side effects. This is also the recommended configuration for FastAPI-style request-scoped sessions.

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`

# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [x] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）：

   无破坏性更新。本改动仅影响 ORM 实例在 `session.commit()` 之后的"过期标记"行为：
   - 改动前：commit 后所有实例属性被标记为 expired，下次访问任一属性会触发一次 SELECT 重新加载。
   - 改动后：commit 不再过期实例，属性值保持上次加载的快照。

   由于当前 `database_model.py` 没有任何 `Relationship` 声明，不存在 lazy-load 重新触发的场景；并且 `autoflush=False` 早已禁用，已有代码不依赖"commit 后自动刷新"的语义。整个仓库的现存调用方都不会因此出现行为变化。

7. 请简要说明本次更新的内容和目的：

   ### 背景 / 复现

   在 main 分支（commit `61acb859`）上使用 WebUI 时，打开"人物管理 / 人物列表"页面会立即报：

   ```
   [WebUI人物] 获取人物列表失败:
   Instance <PersonInfo at 0x7d1c72da2670> is not bound to a Session;
   attribute refresh operation cannot proceed
   ```

   翻看代码，类似形式的"先在 `with get_db_session()` 里查询、出 `with` 后再访问 ORM 属性"的写法在多个 router 里都存在过（`person.py`、`expression.py`、`chat/routes.py` 等）。dev 分支虽然已经在 router 层把这些写法都收进了 `with` 块内（症状修复），但**根因仍然存在**：只要将来某个新加的路由不小心又在 `with` 外面访问了 ORM 字段（哪怕只是 `logger.info(obj.name)`），就会再次抛出这个错误。

   ### 根因

   `src/common/database/database.py` 里的 `SessionLocal` 没有显式设置 `expire_on_commit`，因此使用 SQLAlchemy 的默认值 `True`。在 `get_db_session` 上下文管理器里，`auto_commit=True` 触发 `session.commit()` 之后，**所有已加载的实例属性都会被标记为 expired**；紧接着 `session.close()` 把实例置为 detached 状态。此后任何对该实例属性的访问都会被 SQLAlchemy 解释为"需要刷新过期字段"，而 detached 实例无法 refresh，于是抛出题目里那个错误。

   ### 修复

   把 `SessionLocal` 的 `expire_on_commit` 显式设为 `False`：

   ```python
   SessionLocal = sessionmaker(
       autocommit=False,
       autoflush=False,
       bind=engine,
       class_=Session,
       expire_on_commit=False,   # <-- 新增
   )
   ```

   这样 commit 之后实例属性保持已加载的快照值，即便 session 已关闭、实例处于 detached 状态，也能继续读取这些字段。

   ### 为什么这是合适的根因修复

   1. **当前模型没有 `Relationship`**：`grep -R "Relationship\|relationship\|lazy" src/common/database` 无任何匹配，所以不存在"detached 后再触发 lazy load"的场景，关掉 expire-on-commit 不会引入隐患。
   2. **`autoflush=False` 已经禁用**：现有代码没有依赖"commit 后自动从数据库刷新"的语义，否则早就会因 autoflush 缺失而出问题。
   3. **业界推荐做法**：FastAPI / Starlette 这类"请求作用域 session"的应用场景中，`expire_on_commit=False` 是 SQLAlchemy 官方文档与社区都推荐的标准配置，可参考：
      - [SQLAlchemy 2.0 docs - Committing](https://docs.sqlalchemy.org/en/20/orm/session_basics.html#committing)
      - [SQLAlchemy 2.0 docs - Session FAQ "expire_on_commit"](https://docs.sqlalchemy.org/en/20/orm/session_basics.html#using-the-session)

   ### 与 dev 分支已有修复的关系

   dev 分支已经把 router 层"在 `with` 外读 ORM 属性"的写法都收进 `with` 块（症状修复），本 PR 是**根因防御**——把同样的错误从源头消除，避免未来回归。两层修复互补，不冲突。

   ### 验证

   - **复现**：checkout `main` (`61acb859`)，启动 WebUI，访问 `/person/list` → 100% 触发原错误。
   - **修复后**：在同样的代码基础上仅应用本 PR 改动，重启 WebUI → 同样路径正常返回数据。
   - 现有调用未受影响（无新增/删除的对外行为，仅 ORM 实例状态语义变化）。

# 其他信息
- **关联 Issue**: 无关联 issue（如有用户已开 issue 报同样错误，可在合并时填上 `Close #xxx`）
- **截图/GIF**: N/A
- **附加信息**:
  - 改动仅 1 个文件、+6/-0 行（5 行中文注释 + 1 行参数）
  - 完整 traceback 关键行：
    ```
    sqlalchemy.orm.exc.DetachedInstanceError: Instance <PersonInfo at 0x...>
    is not bound to a Session; attribute refresh operation cannot proceed
    ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了数据库会话管理机制，防止关闭会话后出现对象状态异常的情况，提升了应用在数据库操作中的稳定性和可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->