### PR TITLE
fix: 修复通知消息处理

### DIFF
--- a/src/chat/heart_flow/heartflow_message_processor.py
+++ b/src/chat/heart_flow/heartflow_message_processor.py
@@ -35,11 +35,6 @@ class HeartFCMessageReceiver:
             message: SessionMessage对象，包含原始消息数据和相关信息
         """
         try:
-            # 通知消息不处理
-            if message.is_notify:
-                logger.debug("通知消息，跳过处理")
-                return
-
             # 1. 消息解析与初始化
             userinfo = message.message_info.user_info
             group_info = message.message_info.group_info

--- a/src/chat/message_receive/bot.py
+++ b/src/chat/message_receive/bot.py
@@ -1,6 +1,5 @@
 """聊天消息入口与主链路调度。"""
 
-from contextlib import suppress
 from typing import Any, Dict, List, Optional
 
 import os
@@ -387,69 +386,28 @@ class ChatBot:
         return True
 
     async def handle_notice_message(self, message: SessionMessage) -> bool:
-        """处理通知类消息。
+        """处理通知类消息（戳一戳、撤回、禁言、入群退群等）。
+
+        适配器通过 ``is_notify`` 字段标识通知消息，同时通过
+        ``additional_config`` 中的 ``napcat_notice_type``、``napcat_notice_sub_type``
+        和 ``napcat_notice_payload`` 携带原始通知事件的详细信息。
 
         Args:
-            message: 当前通知消息。
+            message: 当前通知消息（已由适配器设置 ``is_notify=True``）。
 
         Returns:
-            bool: 当前消息是否为通知消息。
+            bool: 当前消息是通知消息时返回 ``True``，否则返回 ``False``。
         """
 
-        if message.message_id != "notice":
+        if not message.is_notify:
             return False
 
-        message.is_notify = True
-        logger.debug("notice消息")
-        try:
-            seg = getattr(message, "message_segment", None)  # SessionMessage 没有 message_segment
-            mi = message.message_info
-            sub_type = None
-            scene = None
-            msg_id = None
-            recalled: Dict[str, Any] = {}
-            recalled_id = None
+        additional_config = message.message_info.additional_config
+        if not isinstance(additional_config, dict):
+            return False
 
-            seg_data = getattr(seg, "data", None)
-            if getattr(seg, "type", None) == "notify" and isinstance(seg_data, dict):
-                sub_type = seg_data.get("sub_type")
-                scene = seg_data.get("scene")
-                msg_id = seg_data.get("message_id")
-                recalled = seg_data.get("recalled_user_info") or {}
-                if isinstance(recalled, dict):
-                    recalled_id = recalled.get("user_id")
-
-            op = mi.user_info
-            gid = mi.group_info.group_id if mi.group_info else None
-
-            # 撤回事件打印；无法获取被撤回者则省略
-            if sub_type == "recall":
-                op_name = (
-                    getattr(op, "user_cardname", None)
-                    or getattr(op, "user_nickname", None)
-                    or str(getattr(op, "user_id", None))
-                )
-                recalled_name = None
-                with suppress(Exception):
-                    if isinstance(recalled, dict):
-                        recalled_name = (
-                            recalled.get("user_cardname")
-                            or recalled.get("user_nickname")
-                            or str(recalled.get("user_id"))
-                        )
-
-                if recalled_name and str(recalled_id) != str(getattr(op, "user_id", None)):
-                    logger.info(f"{op_name} 撤回了 {recalled_name} 的消息")
-                else:
-                    logger.info(f"{op_name} 撤回了消息")
-            else:
-                logger.debug(
-                    f"[notice] sub_type={sub_type} scene={scene} op={getattr(op, 'user_nickname', None)}({getattr(op, 'user_id', None)}) "
-                    f"gid={gid} msg_id={msg_id} recalled={recalled_id}"
-                )
-        except Exception:
-            logger.info("[notice] (简略) 收到一条通知事件")
-
+        # 通知消息由适配器完整格式化（含 [事件-xxx] 前缀及详情），
+        # 此处仅做类型识别，具体文本由消息正常链路输出，避免重复日志。
         return True
 
     async def echo_message_process(self, raw_data: Dict[str, Any]) -> None:
@@ -570,18 +528,8 @@ class ChatBot:
             if isinstance(additional_config, dict):
                 account_id, scope = RouteKeyFactory.extract_components(additional_config)
 
