### PR TITLE
fix: 修复列表编辑器排序后回弹问题

### DIFF
--- a/dashboard/src/components/ListFieldEditor.tsx
+++ b/dashboard/src/components/ListFieldEditor.tsx
@@ -439,7 +439,8 @@ export function ListFieldEditor({
       newIds.push(getItemId(i))
     }
     return newIds
-  }, [items.length, getItemId])
+    // 同长度排序也会改变每个位置对应的数据项，需要重新读取已重排的 ID 映射。
+  }, [items, getItemId])
 
   // DnD 传感器配置
   const sensors = useSensors(
@@ -460,11 +461,17 @@ export function ListFieldEditor({
       if (over && active.id !== over.id) {
         const oldIndex = sortableIds.indexOf(active.id as string)
         const newIndex = sortableIds.indexOf(over.id as string)
+        if (oldIndex === -1 || newIndex === -1) return
+
         const newItems = arrayMove(items, oldIndex, newIndex)
+        // key 必须跟随被拖拽的数据项移动，避免 React 按旧位置复用输入框等子组件状态。
+        arrayMove(sortableIds, oldIndex, newIndex).forEach((id, index) => {
+          itemIds.set(index, id)
+        })
         onChange(newItems)
       }
     },
-    [items, sortableIds, onChange]
+    [items, sortableIds, itemIds, onChange]
   )
 
   // 添加新项
@@ -501,11 +508,17 @@ export function ListFieldEditor({
     (index: number) => {
       if (minItems != null && items.length <= minItems) return
       const newItems = items.filter((_: unknown, i: number) => i !== index)
-      // 清理 itemIds 映射
-      itemIds.delete(index)
+      // 删除后后续数据项会前移，对应的 key 也要前移。
+      sortableIds
+        .filter((_: string, i: number) => i !== index)
+        .forEach((id, nextIndex) => {
+          itemIds.set(nextIndex, id)
+        })
+      // 前移后 Map 中仍会残留旧的最后一项索引，需要按新长度删除尾部 ID。
+      itemIds.delete(newItems.length)
       onChange(newItems)
     },
-    [items, minItems, itemIds, onChange]
+    [items, minItems, sortableIds, itemIds, onChange]
   )
 
   const canAdd = maxItems == null || items.length < maxItems

--- a/dashboard/src/components/__tests__/ListFieldEditor.test.tsx
+++ b/dashboard/src/components/__tests__/ListFieldEditor.test.tsx
@@ -1,10 +1,66 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { useState, type ReactNode } from 'react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ListFieldEditor } from '@/components/ListFieldEditor'
 
+const dndState = vi.hoisted(() => ({
+  onDragEnd: undefined as ((event: unknown) => void) | undefined,
+  sortableItems: [] as string[],
+}))
+
+vi.mock('@dnd-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/core')>()
+
+  return {
+    ...actual,
+    DndContext: ({
+      children,
+      onDragEnd,
+    }: {
+      children: ReactNode
+      onDragEnd?: (event: unknown) => void
+    }) => {
+      dndState.onDragEnd = onDragEnd
+      return <div>{children}</div>
+    },
+  }
+})
+
+vi.mock('@dnd-kit/sortable', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/sortable')>()
+
+  return {
+    ...actual,
+    SortableContext: ({
+      children,
+      items,
+    }: {
+      children: ReactNode
+      items: string[]
+    }) => {
+      dndState.sortableItems = [...items]
+      return <div>{children}</div>
+    },
+    useSortable: () => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: vi.fn(),
+      transform: null,
+      transition: undefined,
+      isDragging: false,
+    }),
+  }
+})
+
 describe('ListFieldEditor', () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn()
+    dndState.onDragEnd = undefined
+    dndState.sortableItems = []
+  })
+
   it('将 multiple=true 的 select 子字段渲染为多选下拉', async () => {
     const user = userEvent.setup()
     const handleChange = vi.fn()
@@ -104,5 +160,35 @@ describe('ListFieldEditor', () => {
     fireEvent.change(input, { target: { value: 'group-b' } })
 
     expect(handleChange).toHaveBeenLastCalledWith([{ push_groups: ['group-b'] }])
+  })
+
+  it('拖拽排序后正在编辑的数字项状态会跟随项目移动', () => {
+    const ControlledListFieldEditor = () => {
+      const [items, setItems] = useState<unknown[]>([1, 2])
+
+      return (
+        <ListFieldEditor
+          value={items}
+          onChange={setItems}
+          itemType="number"
+        />
+      )
+    }
+
+    render(<ControlledListFieldEditor />)
+
+    const inputs = screen.getAllByRole('spinbutton')
+    fireEvent.focus(inputs[0])
+    fireEvent.change(inputs[0], { target: { value: '10' } })
+
+    expect(dndState.onDragEnd).toBeDefined()
+    act(() => {
+      dndState.onDragEnd?.({
+        active: { id: dndState.sortableItems[0] },
+        over: { id: dndState.sortableItems[1] },
+      })
+    })
+
+    expect(screen.getAllByRole('spinbutton').map((input) => (input as HTMLInputElement).value)).toEqual(['2', '10'])
   })
 })


### PR DESCRIPTION
- 同步维护 ListFieldEditor 拖拽排序和删除时的条目 ID 映射，确保 React key 跟随实际数据项移动，避免输入框等子组件状态按旧位置复用导致回弹或状态错位。

- 新增拖拽排序回归测试，覆盖正在编辑的数字项排序后状态跟随项目移动的场景。

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:
7. 请简要说明本次更新的内容和目的：
    修复列表编辑器排序后回弹问题
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
**before**
<img width="543" height="200" alt="202606172174845" src="https://github.com/user-attachments/assets/916bcb37-5083-4720-8b1f-6ac1f536b3c0" />

**after**
<img width="563" height="176" alt="202606172175111" src="https://github.com/user-attachments/assets/5db75cc2-0def-4e8b-8805-e6a07a48e540" />


- **附加信息**:
