### PR TITLE
fix: 修复 focus 空闲退出后 @ 消息无法唤醒的死锁

### DIFF
--- a/pytests/maisaka_test/test_focus_reentry_block.py
+++ b/pytests/maisaka_test/test_focus_reentry_block.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.config.config import global_config
+
+import src.maisaka.focus.manager as focus_manager_module
+import src.maisaka.focus.runtime_mixin as focus_runtime_mixin_module
+import src.maisaka.runtime as maisaka_runtime_module
+from src.maisaka.focus.manager import FocusModeManager
+from src.maisaka.runtime import MaisakaHeartFlowChatting
+
+
+@pytest.fixture
+def focus_manager(monkeypatch) -> FocusModeManager:
+    monkeypatch.setattr(global_config.experimental, "focus_mode", True)
+    monkeypatch.setattr(global_config.experimental, "focus_chat_whitelist", [])
+    monkeypatch.setattr(global_config.experimental, "focus_groups", [])
+    monkeypatch.setattr(global_config.experimental, "focus_cool_time", 120)
+    return FocusModeManager()
+
+
+@pytest.fixture
+def gate_focus_manager(focus_manager, monkeypatch) -> FocusModeManager:
+    monkeypatch.setattr(maisaka_runtime_module, "focus_mode_manager", focus_manager)
+    monkeypatch.setattr(focus_runtime_mixin_module, "focus_mode_manager", focus_manager)
+    return focus_manager
+
+
+def _build_gate_runtime(session_id: str = "group-a") -> MaisakaHeartFlowChatting:
+    runtime = MaisakaHeartFlowChatting.__new__(MaisakaHeartFlowChatting)
+    runtime.session_id = session_id
+    runtime.chat_stream = SimpleNamespace(is_group_session=True)
+    runtime.log_prefix = "[test]"
+    runtime._maybe_schedule_focus_at_wakeup = lambda **kwargs: None
+    runtime._maybe_schedule_focus_cooldown_wakeup = lambda **kwargs: None
+    return runtime
+
+
+def test_idle_exit_block_expires_after_focus_cool_time(focus_manager, monkeypatch) -> None:
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(focus_manager_module, "time", SimpleNamespace(time=lambda: clock["now"]))
+
+    assert focus_manager.try_enter_focus("group-a", is_group_chat=True) is True
+    assert focus_manager.release_focus_and_block_next_entry("group-a") is True
+    assert focus_manager.try_enter_focus("group-a", is_group_chat=True) is False
+
+    clock["now"] += 119.0
+    assert focus_manager.try_enter_focus("group-a", is_group_chat=True) is False
+
+    clock["now"] += 1.0
+    assert focus_manager.try_enter_focus("group-a", is_group_chat=True) is True
+
+
+def test_unblock_focus_entry_allows_blocked_session_reentry(focus_manager) -> None:
+    assert focus_manager.try_enter_focus("group-a", is_group_chat=True) is True
+    assert focus_manager.release_focus_and_block_next_entry("group-a") is True
+    assert focus_manager.try_enter_focus("group-a", is_group_chat=True) is False
+
+    assert focus_manager.unblock_focus_entry("group-a") is True
+    assert focus_manager.try_enter_focus("group-a", is_group_chat=True) is True
+
+
+def test_unblock_focus_entry_ignores_other_sessions(focus_manager) -> None:
+    assert focus_manager.try_enter_focus("group-a", is_group_chat=True) is True
+    assert focus_manager.release_focus_and_block_next_entry("group-a") is True
+
+    assert focus_manager.unblock_focus_entry("group-b") is False
+    assert focus_manager.try_enter_focus("group-a", is_group_chat=True) is False
+
+
+def test_focus_gate_drops_plain_message_while_blocked(gate_focus_manager) -> None:
+    assert gate_focus_manager.try_enter_focus("group-a", is_group_chat=True) is True
+    assert gate_focus_manager.release_focus_and_block_next_entry("group-a") is True
+
+    runtime = _build_gate_runtime()
+    plain_message = SimpleNamespace(is_at=False, message_id="msg-1")
+
+    assert MaisakaHeartFlowChatting._should_continue_after_focus_gate(runtime, plain_message) is False
+    assert gate_focus_manager.is_in_focus_set("group-a") is False
+
+
+def test_focus_gate_allows_at_message_from_blocked_session(gate_focus_manager) -> None:
+    assert gate_focus_manager.try_enter_focus("group-a", is_group_chat=True) is True
+    assert gate_focus_manager.release_focus_and_block_next_entry("group-a") is True
+
+    runtime = _build_gate_runtime()
+    at_message = SimpleNamespace(is_at=True, message_id="msg-2")
+
+    assert MaisakaHeartFlowChatting._should_continue_after_focus_gate(runtime, at_message) is True
+    assert gate_focus_manager.is_in_focus_set("group-a") is True

