### PR TITLE
fix: 模型级温度不再被任务侧显式温度覆盖

### DIFF
--- a/pytests/utils_test/test_effective_temperature.py
+++ b/pytests/utils_test/test_effective_temperature.py
@@ -40,6 +40,13 @@ def test_explicit_temperature_used_when_model_level_absent() -> None:
     assert orchestrator._resolve_effective_temperature(model_info, 0.1) == 0.1
 
 
+def test_explicit_temperature_overrides_extra_params_default() -> None:
+    orchestrator = _build_orchestrator()
+    model_info = _build_model_info(extra_params={"temperature": 0.5})
+
+    assert orchestrator._resolve_effective_temperature(model_info, 0.1) == 0.1
+
+
 def test_extra_params_temperature_used_as_model_default() -> None:
     orchestrator = _build_orchestrator()
     model_info = _build_model_info(extra_params={"temperature": 0.5})

--- a/pytests/utils_test/test_effective_temperature.py
+++ b/pytests/utils_test/test_effective_temperature.py
@@ -1,0 +1,54 @@
+from src.config.model_configs import ModelInfo, TaskConfig
+from src.llm_models.utils_model import LLMOrchestrator
+
+
+class _FixedTaskOrchestrator(LLMOrchestrator):
+    """使用固定任务配置的调度器，避免测试依赖全局配置。"""
+
+    def __init__(self, task_config: TaskConfig) -> None:
+        self._task_config = task_config
+        super().__init__(task_name="temperature_test", request_type="temperature_test")
+
+    def _get_task_config_or_raise(self) -> TaskConfig:
+        return self._task_config
+
+
+def _build_orchestrator() -> LLMOrchestrator:
+    return _FixedTaskOrchestrator(TaskConfig(model_list=["demo-model"], temperature=0.3))
+
+
+def _build_model_info(**overrides) -> ModelInfo:
+    return ModelInfo(
+        api_provider="test-provider",
+        model_identifier="demo-model",
+        name="demo-model",
+        **overrides,
+    )
+
+
+def test_model_level_temperature_overrides_explicit_temperature() -> None:
+    orchestrator = _build_orchestrator()
+    model_info = _build_model_info(temperature=0.6)
+
+    assert orchestrator._resolve_effective_temperature(model_info, 0.1) == 0.6
+
+
+def test_explicit_temperature_used_when_model_level_absent() -> None:
+    orchestrator = _build_orchestrator()
+    model_info = _build_model_info()
+
+    assert orchestrator._resolve_effective_temperature(model_info, 0.1) == 0.1
+
+
+def test_extra_params_temperature_used_as_model_default() -> None:
+    orchestrator = _build_orchestrator()
+    model_info = _build_model_info(extra_params={"temperature": 0.5})
+
+    assert orchestrator._resolve_effective_temperature(model_info, None) == 0.5
+
+
+def test_task_config_temperature_used_as_final_fallback() -> None:
+    orchestrator = _build_orchestrator()
+    model_info = _build_model_info()
+
+    assert orchestrator._resolve_effective_temperature(model_info, None) == 0.3

--- a/src/config/model_configs.py
+++ b/src/config/model_configs.py
@@ -308,7 +308,7 @@ class ModelInfo(ConfigBase):
             "x-icon": "thermometer",
         },
     )
-    """模型级别温度（可选），会覆盖任务配置中的温度"""
+    """模型级别温度（可选），会覆盖任务配置和调用方显式传入的温度"""
 
     max_tokens: int | None = Field(
         default=None,

--- a/src/llm_models/utils_model.py
+++ b/src/llm_models/utils_model.py
@@ -509,6 +509,9 @@ class LLMOrchestrator:
     ) -> Optional[float]:
         """解析响应请求最终使用的温度参数。
 
+        模型级别温度优先于调用方显式传入的温度，
+        避免任务侧的固定温度覆盖仅支持特定温度的模型（如 Kimi-K2 系列）。
+
         Args:
             model_info: 当前模型信息。
             temperature: 调用方显式传入的温度。
@@ -516,10 +519,10 @@ class LLMOrchestrator:
         Returns:
             Optional[float]: 最终生效的温度参数。
         """
-        if temperature is not None:
-            return temperature
         if model_info.temperature is not None:
             return model_info.temperature
+        if temperature is not None:
+            return temperature
         if "temperature" in model_info.extra_params:
             return model_info.extra_params["temperature"]
         return self.model_for_task.temperature


### PR DESCRIPTION
# 请填写以下内容
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）: 无。行为变化仅影响显式配置了模型级 temperature 的模型（原先会被任务侧温度覆盖，现在以模型级为准），未配置模型级温度的场景行为完全不变。
7. 请简要说明本次更新的内容和目的：

模型列表里给模型配置的自定义温度目前会被任务侧显式传入的温度覆盖。像 Kimi-K2.6 这类只接受固定温度的模型，即使已经在模型配置里设置了 temperature=0.6，A_Memorix 证据分类、各类 learner、WebUI 的模型测试（硬编码 temperature=0.0）等调用点仍然按自己的温度发请求，直接返回 400（invalid temperature），并触发无意义的模型切换。

原因在 `LLMOrchestrator._resolve_effective_temperature` 的优先级：调用方显式传参 > 模型级配置 > extra_params > 任务配置。#1820 把 A_memorix 的分类温度做成了可配置，但配置出来的值同样属于“调用方显式传入”，还是会压过模型级设置，所以 #1833 在其合并之后仍然出现。

本次把模型级 temperature 提到最高优先级，在解析函数单点修复，覆盖所有调用点；`ModelInfo.temperature` 的字段说明同步改为“会覆盖任务配置和调用方显式传入的温度”。

测试：新增 `pytests/utils_test/test_effective_temperature.py` 覆盖四级优先级取值；全量 pytest 与 dev 基线对比无新增失败。

# 其他信息
- **关联 Issue**：Close #1833
- **截图/GIF**：无 UI 变化
- **附加信息**: 无


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 调整了温度参数的生效优先级：当模型信息中显式提供 `temperature` 时，将优先使用该值，而不再以调用方传入的 `temperature` 为主。
  * 当模型级温度缺失时，会按新的回退链路继续使用调用方显式值、额外参数默认值以及任务配置兜底。

* **测试**
  * 新增并完善了温度解析优先级的单测，覆盖多种组合场景（包括显式值与 `extra_params.temperature` 同时存在时的覆盖关系）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->