### PR TITLE
feat: WebUI 支持多 host 绑定

### DIFF
--- a/src/common/message_server/server.py
+++ b/src/common/message_server/server.py
@@ -126,5 +126,5 @@ def get_global_server() -> Server:
     global global_server
     if global_server is None:
         bind_address = resolve_main_bind_address()
-        global_server = Server(host=bind_address.host, port=bind_address.port)
+        global_server = Server(host=bind_address.hosts[0], port=bind_address.port)  # 消息服务只需单一地址，取第一个
     return global_server

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -66,7 +66,7 @@ MODEL_CONFIG_PATH: Path = (CONFIG_DIR / "model_config.toml").resolve().absolute(
 LEGACY_ENV_PATH: Path = (PROJECT_ROOT / ".env").resolve().absolute()
 A_MEMORIX_LEGACY_CONFIG_PATH: Path = (CONFIG_DIR / "a_memorix.toml").resolve().absolute()
 MMC_VERSION: str = read_project_version(PROJECT_ROOT)
-CONFIG_VERSION: str = "8.14.12"
+CONFIG_VERSION: str = "8.14.13"
 MODEL_CONFIG_VERSION: str = "1.17.3"
 
 logger = get_logger("config")

--- a/src/config/config_upgrade_hooks.py
+++ b/src/config/config_upgrade_hooks.py
@@ -272,6 +272,25 @@ def _add_precise_expression_selection_default(data: dict[str, Any]) -> list[str]
     return ["expression.enable_precise_expression_selection"]
 
 
+def _normalize_webui_host_to_list(data: dict[str, Any]) -> list[str]:
+    """
+    8.14.13: 将 WebUI host 从 str 转换为 list[str]。
+    旧配置中 host 为单地址字符串（如 "127.0.0.1"），新配置为列表。
+    """
+    webui = _as_dict(data.get("webui"))
+    if webui is None:
+        return []
+
+    host = webui.get("host")
+    if isinstance(host, list):
+        return []
+    if isinstance(host, str):
+        webui["host"] = [host]
+        return ["webui.host"]
+
+    return []
+
+
 def _normalize_group_list_fields(section: dict[str, Any], list_key: str, old_inner_key: str) -> bool:
     group_list = _as_list(section.get(list_key))
     if group_list is None:
@@ -371,6 +390,11 @@ BOT_CONFIG_UPGRADE_HOOKS: tuple[ConfigUpgradeHook, ...] = (
         target_version="8.12.9",
         config_names=("bot_config.toml",),
         migrate=_add_precise_expression_selection_default,
+    ),
+    ConfigUpgradeHook(
+        target_version="8.14.13",
+        config_names=("bot_config.toml",),
+        migrate=_normalize_webui_host_to_list,
     ),
 )
 MODEL_CONFIG_UPGRADE_HOOKS: tuple[ConfigUpgradeHook, ...] = ()

--- a/src/config/official_configs.py
+++ b/src/config/official_configs.py
@@ -4359,7 +4359,7 @@ class WebUIConfig(ConfigBase):
                 "en_US": "WebUI host",
                 "ja_JP": "WebUI ホスト",
             },
-            "x-widget": "input",
+            "x-widget": "tags",
             "x-icon": "globe",
         },
     )

--- a/src/config/official_configs.py
+++ b/src/config/official_configs.py
@@ -4351,8 +4351,8 @@ class WebUIConfig(ConfigBase):
     )
     """是否启动 WebUI 管理界面。"""
 