-            # TODO: 修复事件预处理部分
-            # continue_flag, modified_message = await events_manager.handle_mai_events(
-            #     EventType.ON_MESSAGE_PRE_PROCESS, message
-            # )
-            # if not continue_flag:
-            #     return
-            # if modified_message and modified_message._modify_flags.modify_message_segments:
-            #     message.message_segment = Seg(type="seglist", data=modified_message.message_segments)
-
-            # TODO: notice消息处理
-            # if await self.handle_notice_message(message):
-            #     pass
+            # 通知消息（戳一戳、撤回、禁言等）由适配器标记 is_notify=True，
+            await self.handle_notice_message(message)
 
             # 处理消息内容，识别表情包等二进制数据并转化为文本描述。
             # 如果 Maisaka 需要直接消费图片，会在后续构建 prompt 时按需回填图片二进制数据，

--- a/src/maisaka/reasoning_engine.py
+++ b/src/maisaka/reasoning_engine.py
@@ -1414,13 +1414,6 @@ class MaisakaReasoningEngine:
     async def _ingest_messages(self, messages: list[SessionMessage]) -> None:
         """处理传入消息列表，将其转换为历史消息并加入聊天历史缓存。"""
         for message in messages:
-            if self._runtime._has_chat_history_message(message.message_id):
-                logger.debug(
-                    f"{self._runtime.log_prefix} 跳过已恢复的重复消息上下文: "
-                    f"message_id={message.message_id}"
-                )
-                continue
-
             history_message = await self._build_history_message(message)
             if history_message is None:
                 continue

--- a/src/maisaka/runtime.py
+++ b/src/maisaka/runtime.py
@@ -761,13 +761,7 @@ class MaisakaHeartFlowChatting(MaisakaFocusRuntimeMixin, MaisakaRuntimeDisplayMi
     def _get_pending_message_count(self) -> int:
         """统计当前尚未进入内部循环的新消息数量。"""
         pending_messages = self.message_cache[self._last_processed_index :]
-        if not pending_messages:
-            return 0
-
-        seen_message_ids: set[str] = set()
-        for message in pending_messages:
-            seen_message_ids.add(message.message_id)
-        return len(seen_message_ids)
+        return len(pending_messages)
 
     def _prune_recent_external_message_intervals(self, now: Optional[float] = None) -> None:
         """仅保留最近 30 分钟内的外部消息间隔记录。"""
@@ -837,18 +831,6 @@ class MaisakaHeartFlowChatting(MaisakaFocusRuntimeMixin, MaisakaRuntimeDisplayMi
             return original_message
 
         return None
-
-    def _has_chat_history_message(self, message_id: str) -> bool:
-        """判断指定真实消息是否已经注入过 Maisaka 上下文。"""
-
-        normalized_message_id = str(message_id or "").strip()
-        if not normalized_message_id:
-            return False
-
-        return any(
-            str(getattr(history_message, "message_id", "") or "").strip() == normalized_message_id
-            for history_message in self._chat_history
-        )
 
     def _prune_processed_message_cache(self) -> None:
         """裁剪 runtime 已经消费过的旧消息。"""
@@ -1504,23 +1486,14 @@ class MaisakaHeartFlowChatting(MaisakaFocusRuntimeMixin, MaisakaRuntimeDisplayMi
         if not pending_messages:
             return []
 
-        unique_messages: list[SessionMessage] = []
-        seen_message_ids: set[str] = set()
-        for message in pending_messages:
-            message_id = message.message_id
-            if message_id in seen_message_ids:
-                continue
-            seen_message_ids.add(message_id)
-            unique_messages.append(message)
-
         self._last_processed_index = len(self.message_cache)
-        if unique_messages:
+        if pending_messages:
             focus_mode_manager.mark_read(self.session_id)
         # logger.info(
         # f"{self.log_prefix} 已从消息缓存区[{start_index}:{self._last_processed_index}] "
-        # f"收集 {len(unique_messages)} 条新消息"
+        # f"收集 {len(pending_messages)} 条新消息"
         # )
-        return unique_messages
+        return pending_messages
 
     async def _wait_for_message_quiet_period(self) -> None:
         """等待消息静默窗口结束后，再启动由打断触发的新一轮。"""


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:
7. 请简要说明本次更新的内容和目的：修复通知消息处理，使麦麦处理戳一戳等消息的能力恢复
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 通知消息不再被提前跳过，将继续走完整的消息解析、入库与后续关联流程。
  * 通知消息识别改为依据适配器设置的 `is_notify`，并从附加配置读取通知类型信息以提高准确性。

* **变更**
  * 重复消息上下文不再去重，消息将被逐条构建并写入聊天历史。
  * 待处理消息统计与批次收集改为直接基于缓存切片长度计算。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->