### PR TITLE
fix: bind WebUI in Docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ COPY . .
 RUN git clone --depth 1 --branch main https://github.com/Mai-with-u/MaiBot-Napcat-Adapter.git plugin-templates/MaiBot-Napcat-Adapter
 RUN chmod +x docker-entrypoint.sh
 
-EXPOSE 8000
+EXPOSE 8000 8001
 
 ENTRYPOINT [ "./docker-entrypoint.sh" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - PRIVACY_AGREE=91e5db7659c560bc3545e63859b6ebc0
       - MAIBOT_LEGACY_0X_UPGRADE_CONFIRMED=1 # Docker 无法交互确认旧版升级迁移，默认跳过确认提示
       - MAIBOT_STATISTICS_REPORT_PATH=/MaiMBot/data/maibot_statistics.html # 统计数据输出到共享目录，首次运行可自动创建文件
+      - WEBUI_HOST=0.0.0.0
+      - WEBUI_PORT=8001
 #      - EULA_AGREE=8e6e7d647f7f82d6ea98456b73908656 # 同意EULA
 #      - PRIVACY_AGREE=91e5db7659c560bc3545e63859b6ebc0 # 同意隐私条款
     ports:


### PR DESCRIPTION
Fixes #1792

Docker compose publishes 18001:8001, but a fresh config uses webui.host = 127.0.0.1. That binds the WebUI to the container loopback only, so the published port is not reachable from the host.

Changes:
- set WEBUI_HOST=0.0.0.0 and WEBUI_PORT=8001 for the core service
- add 8001 to Dockerfile EXPOSE metadata

Checked with `docker compose config --quiet`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 杂项
- 更新容器端口配置，现支持在 8000 和 8001 端口访问服务
- 配置 WebUI 监听地址，允许从外部网络访问 8001 端口

<!-- end of auto-generated comment: release notes by coderabbit.ai -->