-    host: str = Field(
-        default="127.0.0.1",
+    host: list[str] = Field(
+        default=["127.0.0.1", "::1"],
         json_schema_extra={
             "label": {
                 "zh_CN": "WebUI 主机",
@@ -4363,7 +4363,7 @@ class WebUIConfig(ConfigBase):
             "x-icon": "globe",
         },
     )
-    """WebUI 监听地址；本机使用通常填 127.0.0.1。"""
+    """WebUI 监听地址列表；可同时绑定 IPv4 和 IPv6，例如 ["0.0.0.0", "::"]。"""
 
     port: int = Field(
         default=8001,

--- a/src/config/startup_bindings.py
+++ b/src/config/startup_bindings.py
@@ -15,24 +15,26 @@ BOT_CONFIG_PATH: Path = (CONFIG_DIR / "bot_config.toml").resolve().absolute()
 class BindAddress:
     """启动阶段使用的绑定地址。"""
 
-    host: str
+    hosts: list[str]
     port: int
 
 
-_DEFAULT_MAIN_BIND_ADDRESS = BindAddress(host="127.0.0.1", port=8080)
-_DEFAULT_WEBUI_BIND_ADDRESS = BindAddress(host="127.0.0.1", port=8001)
+_DEFAULT_MAIN_BIND_ADDRESS = BindAddress(hosts=["127.0.0.1"], port=8080)
+_DEFAULT_WEBUI_BIND_ADDRESS = BindAddress(hosts=["127.0.0.1", "::1"], port=8001)
 
 
 def _as_mapping(value: Any) -> Optional[Mapping[str, Any]]:
     return value if isinstance(value, Mapping) else None
 
 
-def _normalize_host(value: Any, default_host: str) -> str:
-    if not isinstance(value, str):
-        return default_host
-
-    normalized_host = value.strip()
-    return normalized_host or default_host
+def _normalize_hosts(value: Any, default_hosts: list[str]) -> list[str]:
+    if isinstance(value, list):
+        hosts = [h.strip() for h in value if isinstance(h, str) and h.strip()]
+        return hosts or default_hosts
+    if isinstance(value, str):
+        h = value.strip()
+        return [h] if h else default_hosts
+    return default_hosts
 
 
 def _normalize_port(value: Any, default_port: int) -> int:
@@ -73,7 +75,7 @@ def _resolve_bind_address_from_section(
     default_address: BindAddress,
 ) -> BindAddress:
     return BindAddress(
-        host=_normalize_host(section.get(host_key), default_address.host),
+        hosts=_normalize_hosts(section.get(host_key), default_address.hosts),
         port=_normalize_port(section.get(port_key), default_address.port),
     )
 
@@ -117,7 +119,7 @@ def resolve_main_bind_address(config_path: Path = BOT_CONFIG_PATH) -> BindAddres
     global_config = _get_loaded_global_config()
     if global_config is not None:
         return BindAddress(
-            host=global_config.maim_message.ws_server_host,
+            hosts=_normalize_hosts(global_config.maim_message.ws_server_host, _DEFAULT_MAIN_BIND_ADDRESS.hosts),
             port=global_config.maim_message.ws_server_port,
         )
     return get_startup_main_bind_address(config_path)
@@ -129,7 +131,7 @@ def resolve_webui_bind_address(config_path: Path = BOT_CONFIG_PATH) -> BindAddre
     global_config = _get_loaded_global_config()
     if global_config is not None:
         return BindAddress(
-            host=global_config.webui.host,
+            hosts=_normalize_hosts(global_config.webui.host, _DEFAULT_WEBUI_BIND_ADDRESS.hosts),
             port=global_config.webui.port,
         )
     return get_startup_webui_bind_address(config_path)

--- a/src/maisaka/display/prompt_cli_renderer.py
+++ b/src/maisaka/display/prompt_cli_renderer.py
@@ -45,7 +45,7 @@ def _build_webui_local_base_url() -> str:
     try:
         from src.config.config import global_config
 
-        host = str(global_config.webui.host or "127.0.0.1").strip()
+        host = _select_webui_local_host(global_config.webui.host)
         port = int(global_config.webui.port or 8001)
     except Exception:
         host = "127.0.0.1"
@@ -56,6 +56,22 @@ def _build_webui_local_base_url() -> str:
     if ":" in host and not host.startswith("["):
         host = f"[{host}]"
     return f"http://{host}:{port}"
+
+
+def _select_webui_local_host(hosts: Any) -> str:
+    """从 WebUI 监听地址中选择适合终端打开的本机地址。"""
+
+    if isinstance(hosts, str):
+        return hosts.strip() or "127.0.0.1"
+    if isinstance(hosts, list):
+        normalized_hosts = [host.strip() for host in hosts if isinstance(host, str) and host.strip()]
+        if "127.0.0.1" in normalized_hosts:
+            return "127.0.0.1"
+        if "::1" in normalized_hosts:
+            return "::1"
+        if normalized_hosts:
+            return normalized_hosts[0]
+    return "127.0.0.1"
 
 
 def _resolve_prompt_preview_route_target(file_path: Path) -> PromptPreviewRouteTarget | None:

--- a/src/webui/webui_server.py
+++ b/src/webui/webui_server.py
@@ -33,12 +33,12 @@ class _ASGIProxy:
 class WebUIServer:
     """独立的 WebUI 服务器"""
 
-    def __init__(self, host: str = "0.0.0.0", port: int = 8001, register_config_reload: bool = True):
-        self.host = host
+    def __init__(self, hosts: list[str] | None = None, port: int = 8001, register_config_reload: bool = True):
+        self.hosts = hosts or ["127.0.0.1", "::1"]
         self.port = port
         from src.webui.app import create_app, show_access_token
 
-        self._app = create_app(host=host, port=port, enable_static=True)
+        self._app = create_app(host=self.hosts[0], port=port, enable_static=True)
         self.app = _ASGIProxy(self._app)
         self._server: Optional[Any] = None
         self._reload_callback_registered = False
@@ -77,9 +77,68 @@ class WebUIServer:
     async def reload_app(self) -> None:
         from src.webui.app import create_app
 
-        self._app = create_app(host=self.host, port=self.port, enable_static=True)
+        self._app = create_app(host=self.hosts[0], port=self.port, enable_static=True)
         self.app.set_app(self._app)
         logger.info("WebUI 应用已热重载")
+
+    def _create_bound_sockets(self) -> list:
+        import socket as _socket
+
+        sockets = []
+        for host in self.hosts:
+            addr_info_list = _socket.getaddrinfo(host, self.port, _socket.AF_UNSPEC, _socket.SOCK_STREAM)
+            for af, socktype, proto, _, sa in addr_info_list:
+                sock = None
+                try:
+                    sock = _socket.socket(af, socktype, proto)
+                    sock.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
+                    if af == _socket.AF_INET6:
+                        try:
+                            sock.setsockopt(_socket.IPPROTO_IPV6, _socket.IPV6_V6ONLY, 0)
+                        except OSError:
+                            pass
+                    sock.bind(sa)
+                    sock.listen()
+                    sockets.append(sock)
+                    break
+                except OSError:
+                    if sock is not None:
+                        try:
+                            sock.close()
+                        except OSError:
+                            pass
+                    continue
+
+        return sockets
+
+    def _log_bind_addresses(self) -> None:
+        has_v4_localhost = False
+        has_v6_localhost = False
+        has_v4_wildcard = False
+        has_v6_wildcard = False
+
+        for host in self.hosts:
+            if ":" in host:
+                logger.info(f"🌐 访问地址: http://[{host}]:{self.port}")
+                if host == "::":
+                    has_v6_wildcard = True
+                elif host == "::1":
+                    has_v6_localhost = True
+            else:
+                logger.info(f"🌐 访问地址: http://{host}:{self.port}")
+                if host == "0.0.0.0":
+                    has_v4_wildcard = True
+                elif host == "127.0.0.1":
+                    has_v4_localhost = True
+
+        if has_v4_wildcard or has_v6_wildcard:
+            local = []
+            if has_v4_wildcard or has_v4_localhost:
+                local.append(f"http://localhost:{self.port}")
+            if has_v6_wildcard or has_v6_localhost:
+                local.append(f"http://[::1]:{self.port}")
+            if local:
+                logger.info(f"💡 本机访问: {'， '.join(local)}")
 
     async def start(self):
         """启动服务器"""
@@ -87,18 +146,25 @@ class WebUIServer:
         from uvicorn import Server as UvicornServer
 
         self._maybe_register_reload_callback()
-        assert_port_available(
-            host=self.host,
-            port=self.port,
-            service_name="WebUI 服务器",
-            logger=logger,
-            config_hint="webui.port (config/bot_config.toml)",
-            allow_reuse_addr=True,
-        )
+
+        for host in self.hosts:
+            assert_port_available(
+                host=host,
+                port=self.port,
+                service_name="WebUI 服务器",
+                logger=logger,
+                config_hint="webui.port (config/bot_config.toml)",
+                allow_reuse_addr=True,
+            )
+
+        sockets = self._create_bound_sockets()
+        if not sockets:
+            logger.error("❌ WebUI 无法绑定到任何指定地址")
+            raise OSError("WebUI 无法绑定到任何指定地址")
 
         config = Config(
             app=self.app,
-            host=self.host,
+            host=self.hosts[0],
             port=self.port,
             log_config=None,
             access_log=False,
@@ -106,33 +172,22 @@ class WebUIServer:
         self._server = UvicornServer(config=config)
 
         logger.info("🌐 WebUI 服务器启动中...")
-
-        # 根据地址类型显示正确的访问地址
-        if ":" in self.host:
-            # IPv6 地址需要用方括号包裹
-            logger.info(f"🌐 访问地址: http://[{self.host}]:{self.port}")
-            if self.host == "::":
-                logger.info(f"💡 IPv6 本机访问: http://[::1]:{self.port}")
-                logger.info(f"💡 IPv4 本机访问: http://127.0.0.1:{self.port}")
-            elif self.host == "::1":
-                logger.info("💡 仅支持 IPv6 本地访问")
-        else:
-            # IPv4 地址
-            logger.info(f"🌐 访问地址: http://{self.host}:{self.port}")
-            if self.host == "0.0.0.0":
-                logger.info(f"💡 本机访问: http://localhost:{self.port} 或 http://127.0.0.1:{self.port}")
+        self._log_bind_addresses()
+        if len(self.hosts) > 1:
+            logger.info("🔗 WebUI 已绑定到多个地址")
 
         try:
-            await self._server.serve()
+            await self._server.serve(sockets=sockets)
         except OSError as e:
             if is_port_conflict_error(e):
-                log_port_conflict(
-                    logger,
-                    service_name="WebUI 服务器",
-                    host=self.host,
-                    port=self.port,
-                    config_hint="webui.port (config/bot_config.toml)",
-                )
+                for host in self.hosts:
+                    log_port_conflict(
+                        logger,
+                        service_name="WebUI 服务器",
+                        host=host,
+                        port=self.port,
+                        config_hint="webui.port (config/bot_config.toml)",
+                    )
             else:
                 logger.error(f"❌ WebUI 服务器启动失败 (网络错误): {e}")
             raise
@@ -161,8 +216,8 @@ class WebUIServer:
 class ThreadedWebUIServer:
     """在专用线程中运行 WebUI，避免阻塞主事件循环。"""
 
-    def __init__(self, host: str = "0.0.0.0", port: int = 8001) -> None:
-        self.host = host
+    def __init__(self, hosts: list[str] | None = None, port: int = 8001) -> None:
+        self.hosts = hosts or ["127.0.0.1", "::1"]
         self.port = port
         self._thread: threading.Thread | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
@@ -201,7 +256,7 @@ class ThreadedWebUIServer:
 
         try:
             self._server = WebUIServer(
-                host=self.host,
+                hosts=self.hosts,
                 port=self.port,
                 register_config_reload=False,
             )
@@ -314,7 +369,7 @@ def get_webui_server() -> WebUIServer:
         from src.config.startup_bindings import resolve_webui_bind_address
 
         bind_address = resolve_webui_bind_address()
-        _webui_server = WebUIServer(host=bind_address.host, port=bind_address.port)
+        _webui_server = WebUIServer(hosts=bind_address.hosts, port=bind_address.port)
     return _webui_server
 
 
@@ -325,5 +380,5 @@ def get_threaded_webui_server() -> ThreadedWebUIServer:
         from src.config.startup_bindings import resolve_webui_bind_address
 
         bind_address = resolve_webui_bind_address()
-        _threaded_webui_server = ThreadedWebUIServer(host=bind_address.host, port=bind_address.port)
+        _threaded_webui_server = ThreadedWebUIServer(hosts=bind_address.hosts, port=bind_address.port)
     return _threaded_webui_server

--- a/src/webui/webui_server.py
+++ b/src/webui/webui_server.py
@@ -94,19 +94,20 @@ class WebUIServer:
                     sock.setsockopt(_socket.SOL_SOCKET, _socket.SO_REUSEADDR, 1)
                     if af == _socket.AF_INET6:
                         try:
-                            sock.setsockopt(_socket.IPPROTO_IPV6, _socket.IPV6_V6ONLY, 0)
+                            sock.setsockopt(_socket.IPPROTO_IPV6, _socket.IPV6_V6ONLY, 1)
                         except OSError:
                             pass
                     sock.bind(sa)
                     sock.listen()
                     sockets.append(sock)
                     break
-                except OSError:
+                except OSError as bind_err:
                     if sock is not None:
                         try:
                             sock.close()
                         except OSError:
                             pass
+                    logger.warning(f"⚠️ WebUI 无法绑定到 {host}:{self.port} ({sa}): {bind_err}")
                     continue
 
         return sockets


### PR DESCRIPTION
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
4. - [x] 本次更新是否经过测试
7. 请简要说明本次更新的内容和目的：操作系统关闭双栈时允许手动绑定多个地址以允许双栈访问
<img width="856" height="554" alt="image" src="https://github.com/user-attachments/assets/9e7d0513-0732-4c59-8c58-b3906beb8e1c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit
* **新功能**
  * WebUI 支持同时在多个地址上监听（默认同时包含 IPv4 与 IPv6）。
* **改进**
  * 启动与访问提示会展示实际绑定的所有 WebUI 地址。
  * 主服务的绑定将使用地址列表中的第一个有效地址。
* **兼容性**
  * 配置升级可自动将旧版 `webui.host`（单字符串）迁移为新版地址列表格式。
* **Chores**
  * 配置版本号更新至 `8.14.13`。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->