### PR TITLE
fix: 会话淘汰时关闭 MCP 连接，避免遗留 mcp 子进程

### DIFF
--- a/src/maisaka/runtime.py
+++ b/src/maisaka/runtime.py
@@ -390,6 +390,11 @@ class MaisakaHeartFlowChatting(MaisakaFocusRuntimeMixin, MaisakaRuntimeDisplayMi
             await self._reply_effect_tracker.finalize_all("runtime_stop")
         focus_mode_manager.release_focus(self.session_id)
         await self._tool_registry.close()
+        if self._mcp_manager is not None:
+            try:
+                await self._mcp_manager.close()
+            except Exception as exc:
+                logger.warning(f"{self.log_prefix} 关闭 MCP 连接失败: {exc}")
         self._mcp_manager = None
         self._mcp_host_bridge = None
         remove_stage_status(self.session_id)


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:
7. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 停止运行时会显式关闭相关连接，减少残留会话和资源占用。
  * 关闭过程中若发生异常，会记录警告日志，便于排查问题。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->