### PR TITLE
fix: WebUI 模型测试对嵌入任务模型改用嵌入接口

### DIFF
--- a/pytests/webui/test_model_routes.py
+++ b/pytests/webui/test_model_routes.py
@@ -299,7 +299,7 @@ model_list = ["embed-model"]
     assert result.success is True
     assert result.tool_call_ok is False
     assert result.visual_tested is False
-    assert "8" in result.response
+    assert result.response == "嵌入向量维度: 8"
     assert captured["model_name"] == "embed-model"
     assert captured["embedding_input"]
 

--- a/pytests/webui/test_model_routes.py
+++ b/pytests/webui/test_model_routes.py
@@ -256,6 +256,108 @@ visual = true
     assert captured["tools"][0]["name"] == model_routes.MODEL_TEST_TOOL_NAME
 
 
+@pytest.mark.asyncio
+async def test_test_model_capability_tests_embedding_task_model_via_embedding(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """嵌入任务中的模型应通过嵌入接口测试，而不是对话接口。"""
+    model_routes = load_model_routes(monkeypatch)
+    config_path = tmp_path / "model_config.toml"
+    config_path.write_text(
+        """
+[[models]]
+name = "embed-model"
+model_identifier = "embed-model-id"
+api_provider = "Fake"
+
+[model_task_config.embedding]
+model_list = ["embed-model"]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(model_routes, "CONFIG_DIR", str(tmp_path))
+
+    captured: dict[str, Any] = {}
+
+    class FakeOrchestrator:
+        def __init__(self, model_name: str):
+            captured["model_name"] = model_name
+
+        async def get_embedding(self, embedding_input: str, **kwargs: Any):
+            captured["embedding_input"] = embedding_input
+            return SimpleNamespace(embedding=[0.1] * 8, model_name="embed-model")
+
+        async def generate_response_with_message_async(self, **kwargs: Any):
+            raise AssertionError("嵌入模型测试不应调用对话接口")
+
+    monkeypatch.setattr(model_routes, "_SingleModelTestOrchestrator", FakeOrchestrator)
+
+    result = await model_routes.test_model_capability(model_routes.ModelTestRequest(model_name="embed-model"))
+
+    assert result.success is True
+    assert result.tool_call_ok is False
+    assert result.visual_tested is False
+    assert "8" in result.response
+    assert captured["model_name"] == "embed-model"
+    assert captured["embedding_input"]
+
+
+@pytest.mark.asyncio
+async def test_test_model_capability_keeps_chat_test_for_non_embedding_model(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """未配置在嵌入任务中的模型应保持原有对话测试流程。"""
+    model_routes = load_model_routes(monkeypatch)
+    config_path = tmp_path / "model_config.toml"
+    config_path.write_text(
+        """
+[[models]]
+name = "chat-model"
+model_identifier = "chat-model-id"
+api_provider = "Fake"
+
+[model_task_config.embedding]
+model_list = ["other-embed-model"]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(model_routes, "CONFIG_DIR", str(tmp_path))
+
+    class FakeOrchestrator:
+        def __init__(self, model_name: str):
+            self.model_name = model_name
+
+        async def get_embedding(self, embedding_input: str, **kwargs: Any):
+            raise AssertionError("对话模型测试不应调用嵌入接口")
+
+        async def generate_response_with_message_async(self, **kwargs: Any):
+            return model_routes.LLMResponseResult(
+                response="",
+                model_name="chat-model",
+                tool_calls=[
+                    model_routes.ToolCall(
+                        call_id="call-1",
+                        func_name=model_routes.MODEL_TEST_TOOL_NAME,
+                        args={"status": "ok", "echo": "maibot model test", "saw_image": False},
+                    )
+                ],
+                prompt_tokens=10,
+                completion_tokens=5,
+                total_tokens=15,
+            )
+
+    monkeypatch.setattr(model_routes, "_SingleModelTestOrchestrator", FakeOrchestrator)
+
+    result = await model_routes.test_model_capability(model_routes.ModelTestRequest(model_name="chat-model"))
+
+    assert result.success is True
+    assert result.tool_call_ok is True
+
+
 def test_model_test_image_base64_is_valid_png(monkeypatch: pytest.MonkeyPatch) -> None:
     """内置视觉测试图应是可被服务商正常解析的有效 PNG。"""
     model_routes = load_model_routes(monkeypatch)

--- a/src/webui/routers/model.py
+++ b/src/webui/routers/model.py
@@ -4,7 +4,7 @@
 提供从各个 AI 厂商 API 获取可用模型列表的代理接口
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -380,7 +380,7 @@ def _get_model_config(model_name: str) -> Optional[Dict]:
         return None
 
 
-def _get_embedding_task_model_names() -> set:
+def _get_embedding_task_model_names() -> Set[str]:
     """从 model_config.toml 获取嵌入任务配置的模型名称集合。
 
     Returns:
@@ -420,6 +420,8 @@ async def _test_embedding_model(model_name: str) -> ModelTestResponse:
             response=f"嵌入向量维度: {len(result.embedding)}",
             latency_ms=latency_ms,
         )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"嵌入模型测试失败: model={model_name}, error={e}", exc_info=True)
         latency_ms = round((time.time() - start_time) * 1000, 2)

--- a/src/webui/routers/model.py
+++ b/src/webui/routers/model.py
@@ -144,6 +144,10 @@ async def test_model_capability(request: ModelTestRequest):
     if model_config is None:
         raise HTTPException(status_code=404, detail=f"未找到模型: {model_name}")
 
+    # 嵌入模型不支持 chat/completions 接口，需改用嵌入接口测试
+    if model_name in _get_embedding_task_model_names():
+        return await _test_embedding_model(model_name)
+
     visual_enabled = bool(model_config.get("visual", False))
     start_time = time.time()
     try:
@@ -374,6 +378,59 @@ def _get_model_config(model_name: str) -> Optional[Dict]:
     except Exception as e:
         logger.error(f"读取模型配置失败: {e}")
         return None
+
+
+def _get_embedding_task_model_names() -> set:
+    """从 model_config.toml 获取嵌入任务配置的模型名称集合。
+
+    Returns:
+        嵌入任务 model_list 中的模型名称集合，读取失败时返回空集合。
+    """
+    config_path = os.path.join(CONFIG_DIR, "model_config.toml")
+    if not os.path.exists(config_path):
+        return set()
+
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            config_data = tomlkit.load(f)
+
+        task_config = config_data.get("model_task_config", {}).get("embedding", {})
+        return {str(name) for name in task_config.get("model_list", [])}
+    except Exception as e:
+        logger.error(f"读取嵌入任务配置失败: {e}")
+        return set()
+
+
+async def _test_embedding_model(model_name: str) -> ModelTestResponse:
+    """对嵌入任务中的模型执行嵌入测试。
+
+    嵌入模型不支持 chat/completions 接口，直接发对话测试会被服务商拒绝，
+    因此改为调用嵌入接口验证可用性。
+    """
+    start_time = time.time()
+    try:
+        orchestrator = _SingleModelTestOrchestrator(model_name=model_name)
+        result = await orchestrator.get_embedding("MaiBot 模型可用性测试")
+        latency_ms = round((time.time() - start_time) * 1000, 2)
+        return ModelTestResponse(
+            success=True,
+            model_name=result.model_name or model_name,
+            visual_tested=False,
+            tool_call_ok=False,
+            response=f"嵌入向量维度: {len(result.embedding)}",
+            latency_ms=latency_ms,
+        )
+    except Exception as e:
+        logger.error(f"嵌入模型测试失败: model={model_name}, error={e}", exc_info=True)
+        latency_ms = round((time.time() - start_time) * 1000, 2)
+        return ModelTestResponse(
+            success=False,
+            model_name=model_name,
+            visual_tested=False,
+            tool_call_ok=False,
+            latency_ms=latency_ms,
+            error=str(e),
+        )
 
 
 def _build_model_test_prompt(visual_enabled: bool) -> str:


### PR DESCRIPTION
# 请填写以下内容
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）: 无
7. 请简要说明本次更新的内容和目的：

WebUI 的"测试可用性"对所有模型统一发送 chat/completions 对话请求。嵌入模型（如硅基流动的 Qwen/Qwen3-Embedding-8B）不存在于对话端点，服务商直接返回 400（`Model does not exist`），导致嵌入模型的可用性测试必然失败。

修复方式：`test_model_capability` 在发起测试前检查模型是否在 `model_task_config.embedding` 的 `model_list` 中，是则复用同一个单模型编排器改调 `get_embedding()` 验证可用性，成功时在响应中返回嵌入向量维度；其余模型保持原有对话 + 工具调用测试流程不变。

- `src/webui/routers/model.py`：新增 `_get_embedding_task_model_names()`（与 `_get_model_config` 相同方式读取 model_config.toml）和 `_test_embedding_model()`，并在 `test_model_capability` 中按嵌入任务归属分派。
- `pytests/webui/test_model_routes.py`：新增两条用例——嵌入任务模型应走嵌入接口（在干净 dev 上失败、修复后通过）、未配置在嵌入任务中的模型保持对话测试。`pytests/webui` 其余用例全部通过（`test_plugin_management_routes` 的 2 个失败在干净 dev 上同样存在，与本次修改无关）。

边界说明：尚未分配到嵌入任务的模型无法从配置判断类型，仍按对话模型测试；issue 场景中嵌入模型配置到 embedding 任务后即可正常通过测试。

# 其他信息
- **关联 Issue**：Close #1883
- **截图/GIF**：
- **附加信息**: 无


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 模型测试页面现可自动识别“嵌入模型”和“对话模型”，并按对应能力发起测试。
  * 嵌入模型将返回向量维度等结果，并展示耗时，便于快速判断可用性。
* **测试**
  * 新增用例覆盖“嵌入任务 vs 对话任务”的分流逻辑：验证会走正确的能力接口，并校验关键返回字段与成功状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->