--- a/src/maisaka/focus/manager.py
+++ b/src/maisaka/focus/manager.py
@@ -31,6 +31,7 @@ class FocusModeManager:
     def __init__(self) -> None:
         self._focused_session_ids_by_scope: dict[str, list[str]] = {}
         self._next_focus_blocked_session_id_by_scope: dict[str, str] = {}
+        self._next_focus_blocked_at_by_scope: dict[str, float] = {}
         self._last_cycle_at_by_session_id: dict[str, float] = {}
         self._last_read_at_by_session_id: dict[str, datetime] = {}
 
@@ -151,6 +152,7 @@ class FocusModeManager:
         if not self.is_enabled():
             self._focused_session_ids_by_scope.clear()
             self._next_focus_blocked_session_id_by_scope.clear()
+            self._next_focus_blocked_at_by_scope.clear()
             return
 
         focused_session_ids: list[str] = []
@@ -173,25 +175,35 @@ class FocusModeManager:
                 scope_session_ids.append(session_id)
         self._focused_session_ids_by_scope = normalized_focused_session_ids_by_scope
 
+        now = time.time()
+        focus_cool_time = self.get_focus_cool_time()
         blocked_session_ids: list[str] = []
         seen_blocked_session_ids: set[str] = set()
-        for session_id in self._next_focus_blocked_session_id_by_scope.values():
+        blocked_at_by_session_id: dict[str, float] = {}
+        for scope_key, session_id in self._next_focus_blocked_session_id_by_scope.items():
             normalized_session_id = self._normalize_session_id(session_id)
             if not normalized_session_id or normalized_session_id in seen_blocked_session_ids:
                 continue
             if not self._is_session_id_focus_allowed(normalized_session_id):
                 continue
+            blocked_at = self._next_focus_blocked_at_by_scope.get(scope_key, now)
+            if now - blocked_at >= focus_cool_time:
+                continue
             blocked_session_ids.append(normalized_session_id)
             seen_blocked_session_ids.add(normalized_session_id)
+            blocked_at_by_session_id[normalized_session_id] = blocked_at
 
         normalized_blocked_session_id_by_scope: dict[str, str] = {}
+        normalized_blocked_at_by_scope: dict[str, float] = {}
         for session_id in blocked_session_ids:
             scope_key = self._resolve_focus_scope_key(session_id)
             if session_id in self._focused_session_ids_by_scope.get(scope_key, []):
                 continue
             if scope_key not in normalized_blocked_session_id_by_scope:
                 normalized_blocked_session_id_by_scope[scope_key] = session_id
+                normalized_blocked_at_by_scope[scope_key] = blocked_at_by_session_id[session_id]
         self._next_focus_blocked_session_id_by_scope = normalized_blocked_session_id_by_scope
+        self._next_focus_blocked_at_by_scope = normalized_blocked_at_by_scope
 
     def _is_session_id_focus_allowed(self, session_id: str) -> bool:
         normalized_session_id = self._normalize_session_id(session_id)
@@ -242,6 +254,7 @@ class FocusModeManager:
 
         focused_session_ids.append(normalized_session_id)
         self._next_focus_blocked_session_id_by_scope.pop(scope_key, None)
+        self._next_focus_blocked_at_by_scope.pop(scope_key, None)
         self._last_cycle_at_by_session_id[normalized_session_id] = time.time()
         return True
 
@@ -264,7 +277,10 @@ class FocusModeManager:
         self._last_cycle_at_by_session_id.pop(normalized_session_id, None)
 
     def release_focus_and_block_next_entry(self, session_id: str) -> bool:
-        """Remove a focused session and prevent it from claiming the next focus slot."""
+        """Remove a focused session and prevent it from claiming the next focus slot.
+
+        The block expires after focus_cool_time, or immediately via unblock_focus_entry.
+        """
 
         normalized_session_id = self._normalize_session_id(session_id)
         if not normalized_session_id:
