### PR TITLE
feat: 插件配置支持多选字段和对象数组编辑能力

### DIFF
--- a/dashboard/src/components/ListFieldEditor.tsx
+++ b/dashboard/src/components/ListFieldEditor.tsx
@@ -32,6 +32,7 @@ import { DraftNumberInput } from '@/components/ui/draft-number-input'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card } from '@/components/ui/card'
+import { MultiSelect } from '@/components/ui/multi-select'
 import { Switch } from '@/components/ui/switch'
 import { Slider } from '@/components/ui/slider'
 import {
@@ -52,6 +53,10 @@ export interface ItemFieldDefinition {
   label?: string
   placeholder?: string
   default?: unknown
+  /** select 是否允许多选 */
+  multiple?: boolean
+  /** 当字段本身仍是数组时，描述其元素类型 */
+  item_type?: string
   /** select 类型的选项 */
   choices?: unknown[]
   /** slider 类型的最小值 */
@@ -60,6 +65,12 @@ export interface ItemFieldDefinition {
   max?: number
   /** slider 类型的步进 */
   step?: number
+  /** 嵌套数组为 object 时的字段定义 */
+  item_fields?: Record<string, ItemFieldDefinition>
+  /** 嵌套数组最小项数 */
+  min_items?: number
+  /** 嵌套数组最大项数 */
+  max_items?: number
 }
 
 export interface ListFieldEditorProps {
@@ -263,27 +274,47 @@ function ObjectItemEditor({
 
     // select
     if (fieldDef.type === 'select' && fieldDef.choices) {
+      const selectedValues = Array.isArray(fieldValue)
+            ? fieldValue.map((item) => String(item))
+            : Array.isArray(fieldDef.default)
+              ? fieldDef.default.map((item) => String(item))
+              : []
+
       return (
         <div className="space-y-1">
           <Label className="text-xs text-muted-foreground">
             {fieldDef.label ?? fieldName}
           </Label>
-          <Select
-            value={String(fieldValue ?? fieldDef.default ?? '')}
-            onValueChange={(v) => handleFieldChange(fieldName, v)}
-            disabled={disabled}
-          >
-            <SelectTrigger className="h-8 text-sm">
-              <SelectValue placeholder={fieldDef.placeholder ?? '请选择'} />
-            </SelectTrigger>
-            <SelectContent>
-              {fieldDef.choices.map((choice) => (
-                <SelectItem key={String(choice)} value={String(choice)}>
-                  {String(choice)}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+         {
+            fieldDef.multiple ? 
+            <MultiSelect
+              options={fieldDef.choices.map((choice) => ({
+                label: String(choice),
+                value: String(choice),
+              }))}
+              selected={selectedValues}
+              onChange={(nextValue) => handleFieldChange(fieldName, nextValue)}
+              placeholder={fieldDef.placeholder ?? '请选择'}
+              compact
+              disabled={disabled}
+            />: 
+            <Select
+              value={String(fieldValue ?? fieldDef.default ?? '')}
+              onValueChange={(v) => handleFieldChange(fieldName, v)}
+              disabled={disabled}
+            >
+              <SelectTrigger className="h-8 text-sm">
+                <SelectValue placeholder={fieldDef.placeholder ?? '请选择'} />
+              </SelectTrigger>
+              <SelectContent>
+                {fieldDef.choices.map((choice) => (
+                  <SelectItem key={String(choice)} value={String(choice)}>
+                    {String(choice)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          }
         </div>
       )
     }
@@ -305,6 +336,33 @@ function ObjectItemEditor({
             placeholder={fieldDef.placeholder}
             disabled={disabled}
             className="h-8 text-sm"
+          />
+        </div>
+      )
+    }
+
+    // array
+    if (fieldDef.type === 'array') {
+      const selectedValues = Array.isArray(fieldValue)
+        ? fieldValue
+        : Array.isArray(fieldDef.default)
+          ? fieldDef.default
+          : []
+
+      return (
+        <div className="space-y-1">
+          <Label className="text-xs text-muted-foreground">
+            {fieldDef.label ?? fieldName}
+          </Label>
+          <ListFieldEditor
+            value={selectedValues}
+            onChange={(nextValue) => handleFieldChange(fieldName, nextValue)}
+            itemType={fieldDef.item_type ?? 'string'}
+            itemFields={fieldDef.item_fields}
+            minItems={fieldDef.min_items}
+            maxItems={fieldDef.max_items}
+            disabled={disabled}
+            placeholder={fieldDef.placeholder}
           />
         </div>
       )

--- a/dashboard/src/components/__tests__/ListFieldEditor.test.tsx
+++ b/dashboard/src/components/__tests__/ListFieldEditor.test.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ListFieldEditor } from '@/components/ListFieldEditor'
+
+describe('ListFieldEditor', () => {
+  it('将 multiple=true 的 select 子字段渲染为多选下拉', async () => {
+    const user = userEvent.setup()
+    const handleChange = vi.fn()
+
+    render(
+      <ListFieldEditor
+        value={[{ api_names: [] }]}
+        onChange={handleChange}
+        itemType="object"
+        itemFields={{
+          api_names: {
+            type: 'select',
+            label: '需要推送的 API 配置组',
+            default: [],
+            multiple: true,
+            choices: ['daily_news', 'ai_news', 'it_news'],
+          },
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole('combobox'))
+    await user.click(screen.getByText('ai_news'))
+
+    expect(handleChange).toHaveBeenCalledWith([{ api_names: ['ai_news'] }])
+  })
+
+  it('对象数组中的多选子字段会将已选数字值规范为字符串并正确切换', async () => {
+    const user = userEvent.setup()
+    const handleChange = vi.fn()
+
+    render(
+      <ListFieldEditor
+        value={[{ api_ids: [1] }]}
+        onChange={handleChange}
+        itemType="object"
+        itemFields={{
+          api_ids: {
+            type: 'select',
+            label: 'API 编号',
+            default: [],
+            multiple: true,
+            choices: [1, 2, 3],
+          },
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole('combobox'))
+    await user.click(screen.getAllByText('1').at(-1)!)
+
+    expect(handleChange).toHaveBeenCalledWith([{ api_ids: [] }])
+  })
+
+  it('父级 disabled 时禁用对象数组中的多选子字段', () => {
+    render(
+      <ListFieldEditor
+        value={[{ api_names: ['daily_news'] }]}
+        onChange={vi.fn()}
+        itemType="object"
+        itemFields={{
+          api_names: {
+            type: 'select',
+            label: '需要推送的 API 配置组',
+            default: [],
+            multiple: true,
+            choices: ['daily_news', 'ai_news', 'it_news'],
+          },
+        }}
+        disabled
+      />
+    )
+
+    expect(screen.getByRole('combobox')).toBeDisabled()
+  })
+
+  it('保留对象数组子字段中的嵌套字符串数组编辑能力', async () => {
+    const handleChange = vi.fn()
+
+    render(
+      <ListFieldEditor
+        value={[{ push_groups: ['group-a'] }]}
+        onChange={handleChange}
+        itemType="object"
+        itemFields={{
+          push_groups: {
+            type: 'array',
+            label: '推送群列表',
+            default: [],
+            item_type: 'string',
+          },
+        }}
+      />
+    )
+
+    const input = screen.getByDisplayValue('group-a')
+    fireEvent.change(input, { target: { value: 'group-b' } })
+
+    expect(handleChange).toHaveBeenLastCalledWith([{ push_groups: ['group-b'] }])
+  })
+})

--- a/dashboard/src/components/ui/multi-select.tsx
+++ b/dashboard/src/components/ui/multi-select.tsx
@@ -52,6 +52,7 @@ interface MultiSelectProps {
   emptyText?: string
   className?: string
   compact?: boolean
+  disabled?: boolean
 }
 
 // 可排序的标签组件
@@ -60,11 +61,13 @@ function SortableBadge({
   label,
   onRemove,
   compact = false,
+  disabled = false,
 }: {
   value: string
   label: string
   onRemove: (value: string) => void
   compact?: boolean
+  disabled?: boolean
 }) {
   const {
     attributes,
@@ -73,7 +76,7 @@ function SortableBadge({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: value })
+  } = useSortable({ id: value, disabled })
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -85,6 +88,7 @@ function SortableBadge({
   const handleRemoveClick = (e: React.MouseEvent | React.KeyboardEvent) => {
     e.preventDefault()
     e.stopPropagation()
+    if (disabled) return
     onRemove(value)
   }
 
@@ -105,14 +109,20 @@ function SortableBadge({
       <Badge
         variant="secondary"
         className={cn(
-          'flex cursor-move items-center gap-1 hover:bg-secondary/80',
+          'flex items-center gap-1 hover:bg-secondary/80',
+          !disabled && 'cursor-move',
+          disabled && 'opacity-60',
           compact && 'min-h-6 max-w-[calc(100vw-5rem)] px-1.5 py-0 text-[11px] leading-none sm:max-w-full'
         )}
       >
         <div
           {...attributes}
           {...listeners}
-          className="flex cursor-grab items-center active:cursor-grabbing"
+          className={cn(
+            'flex items-center',
+            !disabled && 'cursor-grab active:cursor-grabbing',
+            disabled && 'cursor-not-allowed'
+          )}
         >
           <GripVertical className="h-3 w-3 text-muted-foreground" />
         </div>
@@ -127,6 +137,7 @@ function SortableBadge({
           onClick={handleRemoveClick}
           onPointerDown={handleRemovePointerDown}
           onMouseDown={(e) => e.stopPropagation()}
+          aria-disabled={disabled}
           onKeyDown={(e) => {
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault()
@@ -153,8 +164,15 @@ export function MultiSelect({
   emptyText = '未找到选项',
   className,
   compact = false,
+  disabled = false,
 }: MultiSelectProps) {
   const [open, setOpen] = React.useState(false)
+
+  React.useEffect(() => {
+    if (disabled && open) {
+      setOpen(false)
+    }
+  }, [disabled, open])
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -168,6 +186,7 @@ export function MultiSelect({
   )
 
   const handleSelect = (value: string) => {
+    if (disabled) return
     if (selected.includes(value)) {
       // 取消选择
       onChange(selected.filter((item) => item !== value))
@@ -178,10 +197,12 @@ export function MultiSelect({
   }
 
   const handleRemove = (value: string) => {
+    if (disabled) return
     onChange(selected.filter((item) => item !== value))
   }
 
   const handleDragEnd = (event: DragEndEvent) => {
+    if (disabled) return
     const { active, over } = event
 
     if (over && active.id !== over.id) {
@@ -193,12 +214,20 @@ export function MultiSelect({
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={disabled ? false : open}
+      onOpenChange={(nextOpen) => {
+        if (!disabled) {
+          setOpen(nextOpen)
+        }
+      }}
+    >
       <PopoverTrigger asChild>
         <Button
           variant="outline"
           role="combobox"
           aria-expanded={open}
+          disabled={disabled}
           className={cn(
             'h-auto w-full justify-between',
             compact ? 'min-h-9 px-2 py-1.5' : 'min-h-10',
@@ -227,6 +256,7 @@ export function MultiSelect({
                         label={option?.label || value}
                         onRemove={handleRemove}
                         compact={compact}
+                        disabled={disabled}
                       />
                     )
                   })
@@ -249,6 +279,7 @@ export function MultiSelect({
                   <CommandItem
                     key={option.value}
                     value={option.value}
+                    disabled={disabled}
                     onSelect={() => handleSelect(option.value)}
                   >
                     <div

--- a/dashboard/src/lib/plugin-api/types.ts
+++ b/dashboard/src/lib/plugin-api/types.ts
@@ -96,6 +96,15 @@ export interface ItemFieldDefinition {
   label?: string
   placeholder?: string
   default?: unknown
+  multiple?: boolean
+  choices?: unknown[]
+  min?: number
+  max?: number
+  step?: number
+  item_type?: string
+  item_fields?: Record<string, ItemFieldDefinition>
+  min_items?: number
+  max_items?: number
   i18n?: Record<string, Record<string, string>>
 }
 
@@ -109,6 +118,7 @@ export interface ConfigFieldSchema {
   description: string
   example?: string
   required: boolean
+  multiple?: boolean
   choices?: unknown[]
   min?: number
   max?: number

--- a/dashboard/src/routes/__tests__/plugin-config.test.tsx
+++ b/dashboard/src/routes/__tests__/plugin-config.test.tsx
@@ -129,4 +129,94 @@ describe('PluginConfigPage 特征化', () => {
     await user.click(screen.getByRole('button', { name: /保存/ }))
     await waitFor(() => expect(pluginApi.updatePluginConfigRaw).toHaveBeenCalled())
   })
+
+  it('可视化模式下将 multiple=true 的 select 字段保存为字符串数组', async () => {
+    const user = userEvent.setup()
+    vi.mocked(pluginApi.getPluginConfigSchema).mockResolvedValue({
+      plugin_info: { name: 'Emoji Plugin', version: '1.0.0', description: 'desc' },
+      sections: {
+        batch: {
+          name: 'batch',
+          title: '批量配置',
+          collapsed: false,
+          order: 0,
+          fields: {
+            push_format: {
+              name: 'push_format',
+              type: 'select',
+              default: [],
+              description: '推送格式',
+              required: false,
+              choices: ['image', 'text'],
+              multiple: true,
+              label: '推送格式',
+              hidden: false,
+              disabled: false,
+              order: 0,
+              ui_type: 'select',
+            },
+          },
+        },
+      },
+      layout: { type: 'auto', tabs: [] },
+    } as never)
+    vi.mocked(pluginApi.getPluginConfig).mockResolvedValue({
+      batch: { push_format: [] },
+    } as never)
+
+    render(<PluginConfigPage />)
+    await user.click(await screen.findByRole('button', { name: /Emoji Plugin/ }))
+
+    await screen.findByText('推送格式')
+    await user.click((await screen.findAllByRole('combobox'))[0])
+    await user.click(await screen.findByText('image'))
+    await user.click(await screen.findByText('text'))
+    await user.click(screen.getByRole('button', { name: /保存/ }))
+
+    await waitFor(() =>
+      expect(pluginApi.updatePluginConfig).toHaveBeenCalledWith('test.emoji', {
+        batch: { push_format: ['image', 'text'] },
+      })
+    )
+  })
+
+  it('可视化模式下将 disabled 的多选字段渲染为禁用态', async () => {
+    vi.mocked(pluginApi.getPluginConfigSchema).mockResolvedValue({
+      plugin_info: { name: 'Emoji Plugin', version: '1.0.0', description: 'desc' },
+      sections: {
+        batch: {
+          name: 'batch',
+          title: '批量配置',
+          collapsed: false,
+          order: 0,
+          fields: {
+            push_format: {
+              name: 'push_format',
+              type: 'select',
+              default: ['image'],
+              description: '推送格式',
+              required: false,
+              choices: ['image', 'text'],
+              multiple: true,
+              label: '推送格式',
+              hidden: false,
+              disabled: true,
+              order: 0,
+              ui_type: 'select',
+            },
+          },
+        },
+      },
+      layout: { type: 'auto', tabs: [] },
+    } as never)
+    vi.mocked(pluginApi.getPluginConfig).mockResolvedValue({
+      batch: { push_format: ['image'] },
+    } as never)
+
+    render(<PluginConfigPage />)
+    await userEvent.click(await screen.findByRole('button', { name: /Emoji Plugin/ }))
+
+    await screen.findByText('推送格式')
+    expect((await screen.findAllByRole('combobox'))[0]).toBeDisabled()
+  })
 })

--- a/dashboard/src/routes/plugin-config.tsx
+++ b/dashboard/src/routes/plugin-config.tsx
@@ -14,6 +14,7 @@ import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { ListFieldEditor } from '@/components/ListFieldEditor'
+import { MultiSelect } from '@/components/ui/multi-select'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { CodeEditor } from '@/components/CodeEditor'
 import { useTheme } from '@/components/use-theme'
@@ -218,6 +219,33 @@ function FieldRenderer({ field, value, onChange }: FieldRendererProps) {
       )
 
     case 'select':
+      if (field.multiple) {
+        const selectedValues = Array.isArray(value)
+          ? value.map(v => String(v))
+          : Array.isArray(field.default)
+            ? field.default.map(v => String(v))
+            : []
+
+        return (
+          <div className="space-y-2">
+            <Label>{label}</Label>
+            <MultiSelect
+              options={(field.choices ?? []).map((choice) => ({
+                label: String(choice),
+                value: String(choice),
+              }))}
+              selected={selectedValues}
+              onChange={onChange}
+              placeholder={placeholder || '请选择'}
+              disabled={field.disabled}
+            />
+            {hint && (
+              <p className="text-xs text-muted-foreground">{hint}</p>
+            )}
+          </div>
+        )
+      }
+
       return (
         <div className="space-y-2">
           <Label>{label}</Label>

--- a/src/plugin_runtime/runner/runner_main.py
+++ b/src/plugin_runtime/runner/runner_main.py
@@ -219,8 +219,26 @@ def _deep_copy_plugin_config_mapping(value: Mapping[str, Any]) -> Dict[str, Any]
     return {str(key): _deep_copy_plugin_config_value(item) for key, item in value.items()}
 
 
+def _is_plugin_config_value_type_compatible(target_value: Any, source_value: Any) -> bool:
+    """判断旧配置值是否可回填到新默认配置字段。"""
+
+    if target_value is None:
+        return True
+    if isinstance(target_value, bool):
+        return isinstance(source_value, bool)
+    if isinstance(target_value, str):
+        return isinstance(source_value, str)
+    if isinstance(target_value, list):
+        return isinstance(source_value, list)
+    if isinstance(target_value, int):
+        return isinstance(source_value, int) and not isinstance(source_value, bool)
+    if isinstance(target_value, float):
+        return isinstance(source_value, (int, float)) and not isinstance(source_value, bool)
+    return isinstance(source_value, type(target_value))
+
+
 def _overlay_plugin_config_fields(target: Dict[str, Any], source: Mapping[str, Any]) -> None:
-    """将旧配置中的已有字段覆盖到新配置骨架中。
+    """将旧配置中类型匹配的已有字段覆盖到新配置骨架中。
 
     Args:
         target: 以最新默认配置构造出的目标配置字典。
@@ -236,6 +254,9 @@ def _overlay_plugin_config_fields(target: Dict[str, Any], source: Mapping[str, A
         target_value = target[key]
         if isinstance(target_value, dict) and isinstance(source_value, Mapping):
             _overlay_plugin_config_fields(target_value, source_value)
+            continue
+
+        if not _is_plugin_config_value_type_compatible(target_value, source_value):
             continue
 
         target[key] = _deep_copy_plugin_config_value(source_value)
@@ -276,7 +297,7 @@ def rebuild_plugin_config_data(
 ) -> Dict[str, Any]:
     """基于默认结构重建插件配置。
 
-    该方法用于版本升级场景：以最新默认配置为骨架，仅迁移仍然存在的旧字段值，
+    该方法用于版本升级场景：以最新默认配置为骨架，仅迁移仍然存在且类型匹配的旧字段值，
     从而达到“补齐新增字段、移除废弃字段、保留用户已有值”的效果。
 
     Args:


### PR DESCRIPTION
- 插件配置页支持通过list[Literal["a","b"]]方式配置为多选 select 字段渲染
- ListFieldEditor 支持对象数组中的多选字段与嵌套数组字段编辑
- MultiSelect 增加 disabled 处理并补齐相关回归测试

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [ ] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [ ] 本次更新类型为：BUG修复
   - [x] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:
7. 请简要说明本次更新的内容和目的：
插件配置方式增强，嵌套的配置对象的属性支持数组渲染和支持多选select，让插件配置更灵活
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
<img width="1890" height="2500" alt="image" src="https://github.com/user-attachments/assets/3988ddd1-1c51-4c52-961d-893ca7701e61" />

<img width="993" height="835" alt="image" src="https://github.com/user-attachments/assets/9c491d02-019a-4014-830f-8ca24e672c82" />

- **附加信息**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 表单字段支持多选模式：`select` 可选择多个选项并正确保存为数组值。
  * 新增数组/嵌套数组字段编辑能力：支持配置多项、子项类型与子项字段，并可设置数量范围（min/max）。

* **改进**
  * 多选控件支持禁用状态联动，禁用时不再允许增删与交互。
  * 插件配置“版本升级/重建”回填将进行类型兼容校验，避免不兼容旧值覆盖。

* **测试**
  * 补充多选、嵌套数组与禁用联动的交互用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->