### PR TITLE
fix(a_memorix): add missing AMemorixRelationVectorizationConfig model

### DIFF
--- a/src/config/official_configs.py
+++ b/src/config/official_configs.py
@@ -1736,6 +1736,46 @@ class AMemorixEmbeddingConfig(ConfigBase):
     """段落向量回填配置"""
 
 
+class AMemorixRelationVectorizationConfig(ConfigBase):
+    """A_Memorix 关系向量化配置"""
+
+    enabled: bool = Field(
+        default=False,
+        json_schema_extra={
+            "label": {
+                "zh_CN": "启用",
+                "en_US": "Enabled",
+                "ja_JP": "有効",
+            },
+        },
+    )
+    """是否启用关系向量化"""
+
+    backfill_enabled: bool = Field(
+        default=False,
+        json_schema_extra={
+            "label": {
+                "zh_CN": "回填",
+                "en_US": "Backfill",
+                "ja_JP": "バックフィル",
+            },
+        },
+    )
+    """是否启用关系向量回填"""
+
+    write_on_import: bool = Field(
+        default=True,
+        json_schema_extra={
+            "label": {
+                "zh_CN": "导入时写入",
+                "en_US": "Write on import",
+                "ja_JP": "インポート時書き込み",
+            },
+        },
+    )
+    """导入时是否写入关系向量"""
+
+
 class AMemorixSparseRetrievalConfig(ConfigBase):
     """A_Memorix 稀疏检索配置"""
 
@@ -1945,6 +1985,18 @@ class AMemorixRetrievalConfig(ConfigBase):
         },
     )
     """稀疏检索配置"""
+
+    relation_vectorization: AMemorixRelationVectorizationConfig = Field(
+        default_factory=lambda: AMemorixRelationVectorizationConfig(),
+        json_schema_extra={
+            "label": {
+                "zh_CN": "关系向量化",
+                "en_US": "Relation vectorization",
+                "ja_JP": "関係ベクトル化",
+            },
+        },
+    )
+    """关系向量化配置"""
 
 
 class AMemorixThresholdConfig(ConfigBase):


### PR DESCRIPTION
## 问题

SDKMemoryKernel 运行时通过 `_cfg()` 读取 `retrieval.relation_vectorization` 配置来控制关系向量化功能，但 Pydantic 配置模型 `AMemorixRetrievalConfig` 缺少对应字段。

导致用户在 `bot_config.toml` 中配置了以下内容也无法生效：

```toml
[a_memorix.retrieval.relation_vectorization]
enabled = true
backfill_enabled = true
write_on_import = true
```

Dashboard 长期记忆控制台始终显示关系向量未启用。

## 修复

新增 `AMemorixRelationVectorizationConfig` 模型类，包含三个字段：
- `enabled` — 是否启用关系向量化（默认 false）
- `backfill_enabled` — 是否启用关系向量回填（默认 false）
- `write_on_import` — 导入时是否写入关系向量（默认 true）

并将其添加为 `AMemorixRetrievalConfig.relation_vectorization` 字段。

## 改动文件

- `src/config/official_configs.py` — 新增模型类及字段引用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在 A_Memorix 检索配置中新增关系向量化配置选项
  * 新增三个相关控制开关，支持灵活管理相关行为

<!-- end of auto-generated comment: release notes by coderabbit.ai -->