@@ -279,7 +295,22 @@ class FocusModeManager:
         self.release_focus(normalized_session_id)
         if was_focused:
             self._next_focus_blocked_session_id_by_scope[scope_key] = normalized_session_id
+            self._next_focus_blocked_at_by_scope[scope_key] = time.time()
         return was_focused
+
+    def unblock_focus_entry(self, session_id: str) -> bool:
+        """Lift the idle-exit re-entry block for a session, e.g. when it is explicitly @-summoned."""
+
+        normalized_session_id = self._normalize_session_id(session_id)
+        if not normalized_session_id:
+            return False
+        self._normalize_state()
+        scope_key = self._resolve_focus_scope_key(normalized_session_id)
+        if self._next_focus_blocked_session_id_by_scope.get(scope_key, "") != normalized_session_id:
+            return False
+        self._next_focus_blocked_session_id_by_scope.pop(scope_key, None)
+        self._next_focus_blocked_at_by_scope.pop(scope_key, None)
+        return True
 
     def switch_focus(self, from_session_id: str, to_session_id: str) -> str:
         """Move one focus slot from the current session to another existing session.
@@ -317,6 +348,7 @@ class FocusModeManager:
         self.release_focus(normalized_from_session_id)
         self._focused_session_ids_by_scope.setdefault(from_scope_key, []).append(normalized_to_session_id)
         self._next_focus_blocked_session_id_by_scope.pop(from_scope_key, None)
+        self._next_focus_blocked_at_by_scope.pop(from_scope_key, None)
         self._last_cycle_at_by_session_id[normalized_to_session_id] = time.time()
         self._normalize_state()
         return ""

--- a/src/maisaka/runtime.py
+++ b/src/maisaka/runtime.py
@@ -857,6 +857,8 @@ class MaisakaHeartFlowChatting(MaisakaFocusRuntimeMixin, MaisakaRuntimeDisplayMi
         if not self._is_focus_mode_active_for_current_chat():
             return True
 
+        if message.is_at and focus_mode_manager.unblock_focus_entry(self.session_id):
+            logger.info(f"{self.log_prefix} 收到 @ 消息，已解除连续空闲退出 Focus 后的重新进入限制")
         can_enter_focus = focus_mode_manager.try_enter_focus(
             self.session_id,
             is_group_chat=self.chat_stream.is_group_session,


### PR DESCRIPTION
# 请填写以下内容
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）: 无
7. 请简要说明本次更新的内容和目的：

focus_mode 群聊连续 5 次空闲退出后，`release_focus_and_block_next_entry` 会阻止该群重新进入 focus。这个阻塞没有超时，只有当同 scope 的其他聊天成功进入 focus 时才会被清除；而退出的瞬间槽位恰好是空的，@ 唤醒的 `_select_focus_cooldown_wakeup_runtime` 只会选取“当前在 focus 集合中”的会话——一个也找不到，于是 @ 消息在 `register_message` 阶段就被丢弃。夜间没有其他聊天活动时 @ 也无法唤醒 bot（#1840 生产环境实测 55 分钟无响应）。

修复两点，对应 issue 中建议的前两个方向：

1. 阻塞增加基于 `focus_cool_time` 的超时：在 `_normalize_state` 统一做过期清理，冷却期结束后普通消息可以正常重新进入 focus。复用现有配置项，不新增配置。
2. @ 消息视为明确召唤：准入检查前先解除本会话的空闲退出阻塞（新增 `unblock_focus_entry`），与现有“@ 无视 focus_cool_time 强制唤醒”的语义保持一致。

保持不变的行为：阻塞期内普通消息仍然只缓存、不进入决策；@ 只解除自己所在会话的阻塞，其他聊天不受影响。

测试：新增 `pytests/maisaka_test/test_focus_reentry_block.py`——manager 层覆盖超时过期、解除阻塞、仅对本会话生效；门控层按 issue 的生产日志序列重放（阻塞期普通消息被拦、@ 立即恢复响应并重新占用关注槽）。全量 pytest 与 dev 基线对比无新增失败。

# 其他信息
- **关联 Issue**：Close #1840
- **截图/GIF**：无 UI 变化
- **附加信息**: 无


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持焦点重新进入限制的自动过期与手动解除，提升空闲后恢复会话的灵活性。
  * 对带“@”的消息增加特殊处理，可优先解除焦点重入限制。

* **测试**
  * 新增覆盖焦点阻塞、解阻塞、超时过期以及不同消息类型放行/丢弃行为的测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->