### PR TITLE
fix(A_memorix): 复用缺少指纹的旧向量池

### DIFF
--- a/pytests/A_memorix_test/test_vector_rebuild_runtime.py
+++ b/pytests/A_memorix_test/test_vector_rebuild_runtime.py
@@ -855,6 +855,94 @@ async def test_plain_vector_store_save_preserves_existing_embedding_fingerprint(
 
 
 @pytest.mark.asyncio
+async def test_runtime_auto_stamps_missing_embedding_fingerprint_when_dimension_matches(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_embedding_manager = _FakeEmbeddingManager(dimension=8)
+    data_dir = tmp_path / "a_memorix_data"
+    monkeypatch.setattr(
+        kernel_module,
+        "create_embedding_api_adapter",
+        lambda **kwargs: fake_embedding_manager,
+    )
+    monkeypatch.setattr(kernel_module, "run_embedding_runtime_self_check", _fake_runtime_self_check)
+
+    kernel = SDKMemoryKernel(
+        plugin_root=tmp_path / "plugin_root",
+        config=_kernel_config(data_dir, fake_embedding_manager.default_dimension),
+    )
+    await kernel.initialize()
+    try:
+        assert kernel.vector_store is not None
+        kernel.vector_store.add(
+            np.ones((1, fake_embedding_manager.default_dimension), dtype=np.float32),
+            ["missing-fingerprint"],
+        )
+        kernel.vector_store.save()
+        meta_path = data_dir / "vectors" / "vectors_metadata.pkl"
+        with open(meta_path, "rb") as handle:
+            meta = pickle.load(handle)
+        meta.pop("embedding_fingerprint", None)
+        with open(meta_path, "wb") as handle:
+            pickle.dump(meta, handle)
+
+        assert kernel._stored_vectors_compatible_with_current_embedding(kernel.vector_store) is True
+
+        config = await kernel.memory_runtime_admin(action="get_config")
+        assert config["embedding_fingerprint_status"] == "matched"
+        assert config["stored_embedding_fingerprint"]["hash"] == config["embedding_fingerprint"]["hash"]
+        assert config["vector_rebuild_required"] is False
+    finally:
+        await kernel.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_runtime_does_not_auto_stamp_missing_embedding_fingerprint_when_dimension_mismatches(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_embedding_manager = _FakeEmbeddingManager(dimension=8)
+    data_dir = tmp_path / "a_memorix_data"
+    monkeypatch.setattr(
+        kernel_module,
+        "create_embedding_api_adapter",
+        lambda **kwargs: fake_embedding_manager,
+    )
+    monkeypatch.setattr(kernel_module, "run_embedding_runtime_self_check", _fake_runtime_self_check)
+
+    kernel = SDKMemoryKernel(
+        plugin_root=tmp_path / "plugin_root",
+        config=_kernel_config(data_dir, fake_embedding_manager.default_dimension),
+    )
+    await kernel.initialize()
+    try:
+        assert kernel.vector_store is not None
+        kernel.vector_store.add(
+            np.ones((1, fake_embedding_manager.default_dimension), dtype=np.float32),
+            ["dimension-mismatch"],
+        )
+        kernel.vector_store.save()
+        meta_path = data_dir / "vectors" / "vectors_metadata.pkl"
+        with open(meta_path, "rb") as handle:
+            meta = pickle.load(handle)
+        meta.pop("embedding_fingerprint", None)
+        meta["dimension"] = fake_embedding_manager.default_dimension + 1
+        with open(meta_path, "wb") as handle:
+            pickle.dump(meta, handle)
+
+        assert kernel._stored_vectors_compatible_with_current_embedding(kernel.vector_store) is False
+
+        config = await kernel.memory_runtime_admin(action="get_config")
+        assert config["vector_rebuild_required"] is True
+        assert config["embedding_fingerprint_status"] == "missing"
+        assert config["stored_vector_dimension"] == fake_embedding_manager.default_dimension + 1
+        assert config["embedding_dimension"] == fake_embedding_manager.default_dimension
+    finally:
+        await kernel.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_dual_ready_manifest_rejects_mismatched_embedding_fingerprint(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/src/A_memorix/core/runtime/sdk_memory_kernel.py
+++ b/src/A_memorix/core/runtime/sdk_memory_kernel.py
@@ -437,6 +437,26 @@ class SDKMemoryKernel:
             return None
         return self._normalize_embedding_fingerprint(meta.get("embedding_fingerprint"))
 
+    def _stamp_missing_embedding_fingerprint_if_dimension_matches(self, store: Optional[VectorStore]) -> bool:
+        if store is None:
+            return False
+        stored_dimension = self._stored_vector_dimension(store)
+        if stored_dimension is None or int(stored_dimension) != int(self.embedding_dimension):
+            return False
+        current_fingerprint = self._current_embedding_fingerprint()
+        if current_fingerprint is None:
+            return False
+        stored_fingerprint = self._stored_embedding_fingerprint(store)
+        if stored_fingerprint is not None:
+            return False
+        store.save(embedding_fingerprint=current_fingerprint)
+        logger.warning("旧向量库缺少 embedding 指纹且维度匹配，已写入当前模型指纹以复用旧向量")
+        stamped_fingerprint = self._stored_embedding_fingerprint(store)
+        return (
+            stamped_fingerprint is not None
+            and str(stamped_fingerprint.get("hash", "") or "") == str(current_fingerprint.get("hash", "") or "")
+        )
+
     @staticmethod
     def _embedding_fingerprint_status(
         current: Optional[Dict[str, Any]],
@@ -455,8 +475,15 @@ class SDKMemoryKernel:
     def _stored_vectors_compatible_with_current_embedding(self, store: Optional[VectorStore] = None) -> bool:
         current = self._current_embedding_fingerprint()
         stored = self._stored_embedding_fingerprint(store)
-        if current is None or stored is None:
+        if current is None:
             return False
+        if stored is None:
+            stamped = self._stamp_missing_embedding_fingerprint_if_dimension_matches(store or self.vector_store)
+            if not stamped:
+                return False
+            stored = self._stored_embedding_fingerprint(store)
+            if stored is None:
+                return False
         return str(current.get("hash", "") or "") == str(stored.get("hash", "") or "")
 
     def _vector_mismatch_error(self, *, stored_dimension: int, detected_dimension: int) -> str:
@@ -468,6 +495,8 @@ class SDKMemoryKernel:
         )
 
     def _vector_rebuild_status(self) -> Dict[str, Any]:
+        if self.vector_store is not None and not self._vector_rebuild_lock.locked():
+            self._stamp_missing_embedding_fingerprint_if_dimension_matches(self.vector_store)
         stored_dimension = self._stored_vector_dimension()
         if self._vector_persist_blocked_until_rebuild and self._vector_rebuild_source_dimension is not None:
             stored_dimension = int(self._vector_rebuild_source_dimension)


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [x] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:
7. 请简要说明本次更新的内容和目的：
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 向量库在部分旧数据场景下可自动补齐缺失的兼容信息，提升升级后的可用性。

- **Bug 修复**
  - 当向量维度与当前模型一致但兼容信息缺失时，系统现在会尝试自动恢复，而不是直接判定为不可用。
  - 当向量维度不一致时，系统会继续保持不兼容判断，避免错误补齐。
  - 向量重建状态返回前，会尽可能先完成兼容信息的补全。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->