### PR TITLE
fix: 修复私聊出站消息 user_info 指向错误导致消息无法送达

### DIFF
--- a/src/common/data_models/mai_message_data_model.py
+++ b/src/common/data_models/mai_message_data_model.py
@@ -198,12 +198,18 @@ class MaiMessage(BaseDatabaseDataModel[Messages]):
                 user_info=receiver_user_info,
             )
 
+        # 私聊消息：适配器用 user_info.user_id 作为收件人 QQ
+        # 发件人信息在 sender_info 中，收件人在 receiver_info 中
+        effective_user_info = sender_user_info
+        if receiver_group_info is None and receiver_user_info is not None:
+            effective_user_info = receiver_user_info
+
         maim_msg_info = MaimBaseMessageInfo(
             platform=self.platform,
             message_id=self.message_id,
             time=self.timestamp.timestamp(),
             group_info=receiver_group_info,
-            user_info=sender_user_info,
+            user_info=effective_user_info,
             additional_config=self.message_info.additional_config,
             sender_info=sender_info,
             receiver_info=receiver_info,

--- a/src/config/official_configs.py
+++ b/src/config/official_configs.py
@@ -1736,6 +1736,46 @@ class AMemorixEmbeddingConfig(ConfigBase):
     """段落向量回填配置"""
 
 
+class AMemorixRelationVectorizationConfig(ConfigBase):
+    """A_Memorix 关系向量化配置"""
+
+    enabled: bool = Field(
+        default=False,
+        json_schema_extra={
+            "label": {
+                "zh_CN": "启用",
+                "en_US": "Enabled",
+                "ja_JP": "有効",
+            },
+        },
+    )
+    """是否启用关系向量化"""
+
+    backfill_enabled: bool = Field(
+        default=False,
+        json_schema_extra={
+            "label": {
+                "zh_CN": "回填",
+                "en_US": "Backfill",
+                "ja_JP": "バックフィル",
+            },
+        },
+    )
+    """是否启用关系向量回填"""
+
+    write_on_import: bool = Field(
+        default=True,
+        json_schema_extra={
+            "label": {
+                "zh_CN": "导入时写入",
+                "en_US": "Write on import",
+                "ja_JP": "インポート時書き込み",
+            },
+        },
+    )
+    """导入时是否写入关系向量"""
+
+
 class AMemorixSparseRetrievalConfig(ConfigBase):
     """A_Memorix 稀疏检索配置"""
 
@@ -1945,6 +1985,18 @@ class AMemorixRetrievalConfig(ConfigBase):
         },
     )
     """稀疏检索配置"""
+
+    relation_vectorization: AMemorixRelationVectorizationConfig = Field(
+        default_factory=lambda: AMemorixRelationVectorizationConfig(),
+        json_schema_extra={
+            "label": {
+                "zh_CN": "关系向量化",
+                "en_US": "Relation vectorization",
+                "ja_JP": "関係ベクトル化",
+            },
+        },
+    )
+    """关系向量化配置"""
 
 
 class AMemorixThresholdConfig(ConfigBase):


### PR DESCRIPTION
## 问题

Napcat 适配器在发送私聊消息时，以 `user_info.user_id` 作为目标收件人 QQ 调用 `send_private_msg`。但 `to_maim_message()` 将 `user_info` 设为发件人信息（机器人自身的 QQ），导致私聊消息被发送给机器人自己而非用户。

群聊不受影响，因为适配器走 `group_info.group_id`。

## 根因

重构 `send_service` 统一群聊/私聊发送路径后引入（`d07915eea0`）。此前 `private_generator` 也存在同样问题，但因有额外的发送路径差异，问题未被充分暴露。

## 修复

在 `to_maim_message()` 中：当消息无 `group_info`（即私聊）且 `receiver_user_info` 存在时，将 `user_info` 指向收件人信息而非发件人信息。

```python
effective_user_info = sender_user_info
if receiver_group_info is None and receiver_user_info is not None:
    effective_user_info = receiver_user_info
```

- 群聊路径不受影响（`receiver_group_info is not None`，条件短路）
- `from_maim_message` 不受影响（独立的入站消息解析路径）
- 消息存储不受影响（`to_maim_message` 不修改原始 `SessionMessage`）

## 验证

- 私聊 `/rss_list` 命令：修复前无响应，修复后正常返回
- Napcat 适配器日志确认 `send_private_msg` 正确发送到目标用户
- 群聊消息无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增关系向量化配置能力，支持控制关系向量化的启用状态、回填选项及导入行为。

* **改进**
  * 优化消息处理的用户信息选择逻辑，在特定条件下提供更灵活的用户信息绑定方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->