### PR TITLE
fix(A_memorix): 修复持久化一致性与并发生命周期问题

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,13 @@ select = [
 
 ignore = ["E711", "E501"]
 
+[tool.ruff.lint.flake8-bugbear]
+extend-immutable-calls = ["fastapi.Body", "fastapi.File"]
+
+[tool.ruff.lint.per-file-ignores]
+"scripts/run_a_memorix_webui_backend.py" = ["E402"]
+"src/plugin_runtime/runner/runner_main.py" = ["E402"]
+
 [tool.ruff.format]
 docstring-code-format = true
 indent-style = "space"

--- a/pytests/A_memorix_test/test_feedback_correction_core.py
+++ b/pytests/A_memorix_test/test_feedback_correction_core.py
@@ -94,6 +94,7 @@ async def test_apply_feedback_decision_resolves_paragraph_targets(monkeypatch: p
     forgotten_hashes: list[str] = []
     ingested_payloads: list[Dict[str, Any]] = []
     stale_marks: list[Dict[str, Any]] = []
+    paragraph_lookup_calls: list[list[str]] = []
     episode_sources: list[str] = []
     profile_refresh_ids: list[str] = []
 
@@ -123,11 +124,10 @@ async def test_apply_feedback_decision_resolves_paragraph_targets(monkeypatch: p
             str(hash_value): {"is_inactive": str(hash_value) in forgotten_hashes}
             for hash_value in hashes
         },
-            get_paragraph_hashes_by_relation_hashes=lambda hashes: {
-                "relation-1": ["paragraph-1"]
-            }
-            if "relation-1" in hashes
-            else {},
+            get_paragraph_hashes_by_relation_hashes=lambda hashes: (
+                paragraph_lookup_calls.append(list(hashes))
+                or ({"relation-1": ["paragraph-1"]} if "relation-1" in hashes else {})
+            ),
             get_paragraph_stale_relation_mark=lambda **kwargs: None,
             upsert_paragraph_stale_relation_mark=lambda **kwargs: stale_marks.append(kwargs) or kwargs,
         enqueue_episode_source_rebuild=lambda source, reason="": episode_sources.append(source) or True,
@@ -194,6 +194,7 @@ async def test_apply_feedback_decision_resolves_paragraph_targets(monkeypatch: p
     assert "chat_summary:session-1" in payload["episode_rebuild_sources"]
     assert payload["profile_refresh_person_ids"] == ["person-1"]
     assert stale_marks[0]["paragraph_hash"] == "paragraph-1"
+    assert paragraph_lookup_calls == [["relation-1"]]
     assert {item["action_type"] for item in action_logs} == {
         "forget_relation",
         "ingest_correction",

--- a/pytests/A_memorix_test/test_feedback_correction_core.py
+++ b/pytests/A_memorix_test/test_feedback_correction_core.py
@@ -123,12 +123,13 @@ async def test_apply_feedback_decision_resolves_paragraph_targets(monkeypatch: p
             str(hash_value): {"is_inactive": str(hash_value) in forgotten_hashes}
             for hash_value in hashes
         },
-        get_paragraph_hashes_by_relation_hashes=lambda hashes: {
-            "relation-1": ["paragraph-1"]
-        }
-        if "relation-1" in hashes
-        else {},
-        upsert_paragraph_stale_relation_mark=lambda **kwargs: stale_marks.append(kwargs) or kwargs,
+            get_paragraph_hashes_by_relation_hashes=lambda hashes: {
+                "relation-1": ["paragraph-1"]
+            }
+            if "relation-1" in hashes
+            else {},
+            get_paragraph_stale_relation_mark=lambda **kwargs: None,
+            upsert_paragraph_stale_relation_mark=lambda **kwargs: stale_marks.append(kwargs) or kwargs,
         enqueue_episode_source_rebuild=lambda source, reason="": episode_sources.append(source) or True,
         enqueue_person_profile_refresh=lambda **kwargs: profile_refresh_ids.append(kwargs["person_id"]) or kwargs,
         get_paragraph=lambda paragraph_hash: {"hash": "paragraph-1", "source": "chat_feedback_test_seed:session-1"}
@@ -485,6 +486,13 @@ async def test_fuzzy_modify_execute_recovers_stale_executing_plan(monkeypatch: p
     kernel = SDKMemoryKernel(plugin_root=Path("."), config={})
     kernel.metadata_store = SimpleNamespace(
         get_fuzzy_modify_plan=lambda plan_id: {
+            "plan_id": plan_id,
+            "status": "executing",
+            "confidence": 1.0,
+            "execution": {"attempt": {"status": "executing", "started_at": 1.0}},
+            "plan": {"operations": []},
+        },
+        claim_fuzzy_modify_plan=lambda plan_id: {
             "plan_id": plan_id,
             "status": "executing",
             "confidence": 1.0,

--- a/pytests/A_memorix_test/test_feedback_task_leases.py
+++ b/pytests/A_memorix_test/test_feedback_task_leases.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from src.A_memorix.core.storage.metadata_store import MetadataStore
+
+
+def test_feedback_task_claim_and_rollback_claim_use_leases(tmp_path: Path) -> None:
+    store = MetadataStore(data_dir=tmp_path)
+    store.connect()
+    try:
+        task = store.enqueue_feedback_task(
+            query_tool_id="query-1",
+            session_id="session-1",
+            query_timestamp=1.0,
+            due_at=1.0,
+        )
+        assert task is not None
+        task_id = int(task["id"])
+
+        claimed = store.mark_feedback_task_running(task_id, lease_seconds=60.0)
+        assert claimed is not None
+        assert store.mark_feedback_task_running(task_id, lease_seconds=60.0) is None
+
+        connection = store.get_connection()
+        connection.execute(
+            "UPDATE memory_feedback_tasks SET updated_at = 0 WHERE id = ?",
+            (task_id,),
+        )
+        connection.commit()
+        assert [item["id"] for item in store.fetch_due_feedback_tasks(now=100.0, lease_seconds=60.0)] == [task_id]
+        assert store.mark_feedback_task_running(task_id, lease_seconds=60.0) is not None
+
+        store.finalize_feedback_task(task_id=task_id, status="applied")
+        assert store.mark_feedback_task_rollback_running(task_id=task_id, lease_seconds=60.0) is not None
+        assert store.mark_feedback_task_rollback_running(task_id=task_id, lease_seconds=60.0) is None
+
+        connection.execute(
+            "UPDATE memory_feedback_tasks SET updated_at = 0 WHERE id = ?",
+            (task_id,),
+        )
+        connection.commit()
+        assert store.mark_feedback_task_rollback_running(task_id=task_id, lease_seconds=60.0) is not None
+    finally:
+        store.close()

--- a/pytests/A_memorix_test/test_fuzzy_modify_metadata_store.py
+++ b/pytests/A_memorix_test/test_fuzzy_modify_metadata_store.py
@@ -112,6 +112,33 @@ def test_fuzzy_modify_plan_and_superseded_metadata(tmp_path):
         store.close()
 
 
+def test_fuzzy_modify_plan_claim_uses_execution_lease(tmp_path: Path) -> None:
+    store = MetadataStore(data_dir=tmp_path)
+    store.connect()
+    try:
+        plan = store.create_fuzzy_modify_plan(
+            request_text="测试并发领取",
+            scope="person_profile",
+            plan={"operations": []},
+        )
+
+        claimed = store.claim_fuzzy_modify_plan(plan["plan_id"], stale_after_seconds=60.0)
+        assert claimed is not None
+        assert claimed["status"] == "executing"
+        assert store.claim_fuzzy_modify_plan(plan["plan_id"], stale_after_seconds=60.0) is None
+
+        store.get_connection().execute(
+            "UPDATE memory_fuzzy_modify_plans SET updated_at = 0 WHERE plan_id = ?",
+            (plan["plan_id"],),
+        )
+        store.get_connection().commit()
+        reclaimed = store.claim_fuzzy_modify_plan(plan["plan_id"], stale_after_seconds=60.0)
+        assert reclaimed is not None
+        assert reclaimed["status"] == "executing"
+    finally:
+        store.close()
+
+
 def test_stale_mark_rollback_restores_previous_source(tmp_path):
     store = MetadataStore(data_dir=tmp_path)
     store.connect()

--- a/pytests/A_memorix_test/test_graph_store_persistence.py
+++ b/pytests/A_memorix_test/test_graph_store_persistence.py
@@ -164,3 +164,23 @@ def test_graph_store_failed_mirror_save_does_not_activate_partial_snapshot(
 
     assert active_after == active_before
     assert reloaded.num_edges == 1
+
+
+def test_graph_store_cleanup_failure_does_not_mask_activated_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / "graph"
+    store = GraphStore(data_dir=data_dir)
+    store.add_edges([("Alice", "Bob")], relation_hashes=["rel-1"])
+
+    def fail_cleanup(_data_dir: Path, _generation: str) -> None:
+        raise OSError("forced cleanup failure")
+
+    monkeypatch.setattr(store, "_cleanup_old_snapshots", fail_cleanup)
+
+    store.save()
+
+    reloaded = GraphStore(data_dir=data_dir)
+    reloaded.load()
+    assert reloaded.num_edges == 1

--- a/pytests/A_memorix_test/test_graph_store_persistence.py
+++ b/pytests/A_memorix_test/test_graph_store_persistence.py
@@ -53,7 +53,8 @@ def test_graph_store_load_resets_stale_adjacency_when_metadata_is_empty(tmp_path
     store.add_edges([("Alice", "Bob")], relation_hashes=["rel-1"])
     store.save()
 
-    metadata_path = data_dir / "graph_metadata.json"
+    pointer = json.loads((data_dir / "graph_snapshot.json").read_text(encoding="utf-8"))
+    metadata_path = data_dir / "graph_snapshots" / pointer["generation"] / "graph_metadata.json"
     metadata_path.write_text(json.dumps(_build_empty_graph_metadata()), encoding="utf-8")
 
     reloaded = GraphStore(data_dir=data_dir)
@@ -99,3 +100,67 @@ def test_graph_store_save_uses_sqlite_edge_map_when_metadata_db_exists(tmp_path:
         conn.close()
     assert len(rows) == 1
     assert rows[0][2] == "rel-1"
+
+
+def test_graph_store_rejects_relation_hash_length_mismatch_before_mutation(tmp_path: Path) -> None:
+    store = GraphStore(data_dir=tmp_path / "graph")
+
+    with pytest.raises(ValueError, match="关系哈希数量不匹配"):
+        store.add_edges([("Alice", "Bob"), ("Bob", "Carol")], relation_hashes=["rel-1"])
+
+    assert store.num_nodes == 0
+    assert store.num_edges == 0
+
+
+def test_graph_store_incremental_add_invalidates_transpose_and_saliency(tmp_path: Path) -> None:
+    store = GraphStore(data_dir=tmp_path / "graph")
+    store.add_edges([("Alice", "Bob")], relation_hashes=["rel-1"])
+    store._ensure_adjacency_T()
+    store.get_saliency_scores()
+    assert store._adjacency_T is not None
+    assert store._saliency_cache is not None
+
+    with store.batch_update():
+        store.add_edges([("Carol", "Alice")], relation_hashes=["rel-2"])
+        assert store._adjacency_dirty is True
+        assert store._saliency_cache is None
+
+    assert "Carol" in store.get_in_neighbors("Alice")
+
+
+def test_graph_store_low_weight_edges_keep_csc_coordinates_aligned(tmp_path: Path) -> None:
+    store = GraphStore(matrix_format="csc", data_dir=tmp_path / "graph")
+    store.add_edges(
+        [("Alice", "Bob"), ("Carol", "Alice")],
+        weights=[0.8, 0.05],
+        relation_hashes=["rel-1", "rel-2"],
+    )
+
+    assert store.get_low_weight_edges(0.1) == [("Carol", "Alice")]
+
+
+def test_graph_store_failed_mirror_save_does_not_activate_partial_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / "graph"
+    store = GraphStore(data_dir=data_dir)
+    store.add_edges([("Alice", "Bob")], relation_hashes=["rel-1"])
+    store.save()
+    active_before = json.loads((data_dir / "graph_snapshot.json").read_text(encoding="utf-8"))["generation"]
+
+    store.add_edges([("Bob", "Carol")], relation_hashes=["rel-2"])
+
+    def fail_edge_map(_data_dir: Path) -> bool:
+        raise sqlite3.OperationalError("forced edge map failure")
+
+    monkeypatch.setattr(store, "_save_edge_hash_map", fail_edge_map)
+    with pytest.raises(sqlite3.OperationalError, match="forced edge map failure"):
+        store.save()
+
+    active_after = json.loads((data_dir / "graph_snapshot.json").read_text(encoding="utf-8"))["generation"]
+    reloaded = GraphStore(data_dir=data_dir)
+    reloaded.load()
+
+    assert active_after == active_before
+    assert reloaded.num_edges == 1

--- a/pytests/A_memorix_test/test_metadata_connection_manager.py
+++ b/pytests/A_memorix_test/test_metadata_connection_manager.py
@@ -204,3 +204,28 @@ def test_metadata_store_closed_manager_cannot_create_new_connections(tmp_path: P
     assert manager.connection_count == 0
     with pytest.raises(RuntimeError, match="连接管理器已关闭"):
         manager.connection()
+
+
+@pytest.mark.parametrize("operation", ["upsert", "delete"])
+def test_fts_paragraph_write_preserves_unmanaged_outer_transaction(
+    operation: str,
+    tmp_path: Path,
+) -> None:
+    store = MetadataStore(data_dir=tmp_path)
+    store.connect()
+    try:
+        paragraph_hash = store.add_paragraph("FTS 外部事务测试")
+        connection = store.get_connection()
+        connection.execute("BEGIN")
+        connection.execute("UPDATE paragraphs SET content = ? WHERE hash = ?", ("事务内内容", paragraph_hash))
+
+        if operation == "upsert":
+            assert store.fts_upsert_paragraph(paragraph_hash) is True
+        else:
+            assert store.fts_delete_paragraph(paragraph_hash) is True
+
+        assert connection.in_transaction is True
+        connection.rollback()
+        assert store.get_paragraph(paragraph_hash)["content"] == "FTS 外部事务测试"
+    finally:
+        store.close()

--- a/pytests/A_memorix_test/test_metadata_connection_manager.py
+++ b/pytests/A_memorix_test/test_metadata_connection_manager.py
@@ -46,6 +46,42 @@ def test_metadata_store_transaction_rolls_back_on_error(tmp_path: Path) -> None:
         store.close()
 
 
+def test_metadata_store_transaction_rolls_back_on_base_exception(tmp_path: Path) -> None:
+    class StopTransaction(BaseException):
+        pass
+
+    store = MetadataStore(data_dir=tmp_path)
+    store.connect()
+    try:
+        with pytest.raises(StopTransaction):
+            with store.transaction(immediate=True) as connection:
+                connection.execute(
+                    "INSERT INTO paragraphs (hash, content, knowledge_type) VALUES (?, ?, ?)",
+                    ("base-exception-hash", "不会提交", "mixed"),
+                )
+                raise StopTransaction
+
+        assert store.get_paragraph("base-exception-hash") is None
+        manager = store._connection_manager
+        assert manager is not None
+        connection = manager.connection()
+        assert connection._managed_transaction_depth == 0
+        assert connection.in_transaction is False
+    finally:
+        store.close()
+
+
+def test_metadata_store_rejects_unmanaged_override_transaction(tmp_path: Path) -> None:
+    store = MetadataStore(data_dir=tmp_path)
+    connection = sqlite3.connect(":memory:")
+    store._conn = connection
+    try:
+        with pytest.raises(TypeError, match="不支持受管事务"):
+            store.transaction()
+    finally:
+        store.close()
+
+
 def test_metadata_store_reinitializes_schema_after_switching_data_directory(tmp_path: Path) -> None:
     first_data_dir = tmp_path / "first"
     second_data_dir = tmp_path / "second"

--- a/pytests/A_memorix_test/test_runtime_lifecycle_boundaries.py
+++ b/pytests/A_memorix_test/test_runtime_lifecycle_boundaries.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+import asyncio
 import pytest
 
 from src.A_memorix.core.runtime import sdk_memory_kernel as kernel_module
@@ -263,12 +264,47 @@ async def test_plugin_config_update_awaits_kernel_shutdown() -> None:
     plugin = object.__new__(AMemorixPlugin)
     plugin._plugin_config = {"old": True}
     plugin._kernel = FakeKernel()  # type: ignore[assignment]
+    plugin._kernel_lock = asyncio.Lock()
 
     await plugin.on_config_update("self", {"new": True}, "test-version")
 
     assert events == ["shutdown"]
     assert plugin._plugin_config == {"new": True}
     assert plugin._kernel is None
+
+
+@pytest.mark.asyncio
+async def test_plugin_concurrent_get_kernel_initializes_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.A_memorix import plugin as plugin_module
+
+    initialize_started = asyncio.Event()
+    allow_initialize = asyncio.Event()
+    created_kernels: list[Any] = []
+
+    class FakeKernel:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+            created_kernels.append(self)
+
+        async def initialize(self) -> None:
+            initialize_started.set()
+            await allow_initialize.wait()
+
+    monkeypatch.setattr(plugin_module, "SDKMemoryKernel", FakeKernel)
+    plugin = plugin_module.AMemorixPlugin()
+
+    first_task = asyncio.create_task(plugin._get_kernel())
+    await initialize_started.wait()
+    second_task = asyncio.create_task(plugin._get_kernel())
+    await asyncio.sleep(0)
+
+    assert len(created_kernels) == 1
+
+    allow_initialize.set()
+    first_kernel, second_kernel = await asyncio.gather(first_task, second_task)
+
+    assert first_kernel is second_kernel
+    assert created_kernels == [first_kernel]
 
 
 @pytest.mark.asyncio

--- a/pytests/A_memorix_test/test_runtime_payloads.py
+++ b/pytests/A_memorix_test/test_runtime_payloads.py
@@ -19,6 +19,7 @@ from src.A_memorix.core.utils.runtime_payloads import (
 
 def test_runtime_payload_tokens_keep_order_and_drop_empty_duplicates() -> None:
     assert tokens([" Alice ", "", None, "Alice", "Bob", 42]) == ["Alice", "Bob", "42"]
+    assert tokens("active") == ["active"]
     assert merge_tokens(["Alice", "Bob"], ["Bob", "Carol"], None) == ["Alice", "Bob", "Carol"]
     assert argument_tokens("Alice") == ["Alice"]
     assert merge_argument_tokens(["Alice"], "Bob", ["Alice", "Carol"]) == ["Alice", "Bob", "Carol"]

--- a/pytests/A_memorix_test/test_runtime_service_boundaries.py
+++ b/pytests/A_memorix_test/test_runtime_service_boundaries.py
@@ -1568,6 +1568,44 @@ async def test_source_admin_delete_actions_use_kernel_patched_boundaries(
 
 
 @pytest.mark.asyncio
+async def test_episode_batch_preserves_processing_error_when_failure_marking_also_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_failures: list[tuple[str, str]] = []
+
+    class FakeMetadataStore:
+        def fetch_episode_pending_batch(self, *, limit: int, max_retry: int) -> list[dict[str, str]]:
+            return [{"paragraph_hash": "paragraph-1", "source": "source-1"}]
+
+        def mark_episode_pending_running(self, hashes: list[str]) -> None:
+            assert hashes == ["paragraph-1"]
+
+        def mark_episode_pending_failed(self, hash_value: str, error: str) -> None:
+            raise RuntimeError(f"mark failed: {hash_value}: {error}")
+
+        def mark_episode_source_failed(self, source: str, error: str) -> None:
+            source_failures.append((source, error))
+
+    class FakeEpisodeService:
+        async def process_pending_rows(self, rows: list[dict[str, str]]) -> dict[str, Any]:
+            raise ValueError("primary episode failure")
+
+    kernel = SDKMemoryKernel(plugin_root=Path.cwd(), config={})
+    kernel.metadata_store = FakeMetadataStore()  # type: ignore[assignment]
+    kernel.episode_service = FakeEpisodeService()  # type: ignore[assignment]
+
+    async def fake_initialize() -> None:
+        return None
+
+    monkeypatch.setattr(kernel, "initialize", fake_initialize)
+
+    with pytest.raises(ValueError, match="primary episode failure"):
+        await kernel._ingest_service.process_episode_pending_batch()
+
+    assert source_failures == [("source-1", "episode processing failed: primary episode failure")]
+
+
+@pytest.mark.asyncio
 async def test_memory_maintenance_cycle_uses_kernel_patched_phase_boundaries(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1609,6 +1647,30 @@ async def test_memory_maintenance_cycle_uses_kernel_patched_phase_boundaries(
     assert calls == ["freeze", "orphan"]
     assert kernel._last_maintenance_at == 123.0
     assert persist_calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("configured_interval", "expected_sleep"), [(None, 3600.0), (0, 60.0)])
+async def test_memory_maintenance_loop_handles_none_without_overwriting_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    configured_interval: float | None,
+    expected_sleep: float,
+) -> None:
+    kernel = SDKMemoryKernel(
+        plugin_root=Path.cwd(),
+        config={"memory": {"base_decay_interval_hours": configured_interval}},
+    )
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+        kernel._background_stopping = True
+
+    monkeypatch.setattr(memory_maintenance_service.asyncio, "sleep", fake_sleep)
+
+    await kernel._maintenance_service._memory_maintenance_loop()
+
+    assert sleep_calls == [expected_sleep]
 
 
 @pytest.mark.asyncio

--- a/pytests/A_memorix_test/test_runtime_service_boundaries.py
+++ b/pytests/A_memorix_test/test_runtime_service_boundaries.py
@@ -10,6 +10,8 @@ from src.A_memorix.core.retrieval import RetrievalResult
 from src.A_memorix.core.runtime import sdk_memory_kernel as kernel_module
 from src.A_memorix.core.runtime.sdk_memory_kernel import KernelSearchRequest, SDKMemoryKernel
 from src.A_memorix.core.runtime.services import memory_maintenance_service
+from src.A_memorix.core.storage.graph_store import GraphStore
+from src.A_memorix.core.storage.metadata_store import MetadataStore
 from src.A_memorix.core.utils import profile_policy
 
 
@@ -48,6 +50,52 @@ async def test_graph_admin_delete_node_uses_kernel_patched_delete_action(monkeyp
     assert result["success"] is True
     assert result["deleted"] is True
     assert result["marker"] == "kernel-patched"
+
+
+def test_graph_admin_rename_rehashes_relations_and_invalidates_vectors(tmp_path: Path) -> None:
+    metadata_store = MetadataStore(data_dir=tmp_path / "metadata")
+    metadata_store.connect()
+    try:
+        paragraph_hash = metadata_store.add_paragraph("Alice 喜欢 Bob", source="test")
+        old_entity_hash = metadata_store.add_entity("Alice", vector_index=12, source_paragraph=paragraph_hash)
+        metadata_store.add_entity("Bob", source_paragraph=paragraph_hash)
+        old_relation_hash = metadata_store.add_relation(
+            "Alice",
+            "喜欢",
+            "Bob",
+            vector_index=34,
+            source_paragraph=paragraph_hash,
+        )
+        deleted_vector_ids: list[str] = []
+        vector_store = SimpleNamespace(
+            delete=lambda ids: deleted_vector_ids.extend(ids) or len(ids),
+        )
+        kernel = SDKMemoryKernel(plugin_root=Path.cwd(), config={})
+        kernel.metadata_store = metadata_store
+        kernel.graph_store = GraphStore(data_dir=tmp_path / "graph")
+        kernel.vector_store = vector_store  # type: ignore[assignment]
+        kernel._persist = lambda: None  # type: ignore[method-assign]
+
+        result = kernel._rename_node("Alice", "Carol")
+
+        assert result["success"] is True
+        new_relation_hash = metadata_store.compute_relation_hash("Carol", "喜欢", "Bob")
+        assert metadata_store.get_relation(old_relation_hash) is None
+        relation = metadata_store.get_relation(new_relation_hash)
+        assert relation is not None
+        assert relation["subject"] == "Carol"
+        assert relation["vector_index"] is None
+        assert relation["vector_state"] == "none"
+        assert metadata_store.get_entity(old_entity_hash) is None
+        new_entity = metadata_store.get_entity(result["entity_hash"])
+        assert new_entity is not None
+        assert new_entity["vector_index"] is None
+        paragraph_relations = metadata_store.get_paragraph_relations(paragraph_hash)
+        assert [item["hash"] for item in paragraph_relations] == [new_relation_hash]
+        assert old_entity_hash in deleted_vector_ids
+        assert old_relation_hash in deleted_vector_ids
+    finally:
+        metadata_store.close()
 
 
 @pytest.mark.asyncio
@@ -366,6 +414,32 @@ async def test_runtime_config_service_apply_tuning_uses_kernel_patched_runtime_b
     assert calls[0][0] == "build"
     assert calls[0][1]["owner_tag"] == "sdk_kernel_tuning_apply"
     assert calls[1:] == [("refresh", True), ("sparse", None)]
+
+
+@pytest.mark.asyncio
+async def test_runtime_config_service_clears_sparse_index_when_rebuild_disables_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kernel = SDKMemoryKernel(plugin_root=Path.cwd(), config={})
+    kernel.sparse_index = object()  # type: ignore[assignment]
+    monkeypatch.setattr(
+        kernel_module,
+        "build_search_runtime",
+        lambda **kwargs: SimpleNamespace(
+            ready=True,
+            error="",
+            retriever="retriever",
+            threshold_filter="threshold",
+            sparse_index=None,
+        ),
+    )
+    monkeypatch.setattr(kernel, "_refresh_runtime_dependents", lambda **kwargs: None)
+    monkeypatch.setattr(kernel, "_apply_runtime_sparse_mode", lambda: None)
+
+    result = await kernel._runtime_config_service.apply_retrieval_tuning_profile({}, validate=True)
+
+    assert result["success"] is True
+    assert kernel.sparse_index is None
 
 
 def test_chat_filter_service_uses_kernel_patched_filter_boundary(
@@ -1846,6 +1920,36 @@ async def test_request_dedup_service_shares_inflight_request() -> None:
     assert first_result == (False, {"success": True})
     assert second_result == (True, {"success": True})
     assert calls == 1
+    assert kernel._request_dedup_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_request_dedup_waiter_cancellation_does_not_cancel_shared_request() -> None:
+    kernel = SDKMemoryKernel(plugin_root=Path.cwd(), config={})
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def executor() -> dict[str, Any]:
+        started.set()
+        await release.wait()
+        return {"success": True}
+
+    owner = asyncio.create_task(
+        kernel._request_dedup_service.execute_request_with_dedup("same-request", executor)
+    )
+    await started.wait()
+    waiter = asyncio.create_task(
+        kernel._request_dedup_service.execute_request_with_dedup("same-request", executor)
+    )
+    await asyncio.sleep(0)
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    assert "same-request" in kernel._request_dedup_tasks
+    release.set()
+    assert await owner == (False, {"success": True})
+    await asyncio.sleep(0)
     assert kernel._request_dedup_tasks == {}
 
 

--- a/pytests/A_memorix_test/test_sparse_warmup_backend.py
+++ b/pytests/A_memorix_test/test_sparse_warmup_backend.py
@@ -175,6 +175,25 @@ def test_tokenized_shadow_index_does_not_commit_outer_transaction(tmp_path: Path
         store.close()
 
 
+def test_primary_fts_delete_does_not_commit_outer_transaction(tmp_path: Path) -> None:
+    store = MetadataStore(data_dir=tmp_path)
+    store.connect()
+    try:
+        paragraph_hash = store.add_paragraph("primary fts rollback probe 蓝莓曲奇", source="test")
+        assert store.fts_upsert_paragraph(paragraph_hash) is True
+
+        conn = store.get_connection()
+        conn.execute("BEGIN IMMEDIATE")
+        assert store.fts_delete_paragraph(paragraph_hash, conn=conn) is True
+        assert conn.in_transaction is True
+
+        conn.rollback()
+        rows = store.fts_search_bm25("蓝莓曲奇", limit=5)
+        assert {row["hash"] for row in rows} == {paragraph_hash}
+    finally:
+        store.close()
+
+
 def test_sparse_experimental_backend_is_explicitly_not_runtime_ready(tmp_path: Path) -> None:
     store = MetadataStore(data_dir=tmp_path)
     store.connect()

--- a/pytests/A_memorix_test/test_summary_importer_model_config.py
+++ b/pytests/A_memorix_test/test_summary_importer_model_config.py
@@ -121,6 +121,26 @@ def test_resolve_summary_model_config_rejects_legacy_string_selector(monkeypatch
         importer._resolve_summary_model_config()
 
 
+def test_resolve_summary_model_config_skips_task_with_invalid_model(monkeypatch):
+    monkeypatch.setattr(llm_api, "get_available_models", _fake_available_models)
+    importer = SummaryImporter(
+        vector_store=None,
+        graph_store=None,
+        metadata_store=None,
+        embedding_manager=None,
+        plugin_config={
+            "summarization": {
+                "model_name": ["memory:not-a-memory-model", "utils:utils-model"],
+            }
+        },
+    )
+
+    resolved = importer._resolve_summary_model_config()
+
+    assert resolved is not None
+    assert resolved.model_list == ["utils-model"]
+
+
 def test_summary_importer_normalizes_llm_entities_and_relations():
     assert _normalize_entity_items(["Alice", {"name": "地图"}, ["bad"], "Alice"]) == ["Alice", "地图"]
     assert _normalize_entity_items("Alice") == []

--- a/pytests/A_memorix_test/test_vector_rebuild_runtime.py
+++ b/pytests/A_memorix_test/test_vector_rebuild_runtime.py
@@ -603,6 +603,43 @@ async def test_dual_initialize_without_ready_manifest_falls_back_to_single_pool(
     await dual_kernel.shutdown()
 
 
+def test_dual_cleanup_keeps_activated_directories_when_ready_manifest_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    data_dir = tmp_path / "a_memorix_data"
+    kernel = SDKMemoryKernel(
+        plugin_root=tmp_path / "plugin_root",
+        config=_dual_kernel_config(data_dir, 8),
+    )
+    vectors_root = data_dir / "vectors"
+    paragraph_dir = vectors_root / "paragraph"
+    graph_dir = vectors_root / "graph"
+    paragraph_dir.mkdir(parents=True)
+    graph_dir.mkdir(parents=True)
+    (paragraph_dir / "current.txt").write_text("new paragraph", encoding="utf-8")
+    (graph_dir / "current.txt").write_text("new graph", encoding="utf-8")
+
+    backup_root = vectors_root / "dual_backup_1"
+    backup_paragraph = backup_root / "paragraph"
+    backup_graph = backup_root / "graph"
+    backup_paragraph.mkdir(parents=True)
+    backup_graph.mkdir(parents=True)
+    (backup_paragraph / "old.txt").write_text("old paragraph", encoding="utf-8")
+    (backup_graph / "old.txt").write_text("old graph", encoding="utf-8")
+    (backup_root / "activation.json").write_text(
+        json.dumps({"status": "activated", "had_paragraph": True, "had_graph": True}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(kernel, "_dual_vector_ready", lambda **kwargs: False)
+
+    kernel._dual_vector_state_service._cleanup_stale_dual_vector_build_dirs()
+
+    assert (paragraph_dir / "current.txt").read_text(encoding="utf-8") == "new paragraph"
+    assert (graph_dir / "current.txt").read_text(encoding="utf-8") == "new graph"
+    assert not backup_root.exists()
+
+
 @pytest.mark.asyncio
 async def test_default_dual_mode_starts_auto_migration_without_blocking_initialize(
     monkeypatch: pytest.MonkeyPatch,

--- a/pytests/A_memorix_test/test_vector_store_consistency.py
+++ b/pytests/A_memorix_test/test_vector_store_consistency.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import shutil
+
+import numpy as np
+import pytest
+
+from src.A_memorix.core.storage.vector_store import HAS_FAISS, VectorStore
+
+
+pytestmark = pytest.mark.skipif(not HAS_FAISS, reason="Faiss 未安装")
+
+
+def _vector() -> np.ndarray:
+    return np.asarray([[1.0, 0.0]], dtype=np.float32)
+
+
+def test_vector_id_map_cache_detects_equal_size_membership_change(tmp_path: Path) -> None:
+    store = VectorStore(dimension=2, data_dir=tmp_path / "vectors")
+    store._known_hashes = {"old"}
+    store._invalidate_id_map()
+    old_map = dict(store._int_to_str_map)
+
+    store._known_hashes = {"new"}
+    store._invalidate_id_map()
+
+    assert old_map != store._int_to_str_map
+    assert set(store._int_to_str_map.values()) == {"new"}
+
+
+def test_vector_compaction_removes_deleted_hash_and_allows_readd(tmp_path: Path) -> None:
+    store = VectorStore(dimension=2, data_dir=tmp_path / "vectors", buffer_size=1)
+    assert store.add(_vector(), ["relation-1"]) == 1
+    assert store.delete(["relation-1"]) == 1
+
+    store.rebuild_index()
+
+    assert "relation-1" not in store
+    assert store.add(_vector(), ["relation-1"]) == 1
+
+
+def test_vector_compaction_journal_restores_consistent_backup(tmp_path: Path) -> None:
+    store = VectorStore(dimension=2, data_dir=tmp_path / "vectors", buffer_size=1)
+    store.add(_vector(), ["relation-1"])
+    original_bin = store._bin_path.read_bytes()
+    original_ids = store._ids_bin_path.read_bytes()
+    shutil.copy2(store._bin_path, store._bin_backup_path)
+    shutil.copy2(store._ids_bin_path, store._ids_backup_path)
+    store._bin_path.write_bytes(b"broken")
+    store._compaction_journal_path.write_text(
+        json.dumps({"expected_count": 2}),
+        encoding="utf-8",
+    )
+
+    store._recover_interrupted_compaction_unlocked()
+
+    assert store._bin_path.read_bytes() == original_bin
+    assert store._ids_bin_path.read_bytes() == original_ids
+    assert not store._compaction_journal_path.exists()

--- a/pytests/webui/test_memory_routes_integration.py
+++ b/pytests/webui/test_memory_routes_integration.py
@@ -113,7 +113,7 @@ def _build_test_config(data_dir: Path) -> Dict[str, Any]:
         },
         "threshold": {
             "percentile": 70.0,
-            "min_results": 1,
+            "min_results": 20,
         },
         "web": {
             "tuning": {
@@ -193,7 +193,13 @@ def _wait_for_tuning_task_terminal(client: TestClient, task_id: str, *, timeout_
     raise AssertionError(f"调优任务超时: task_id={task_id}, last_payload={last_payload}")
 
 
-def _wait_for_query_hit(client: TestClient, query: str, *, timeout_seconds: float = 30.0) -> Dict[str, Any]:
+def _wait_for_query_hit(
+    client: TestClient,
+    query: str,
+    *,
+    expected_content: str = "",
+    timeout_seconds: float = 30.0,
+) -> Dict[str, Any]:
     deadline = monotonic() + timeout_seconds
     last_payload: Dict[str, Any] = {}
     while monotonic() < deadline:
@@ -205,7 +211,11 @@ def _wait_for_query_hit(client: TestClient, query: str, *, timeout_seconds: floa
         )
         last_payload = payload
         hits = payload.get("hits") or []
-        if isinstance(hits, list) and len(hits) > 0:
+        if isinstance(hits, list) and any(
+            isinstance(item, dict)
+            and (not expected_content or expected_content in str(item.get("content", "") or ""))
+            for item in hits
+        ):
             return payload
         sleep(0.2)
     raise AssertionError(f"检索命中超时: query={query}, last_payload={last_payload}")
@@ -442,7 +452,7 @@ def integration_state(tmp_path_factory: pytest.TempPathFactory) -> Generator[Dic
         seed_task = _wait_for_import_task_terminal(client, seed_task_id)
         assert str(seed_task.get("status", "") or "") in {"completed", "completed_with_errors"}, seed_task
 
-        _wait_for_query_hit(client, unique_token, timeout_seconds=45.0)
+        _wait_for_query_hit(client, unique_token, expected_content=unique_token, timeout_seconds=45.0)
 
         yield {
             "client": client,
@@ -478,7 +488,12 @@ def test_retrieval_module_end_to_end_queries_seeded_data(integration_state: Dict
     client = integration_state["client"]
     unique_token = integration_state["unique_token"]
 
-    aggregate_payload = _wait_for_query_hit(client, unique_token, timeout_seconds=45.0)
+    aggregate_payload = _wait_for_query_hit(
+        client,
+        unique_token,
+        expected_content=unique_token,
+        timeout_seconds=45.0,
+    )
     hits = aggregate_payload.get("hits") or []
     joined_content = "\n".join(str(item.get("content", "") or "") for item in hits if isinstance(item, dict))
     assert unique_token in joined_content
@@ -559,10 +574,17 @@ def test_tuning_module_end_to_end_create_and_apply_best(integration_state: Dict[
     assert runtime_retrieval.get("top_k_final") == applied_retrieval.get("top_k_final")
     assert runtime_retrieval.get("fusion") == applied_retrieval.get("fusion")
 
-    probe_payload = _wait_for_query_hit(client, probe_query, timeout_seconds=45.0)
+    probe_payload = _wait_for_query_hit(
+        client,
+        probe_query,
+        expected_content=probe_phrase,
+        timeout_seconds=45.0,
+    )
     probe_hits = probe_payload.get("hits") or []
     joined_probe_content = "\n".join(str(item.get("content", "") or "") for item in probe_hits if isinstance(item, dict))
     assert probe_phrase in joined_probe_content
+
+    _assert_response_ok(client.post("/api/webui/memory/retrieval_tuning/profile/rollback"))
 
 
 def test_delete_module_end_to_end_preview_execute_restore(integration_state: Dict[str, Any]) -> None:
@@ -708,7 +730,12 @@ def test_real_api_business_flow_import_query_graph_delete_restore(integration_st
     source_item = _wait_for_source_paragraph_count(client, source_name, min_count=2, timeout_seconds=45.0)
     assert _source_paragraph_count(source_item) == 2
 
-    relation_query_payload = _wait_for_query_hit(client, access_code, timeout_seconds=45.0)
+    relation_query_payload = _wait_for_query_hit(
+        client,
+        access_code,
+        expected_content=access_code,
+        timeout_seconds=45.0,
+    )
     relation_hits = [
         item
         for item in (relation_query_payload.get("hits") or [])
@@ -719,6 +746,7 @@ def test_real_api_business_flow_import_query_graph_delete_restore(integration_st
     paragraph_query_payload = _wait_for_query_hit(
         client,
         f"{person_name} {location_name} {device_name}",
+        expected_content=location_name,
         timeout_seconds=45.0,
     )
     paragraph_hits = [
@@ -726,7 +754,10 @@ def test_real_api_business_flow_import_query_graph_delete_restore(integration_st
         for item in (paragraph_query_payload.get("hits") or [])
         if isinstance(item, dict)
         and str(item.get("type", "") or "") == "paragraph"
-        and person_name in str(item.get("content", "") or "")
+        and all(
+            token in str(item.get("content", "") or "")
+            for token in (person_name, location_name, device_name)
+        )
     ]
     assert paragraph_hits, paragraph_query_payload
 
@@ -815,7 +846,12 @@ def test_real_api_business_flow_import_query_graph_delete_restore(integration_st
         )
     )
     _wait_for_source_paragraph_count(client, source_name, min_count=2, timeout_seconds=45.0)
-    restored_query = _wait_for_query_hit(client, access_code, timeout_seconds=45.0)
+    restored_query = _wait_for_query_hit(
+        client,
+        access_code,
+        expected_content=access_code,
+        timeout_seconds=45.0,
+    )
     assert any(
         access_code in str(item.get("content", "") or "")
         for item in (restored_query.get("hits") or [])

--- a/scripts/expression_selection/offline_runner.py
+++ b/scripts/expression_selection/offline_runner.py
@@ -16,7 +16,7 @@ from hashlib import sha256
 from pathlib import Path
 from random import Random
 from sys import path as sys_path
-from typing import Any, Dict, List, Sequence
+from typing import Any, List, Sequence
 
 import argparse
 import asyncio

--- a/src/A_memorix/core/retrieval/sparse_bm25.py
+++ b/src/A_memorix/core/retrieval/sparse_bm25.py
@@ -654,19 +654,22 @@ class SparseBM25Index:
 
     def unload(self) -> None:
         """卸载 BM25 连接并尽量释放内存。"""
-        if self._conn is not None:
-            try:
+        conn = self._conn
+        try:
+            if conn is not None:
                 if self.config.shrink_memory_on_unload:
-                    self.metadata_store.shrink_memory(conn=self._conn)
-            except sqlite3.Error as exc:
-                logger.warning(f"SparseBM25Index 释放 SQLite 缓存失败: {exc}")
-            try:
-                self._conn.close()
-            except sqlite3.Error as exc:
-                logger.warning(f"SparseBM25Index 关闭连接失败: {exc}")
-        self._conn = None
-        self._loaded = False
-        logger.info("SparseBM25Index unloaded")
+                    self.metadata_store.shrink_memory(conn=conn)
+        except sqlite3.Error as exc:
+            logger.warning(f"SparseBM25Index 释放 SQLite 缓存失败: {exc}")
+        finally:
+            if conn is not None:
+                try:
+                    conn.close()
+                except sqlite3.Error as exc:
+                    logger.warning(f"SparseBM25Index 关闭连接失败: {exc}")
+            self._conn = None
+            self._loaded = False
+            logger.info("SparseBM25Index unloaded")
 
     def stats(self) -> Dict[str, Any]:
         backend_stats = self._backend.stats(self._conn if self.loaded else None)

--- a/src/A_memorix/core/runtime/lifecycle_orchestrator.py
+++ b/src/A_memorix/core/runtime/lifecycle_orchestrator.py
@@ -199,7 +199,7 @@ async def initialize_storage_async(plugin: Any) -> None:
 
     logger.info(f"A_Memorix 数据存储路径: {data_dir}")
     data_dir.mkdir(parents=True, exist_ok=True)
-    run_startup_format_migration(data_dir)
+    await asyncio.to_thread(run_startup_format_migration, data_dir)
 
     plugin.embedding_manager = create_embedding_api_adapter(
         batch_size=plugin.get_config("embedding.batch_size", 32),

--- a/src/A_memorix/core/runtime/services/correction_admin_service.py
+++ b/src/A_memorix/core/runtime/services/correction_admin_service.py
@@ -205,6 +205,12 @@ class MemoryCorrectionAdminService(KernelServiceBase):
             if not fuzzy_modify_cfg_auto_execute_enabled() or confidence < fuzzy_modify_cfg_confirm_threshold():
                 return {"success": False, "error": "需要用户确认后才能执行", "requires_confirmation": True}
 
+        claimed_plan = self.metadata_store.claim_fuzzy_modify_plan(token)
+        if claimed_plan is None:
+            latest = self.metadata_store.get_fuzzy_modify_plan(token)
+            return {"success": False, "error": "修改计划正在执行或状态已变化", "plan": latest}
+        plan_record = claimed_plan
+
         previous_execution = plan_record.get("execution") if isinstance(plan_record.get("execution"), dict) else {}
         attempt_started_at = time.time()
         executing_payload = {
@@ -413,7 +419,7 @@ class MemoryCorrectionAdminService(KernelServiceBase):
 
         if relation_hashes:
             self.metadata_store.mark_relations_inactive(relation_hashes, inactive_since=time.time())
-        if restored_targets:
+        if relation_hashes or restored_targets:
             self._rebuild_graph_from_metadata()
             self._persist()
         rollback_success = not restore_failures
@@ -573,7 +579,11 @@ class MemoryCorrectionAdminService(KernelServiceBase):
             for item in candidates
             if str(item.get("hash", "") or "").strip()
         }
-        confidence = min(1.0, max(0.0, float(payload.get("confidence", 0.0) or 0.0)))
+        try:
+            confidence = float(payload.get("confidence", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            confidence = 0.0
+        confidence = min(1.0, max(0.0, confidence))
         max_targets = fuzzy_modify_cfg_max_targets()
         operations: List[Dict[str, Any]] = []
         for raw in payload.get("operations") or []:
@@ -677,12 +687,17 @@ class MemoryCorrectionAdminService(KernelServiceBase):
             obj = str(row.get("object", "") or "").strip()
             if not (subject and predicate and obj):
                 continue
+            raw_confidence = row.get("confidence", 1.0)
+            try:
+                confidence = float(1.0 if raw_confidence is None else raw_confidence)
+            except (TypeError, ValueError):
+                confidence = 1.0
             relations.append(
                 {
                     "subject": subject,
                     "predicate": predicate,
                     "object": obj,
-                    "confidence": min(1.0, max(0.0, float(row.get("confidence", 1.0) or 1.0))),
+                    "confidence": min(1.0, max(0.0, confidence)),
                     "metadata": row.get("metadata") if isinstance(row.get("metadata"), dict) else {},
                 }
             )

--- a/src/A_memorix/core/runtime/services/delete_admin_service.py
+++ b/src/A_memorix/core/runtime/services/delete_admin_service.py
@@ -634,6 +634,20 @@ class MemoryDeleteAdminService(KernelServiceBase):
         relation_hashes = tokens((plan.get("target_hashes") or {}).get("relations"))
         requested_source_tokens = tokens((plan.get("target_hashes") or {}).get("sources"))
         matched_source_tokens = tokens((plan.get("target_hashes") or {}).get("matched_sources"))
+        operation = self.metadata_store.create_delete_operation(
+            mode=act_mode,
+            selector=plan.get("selector"),
+            items=plan.get("items", []),
+            reason=reason,
+            requested_by=requested_by,
+            summary={
+                "counts": plan.get("counts", {}),
+                "sources": plan.get("sources", []),
+                "vector_ids": plan.get("vector_ids", []),
+                "state": "prepared",
+            },
+        )
+        operation_id = str(operation.get("operation_id", "") or "")
 
         try:
             if paragraph_hashes:
@@ -660,25 +674,11 @@ class MemoryDeleteAdminService(KernelServiceBase):
 
             conn.commit()
 
-            deleted_relations = self.metadata_store.backup_and_delete_relations(relation_hashes)
+            self.metadata_store.backup_and_delete_relations(relation_hashes)
             deleted_vectors = self._delete_vectors_by_type(
                 paragraph_hashes=paragraph_hashes,
                 entity_hashes=entity_hashes,
                 relation_hashes=relation_hashes,
-            )
-
-            operation = self.metadata_store.create_delete_operation(
-                mode=act_mode,
-                selector=plan.get("selector"),
-                items=plan.get("items", []),
-                reason=reason,
-                requested_by=requested_by,
-                summary={
-                    "counts": plan.get("counts", {}),
-                    "sources": plan.get("sources", []),
-                    "vector_ids": plan.get("vector_ids", []),
-                    "deleted_relation_rows": deleted_relations,
-                },
             )
 
             if plan.get("sources"):
@@ -687,7 +687,7 @@ class MemoryDeleteAdminService(KernelServiceBase):
             self._persist()
             return self._build_standard_delete_result(
                 mode=act_mode,
-                operation_id=str(operation.get("operation_id", "") or ""),
+                operation_id=operation_id,
                 counts=plan.get("counts", {}),
                 sources=plan.get("sources", []),
                 deleted_entity_count=len(entity_hashes),
@@ -702,7 +702,7 @@ class MemoryDeleteAdminService(KernelServiceBase):
         except Exception as exc:
             conn.rollback()
             logger.warning(f"delete_admin execute 失败: {exc}")
-            return self._build_standard_delete_result(mode=act_mode, error=str(exc))
+            return self._build_standard_delete_result(mode=act_mode, operation_id=operation_id, error=str(exc))
 
     async def _invalidate_import_manifest_for_sources(self, result: Dict[str, Any]) -> None:
         if not isinstance(result, dict) or not result.get("success"):
@@ -849,13 +849,18 @@ class MemoryDeleteAdminService(KernelServiceBase):
             "restored_relations": restored_relations.get("restored_hashes", []),
             "sources": sources,
         }
-        self.metadata_store.mark_delete_operation_restored(str(operation.get("operation_id", "") or ""), summary=summary)
+        relation_failures = restored_relations.get("failures", [])
+        if not relation_failures:
+            self.metadata_store.mark_delete_operation_restored(
+                str(operation.get("operation_id", "") or ""),
+                summary=summary,
+            )
         return {
-            "success": True,
+            "success": not relation_failures,
             "operation_id": str(operation.get("operation_id", "") or ""),
             **summary,
             "restored_relation_count": restored_relations.get("restored_count", 0),
-            "relation_failures": restored_relations.get("failures", []),
+            "relation_failures": relation_failures,
         }
 
     async def _purge_deleted_memory(self, *, grace_hours: Optional[float], limit: int) -> Dict[str, Any]:

--- a/src/A_memorix/core/runtime/services/dual_vector_state_service.py
+++ b/src/A_memorix/core/runtime/services/dual_vector_state_service.py
@@ -173,8 +173,21 @@ class MemoryDualVectorStateService(KernelServiceBase):
         backup_paragraph = backup_root / "paragraph"
         backup_graph = backup_root / "graph"
         backup_root.mkdir(parents=True, exist_ok=True)
+        activation_journal = backup_root / "activation.json"
         paragraph_dst = self._paragraph_vector_dir()
         graph_dst = self._graph_vector_dir()
+        activation_journal.write_text(
+            json.dumps(
+                {
+                    "status": "prepared",
+                    "build_root": str(build_root),
+                    "had_paragraph": paragraph_dst.exists(),
+                    "had_graph": graph_dst.exists(),
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
         try:
             if paragraph_dst.exists():
                 shutil.move(str(paragraph_dst), str(backup_paragraph))
@@ -183,7 +196,17 @@ class MemoryDualVectorStateService(KernelServiceBase):
             shutil.move(str(paragraph_src), str(paragraph_dst))
             shutil.move(str(graph_src), str(graph_dst))
             shutil.rmtree(build_root, ignore_errors=True)
-            shutil.rmtree(backup_root, ignore_errors=True)
+            activation_journal.write_text(
+                json.dumps(
+                    {
+                        "status": "activated",
+                        "had_paragraph": backup_paragraph.exists(),
+                        "had_graph": backup_graph.exists(),
+                    },
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
         except Exception:
             if paragraph_dst.exists():
                 shutil.rmtree(paragraph_dst, ignore_errors=True)
@@ -193,16 +216,59 @@ class MemoryDualVectorStateService(KernelServiceBase):
                 shutil.move(str(backup_paragraph), str(paragraph_dst))
             if backup_graph.exists():
                 shutil.move(str(backup_graph), str(graph_dst))
+            shutil.rmtree(backup_root, ignore_errors=True)
             raise
 
     def _cleanup_stale_dual_vector_build_dirs(self) -> None:
         vectors_root = self._vectors_root()
         if not vectors_root.exists():
             return
+        backup_dirs = sorted(
+            (
+                child
+                for child in vectors_root.iterdir()
+                if child.is_dir() and child.name.startswith("dual_backup_")
+            ),
+            key=lambda path: path.name,
+            reverse=True,
+        )
+        unresolved_backup = False
+        for backup_root in backup_dirs:
+            journal_path = backup_root / "activation.json"
+            if not journal_path.exists():
+                unresolved_backup = True
+                logger.error(f"发现缺少激活日志的双池备份，已保留供人工恢复: {backup_root}")
+                continue
+            if self._dual_vector_ready():
+                shutil.rmtree(backup_root, ignore_errors=True)
+                continue
+            try:
+                journal = json.loads(journal_path.read_text(encoding="utf-8"))
+                had_paragraph = bool(journal.get("had_paragraph", True))
+                had_graph = bool(journal.get("had_graph", True))
+                interrupted_root = backup_root / "interrupted_new"
+                interrupted_root.mkdir(parents=True, exist_ok=True)
+                for name, destination, existed_before in (
+                    ("paragraph", self._paragraph_vector_dir(), had_paragraph),
+                    ("graph", self._graph_vector_dir(), had_graph),
+                ):
+                    if destination.exists():
+                        shutil.move(str(destination), str(interrupted_root / name))
+                    backup_path = backup_root / name
+                    if existed_before:
+                        if not backup_path.exists():
+                            raise RuntimeError(f"双池备份缺少目录: {backup_path}")
+                        shutil.move(str(backup_path), str(destination))
+                shutil.rmtree(backup_root, ignore_errors=True)
+                logger.warning("检测到未完成的双池激活，已恢复切换前目录")
+            except Exception as exc:
+                unresolved_backup = True
+                logger.error(f"恢复双池激活备份失败，已保留现场: backup={backup_root}, error={exc}")
+
+        if unresolved_backup:
+            return
         for child in vectors_root.iterdir():
             if child.is_dir() and child.name.startswith("dual_build_"):
-                shutil.rmtree(child, ignore_errors=True)
-            elif child.is_dir() and child.name.startswith("dual_backup_"):
                 shutil.rmtree(child, ignore_errors=True)
 
     def _make_vector_store(self, data_dir: Path, *, dimension: Optional[int] = None) -> VectorStore:

--- a/src/A_memorix/core/runtime/services/dual_vector_state_service.py
+++ b/src/A_memorix/core/runtime/services/dual_vector_state_service.py
@@ -244,6 +244,13 @@ class MemoryDualVectorStateService(KernelServiceBase):
                 continue
             try:
                 journal = json.loads(journal_path.read_text(encoding="utf-8"))
+                status = str(journal.get("status", "") or "").strip().lower()
+                if status == "activated":
+                    shutil.rmtree(backup_root, ignore_errors=True)
+                    logger.warning("检测到已完成但尚未清理的双池激活，已保留当前目录并清理旧备份")
+                    continue
+                if status != "prepared":
+                    raise RuntimeError(f"双池激活日志状态无效: {status or 'missing'}")
                 had_paragraph = bool(journal.get("had_paragraph", True))
                 had_graph = bool(journal.get("had_graph", True))
                 interrupted_root = backup_root / "interrupted_new"

--- a/src/A_memorix/core/runtime/services/feedback_correction_service.py
+++ b/src/A_memorix/core/runtime/services/feedback_correction_service.py
@@ -293,9 +293,6 @@ class MemoryFeedbackCorrectionService(KernelServiceBase):
                 "task": self._build_feedback_task_detail(task),
                 "result": task.get("rollback_result") if isinstance(task.get("rollback_result"), dict) else {},
             }
-        if rollback_status == "running":
-            return {"success": False, "error": "该反馈纠错任务正在回退中", "task": self._build_feedback_task_detail(task)}
-
         query_tool_id = str(task.get("query_tool_id", "") or "").strip()
         rollback_plan = task.get("rollback_plan") if isinstance(task.get("rollback_plan"), dict) else {}
         if not rollback_plan:
@@ -1145,6 +1142,7 @@ class MemoryFeedbackCorrectionService(KernelServiceBase):
 
         stale_paragraph_map: Dict[str, List[str]] = {}
         stale_paragraph_hashes: List[str] = []
+        previous_stale_marks: Dict[tuple[str, str], Optional[Dict[str, Any]]] = {}
         episode_rebuild_sources: List[str] = []
         profile_refresh_person_ids: List[str] = []
         rollback_plan: Dict[str, Any] = {}
@@ -1195,6 +1193,15 @@ class MemoryFeedbackCorrectionService(KernelServiceBase):
 
         applied = forget_success if decision_type == "reject" else (forget_success and ingest_success)
         if applied:
+            candidate_stale_map = self.metadata_store.get_paragraph_hashes_by_relation_hashes(relation_hashes)
+            previous_stale_marks = {
+                (paragraph_hash, relation_hash): self.metadata_store.get_paragraph_stale_relation_mark(
+                    paragraph_hash=paragraph_hash,
+                    relation_hash=relation_hash,
+                )
+                for relation_hash, paragraph_hashes in candidate_stale_map.items()
+                for paragraph_hash in paragraph_hashes
+            }
             stale_paragraph_map = self._mark_feedback_stale_paragraphs(
                 task_id=task_id,
                 query_tool_id=query_tool_id,
@@ -1294,6 +1301,7 @@ class MemoryFeedbackCorrectionService(KernelServiceBase):
                         "source_type": "feedback_correction",
                         "source_id": str(task_id),
                         "source_operation_id": f"feedback_correction:{task_id}:{paragraph_hash}:{relation_hash}",
+                        "previous_mark": previous_stale_marks.get((paragraph_hash, relation_hash)),
                     }
                     for relation_hash, paragraph_hashes in stale_paragraph_map.items()
                     for paragraph_hash in (paragraph_hashes or [])
@@ -1363,7 +1371,10 @@ class MemoryFeedbackCorrectionService(KernelServiceBase):
             return
 
         assert self.metadata_store is not None
-        self.metadata_store.mark_feedback_task_running(task_id)
+        running_task = self.metadata_store.mark_feedback_task_running(task_id)
+        if running_task is None:
+            return
+        task = running_task
 
         decision_payload: Dict[str, Any] = {}
         session_id = str(task.get("session_id", "") or "").strip()

--- a/src/A_memorix/core/runtime/services/feedback_correction_service.py
+++ b/src/A_memorix/core/runtime/services/feedback_correction_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import asyncio
 import json
@@ -100,13 +100,18 @@ class MemoryFeedbackCorrectionService(KernelServiceBase):
         query_tool_id: str,
         relation_hashes: Sequence[str],
         reason: str,
+        paragraph_map: Optional[Dict[str, List[str]]] = None,
     ) -> Dict[str, List[str]]:
         if self.metadata_store is None or not feedback_cfg_paragraph_mark_enabled():
             return {}
 
         relation_tokens = tokens(relation_hashes)
-        paragraph_map = self.metadata_store.get_paragraph_hashes_by_relation_hashes(relation_tokens)
-        for relation_hash, paragraph_hashes in paragraph_map.items():
+        resolved_paragraph_map = (
+            paragraph_map
+            if paragraph_map is not None
+            else self.metadata_store.get_paragraph_hashes_by_relation_hashes(relation_tokens)
+        )
+        for relation_hash, paragraph_hashes in resolved_paragraph_map.items():
             for paragraph_hash in paragraph_hashes:
                 self.metadata_store.upsert_paragraph_stale_relation_mark(
                     paragraph_hash=paragraph_hash,
@@ -118,7 +123,7 @@ class MemoryFeedbackCorrectionService(KernelServiceBase):
                     source_id=str(task_id),
                     source_operation_id=f"feedback_correction:{task_id}:{paragraph_hash}:{relation_hash}",
                 )
-        return paragraph_map
+        return resolved_paragraph_map
 
     def _enqueue_feedback_episode_rebuilds(
         self,
@@ -1142,7 +1147,7 @@ class MemoryFeedbackCorrectionService(KernelServiceBase):
 
         stale_paragraph_map: Dict[str, List[str]] = {}
         stale_paragraph_hashes: List[str] = []
-        previous_stale_marks: Dict[tuple[str, str], Optional[Dict[str, Any]]] = {}
+        previous_stale_marks: Dict[Tuple[str, str], Optional[Dict[str, Any]]] = {}
         episode_rebuild_sources: List[str] = []
         profile_refresh_person_ids: List[str] = []
         rollback_plan: Dict[str, Any] = {}
@@ -1207,6 +1212,7 @@ class MemoryFeedbackCorrectionService(KernelServiceBase):
                 query_tool_id=query_tool_id,
                 relation_hashes=relation_hashes,
                 reason=str(decision.get("reason", "") or "") or "feedback_correction",
+                paragraph_map=candidate_stale_map,
             )
             stale_paragraph_hashes = merge_tokens(
                 *[

--- a/src/A_memorix/core/runtime/services/graph_admin_service.py
+++ b/src/A_memorix/core/runtime/services/graph_admin_service.py
@@ -1009,95 +1009,195 @@ class MemoryGraphAdminService(KernelServiceBase):
         if source == target:
             return {"success": True, "renamed": False, "old_name": source, "new_name": target}
 
-        conn = self.metadata_store.get_connection()
-        cursor = conn.cursor()
         old_hash = compute_hash(source.lower())
         target_hash = compute_hash(target.lower())
-
-        cursor.execute(
-            """
-            SELECT hash, name, vector_index, appearance_count, created_at, metadata
-            FROM entities
-            WHERE hash = ?
-               OR LOWER(TRIM(name)) = LOWER(TRIM(?))
-            LIMIT 1
-            """,
-            (old_hash, source),
-        )
-        old_row = cursor.fetchone()
-        if old_row is None:
-            return {"success": False, "error": "原节点不存在"}
-
-        cursor.execute(
-            """
-            SELECT hash, appearance_count
-            FROM entities
-            WHERE hash = ?
-               OR LOWER(TRIM(name)) = LOWER(TRIM(?))
-            LIMIT 1
-            """,
-            (target_hash, target),
-        )
-        target_row = cursor.fetchone()
-
+        old_relation_hashes: List[str] = []
+        relation_hash_map: Dict[str, str] = {}
+        resolved_target_hash = target_hash
+        old_entity_hash = old_hash
         try:
-            cursor.execute("BEGIN IMMEDIATE")
-            if target_row is None:
+            with self.metadata_store.transaction(immediate=True) as conn:
+                cursor = conn.cursor()
                 cursor.execute(
                     """
-                    INSERT INTO entities (hash, name, vector_index, appearance_count, created_at, metadata, is_deleted, deleted_at)
-                    VALUES (?, ?, ?, ?, ?, ?, 0, NULL)
-                    """,
-                    (
-                        target_hash,
-                        target,
-                        old_row["vector_index"],
-                        old_row["appearance_count"],
-                        old_row["created_at"],
-                        old_row["metadata"],
-                    ),
-                )
-                resolved_target_hash = target_hash
-            else:
-                resolved_target_hash = str(target_row["hash"] or "").strip()
-                cursor.execute(
-                    """
-                    UPDATE entities
-                    SET name = ?,
-                        appearance_count = COALESCE(appearance_count, 0) + ?,
-                        is_deleted = 0,
-                        deleted_at = NULL
+                    SELECT *
+                    FROM entities
                     WHERE hash = ?
+                       OR LOWER(TRIM(name)) = LOWER(TRIM(?))
+                    LIMIT 1
                     """,
-                    (
-                        target,
-                        int(old_row["appearance_count"] or 0),
-                        resolved_target_hash,
-                    ),
+                    (old_hash, source),
                 )
+                old_row = cursor.fetchone()
+                if old_row is None:
+                    return {"success": False, "error": "原节点不存在"}
+                old_entity_hash = str(old_row["hash"] or "").strip()
+                old_entity_name = str(old_row["name"] or "").strip()
 
-            cursor.execute(
-                "UPDATE OR IGNORE paragraph_entities SET entity_hash = ? WHERE entity_hash = ?",
-                (resolved_target_hash, old_row["hash"]),
-            )
-            cursor.execute("DELETE FROM paragraph_entities WHERE entity_hash = ?", (old_row["hash"],))
-            cursor.execute(
-                "UPDATE relations SET subject = ? WHERE LOWER(TRIM(subject)) = LOWER(TRIM(?))",
-                (target, old_row["name"]),
-            )
-            cursor.execute(
-                "UPDATE relations SET object = ? WHERE LOWER(TRIM(object)) = LOWER(TRIM(?))",
-                (target, old_row["name"]),
-            )
-            cursor.execute("DELETE FROM entities WHERE hash = ?", (old_row["hash"],))
-            conn.commit()
+                cursor.execute(
+                    """
+                    SELECT *
+                    FROM entities
+                    WHERE hash = ?
+                       OR LOWER(TRIM(name)) = LOWER(TRIM(?))
+                    LIMIT 1
+                    """,
+                    (target_hash, target),
+                )
+                target_row = cursor.fetchone()
+
+                if target_row is not None and str(target_row["hash"] or "").strip() == old_entity_hash:
+                    resolved_target_hash = old_entity_hash
+                    cursor.execute(
+                        """
+                        UPDATE entities
+                        SET name = ?, vector_index = NULL, is_deleted = 0, deleted_at = NULL
+                        WHERE hash = ?
+                        """,
+                        (target, old_entity_hash),
+                    )
+                elif target_row is None:
+                    cursor.execute(
+                        """
+                        INSERT INTO entities (
+                            hash, name, vector_index, appearance_count, created_at, metadata, is_deleted, deleted_at
+                        ) VALUES (?, ?, NULL, ?, ?, ?, 0, NULL)
+                        """,
+                        (
+                            target_hash,
+                            target,
+                            old_row["appearance_count"],
+                            old_row["created_at"],
+                            old_row["metadata"],
+                        ),
+                    )
+                    resolved_target_hash = target_hash
+                else:
+                    resolved_target_hash = str(target_row["hash"] or "").strip()
+                    cursor.execute(
+                        """
+                        UPDATE entities
+                        SET name = ?,
+                            appearance_count = COALESCE(appearance_count, 0) + ?,
+                            is_deleted = 0,
+                            deleted_at = NULL
+                        WHERE hash = ?
+                        """,
+                        (target, int(old_row["appearance_count"] or 0), resolved_target_hash),
+                    )
+
+                if resolved_target_hash != old_entity_hash:
+                    cursor.execute(
+                        """
+                        INSERT OR IGNORE INTO paragraph_entities (paragraph_hash, entity_hash, mention_count)
+                        SELECT paragraph_hash, ?, mention_count
+                        FROM paragraph_entities
+                        WHERE entity_hash = ?
+                        """,
+                        (resolved_target_hash, old_entity_hash),
+                    )
+                    cursor.execute("DELETE FROM paragraph_entities WHERE entity_hash = ?", (old_entity_hash,))
+
+                cursor.execute(
+                    """
+                    SELECT *
+                    FROM relations
+                    WHERE LOWER(TRIM(subject)) = LOWER(TRIM(?))
+                       OR LOWER(TRIM(object)) = LOWER(TRIM(?))
+                    """,
+                    (old_entity_name, old_entity_name),
+                )
+                affected_relations = cursor.fetchall()
+                for relation_row in affected_relations:
+                    relation_data = dict(relation_row)
+                    old_relation_hash = str(relation_data["hash"] or "").strip()
+                    relation_subject = str(relation_data.get("subject", "") or "").strip()
+                    relation_object = str(relation_data.get("object", "") or "").strip()
+                    if relation_subject.lower() == old_entity_name.lower():
+                        relation_subject = target
+                    if relation_object.lower() == old_entity_name.lower():
+                        relation_object = target
+                    new_relation_hash = self.metadata_store.compute_relation_hash(
+                        relation_subject,
+                        str(relation_data.get("predicate", "") or "").strip(),
+                        relation_object,
+                    )
+                    relation_data.update(
+                        {
+                            "hash": new_relation_hash,
+                            "subject": relation_subject,
+                            "object": relation_object,
+                            "vector_index": None,
+                            "vector_state": "none",
+                            "vector_updated_at": None,
+                            "vector_error": None,
+                            "vector_retry_count": 0,
+                        }
+                    )
+                    old_relation_hashes.append(old_relation_hash)
+                    relation_hash_map[old_relation_hash] = new_relation_hash
+
+                    if new_relation_hash == old_relation_hash:
+                        cursor.execute(
+                            """
+                            UPDATE relations
+                            SET subject = ?, object = ?, vector_index = NULL,
+                                vector_state = 'none', vector_updated_at = NULL,
+                                vector_error = NULL, vector_retry_count = 0
+                            WHERE hash = ?
+                            """,
+                            (relation_subject, relation_object, old_relation_hash),
+                        )
+                        continue
+
+                    columns = list(relation_data)
+                    placeholders = ",".join("?" for _ in columns)
+                    cursor.execute(
+                        f"INSERT OR IGNORE INTO relations ({','.join(columns)}) VALUES ({placeholders})",
+                        tuple(relation_data[column] for column in columns),
+                    )
+                    cursor.execute(
+                        """
+                        INSERT OR IGNORE INTO paragraph_relations (paragraph_hash, relation_hash)
+                        SELECT paragraph_hash, ? FROM paragraph_relations WHERE relation_hash = ?
+                        """,
+                        (new_relation_hash, old_relation_hash),
+                    )
+                    cursor.execute("DELETE FROM relations WHERE hash = ?", (old_relation_hash,))
+
+                    cursor.execute(
+                        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'graph_edge_relation_map'"
+                    )
+                    if cursor.fetchone() is not None:
+                        cursor.execute(
+                            "UPDATE OR IGNORE graph_edge_relation_map SET relation_hash = ? WHERE relation_hash = ?",
+                            (new_relation_hash, old_relation_hash),
+                        )
+                        cursor.execute(
+                            "DELETE FROM graph_edge_relation_map WHERE relation_hash = ?",
+                            (old_relation_hash,),
+                        )
+
+                if resolved_target_hash != old_entity_hash:
+                    cursor.execute("DELETE FROM entities WHERE hash = ?", (old_entity_hash,))
         except Exception as exc:
-            conn.rollback()
             return {"success": False, "error": f"rename failed: {exc}"}
 
+        self.metadata_store.rebuild_relation_hash_aliases()
+        self._delete_vectors_by_type(
+            entity_hashes=[old_entity_hash],
+            relation_hashes=old_relation_hashes,
+        )
         self._rebuild_graph_from_metadata()
         self._persist()
-        return {"success": True, "renamed": True, "old_name": source, "new_name": target}
+        return {
+            "success": True,
+            "renamed": True,
+            "old_name": source,
+            "new_name": target,
+            "entity_hash": resolved_target_hash,
+            "relation_hash_map": relation_hash_map,
+        }
 
     def _update_edge_weight(
         self,

--- a/src/A_memorix/core/runtime/services/ingest_service.py
+++ b/src/A_memorix/core/runtime/services/ingest_service.py
@@ -345,9 +345,17 @@ class MemoryIngestService(KernelServiceBase):
         except Exception as exc:
             error = f"episode processing failed: {exc}"
             for hash_value in pending_hashes:
-                self.metadata_store.mark_episode_pending_failed(hash_value, error)
+                try:
+                    self.metadata_store.mark_episode_pending_failed(hash_value, error)
+                except Exception as mark_exc:
+                    logger.warning(
+                        f"回写 Episode 待处理项失败状态异常: hash={hash_value}, error={mark_exc}"
+                    )
             for source in source_to_hashes:
-                self.metadata_store.mark_episode_source_failed(source, error)
+                try:
+                    self.metadata_store.mark_episode_source_failed(source, error)
+                except Exception as mark_exc:
+                    logger.warning(f"回写 Episode 来源失败状态异常: source={source}, error={mark_exc}")
             raise
         done_hashes = [str(item or "").strip() for item in result.get("done_hashes", []) if str(item or "").strip()]
         failed_hashes = {

--- a/src/A_memorix/core/runtime/services/ingest_service.py
+++ b/src/A_memorix/core/runtime/services/ingest_service.py
@@ -278,6 +278,7 @@ class MemoryIngestService(KernelServiceBase):
 
         stored_relations: List[str] = []
         for row in [dict(item) for item in (relations or []) if isinstance(item, dict)]:
+            confidence_value = row.get("confidence", 1.0)
             subject = str(row.get("subject", "") or "").strip()
             predicate = str(row.get("predicate", "") or "").strip()
             obj = str(row.get("object", "") or "").strip()
@@ -287,7 +288,7 @@ class MemoryIngestService(KernelServiceBase):
                 subject=subject,
                 predicate=predicate,
                 obj=obj,
-                confidence=float(row.get("confidence", 1.0) or 1.0),
+                confidence=float(1.0 if confidence_value is None else confidence_value),
                 source_paragraph=paragraph_hash,
                 metadata=row.get("metadata") if isinstance(row.get("metadata"), dict) else {"external_id": external_token, "source_type": source_type},
                 write_vector=self.relation_vectors_enabled,
@@ -339,7 +340,15 @@ class MemoryIngestService(KernelServiceBase):
         if pending_hashes:
             self.metadata_store.mark_episode_pending_running(pending_hashes)
 
-        result = await self.episode_service.process_pending_rows(pending_rows)
+        try:
+            result = await self.episode_service.process_pending_rows(pending_rows)
+        except Exception as exc:
+            error = f"episode processing failed: {exc}"
+            for hash_value in pending_hashes:
+                self.metadata_store.mark_episode_pending_failed(hash_value, error)
+            for source in source_to_hashes:
+                self.metadata_store.mark_episode_source_failed(source, error)
+            raise
         done_hashes = [str(item or "").strip() for item in result.get("done_hashes", []) if str(item or "").strip()]
         failed_hashes = {
             str(hash_value or "").strip(): str(error or "").strip()

--- a/src/A_memorix/core/runtime/services/memory_maintenance_service.py
+++ b/src/A_memorix/core/runtime/services/memory_maintenance_service.py
@@ -14,24 +14,24 @@ logger = get_logger("A_Memorix.SDKMemoryKernel")
 
 class MemoryMaintenanceService(KernelServiceBase):
     async def _memory_maintenance_loop(self) -> None:
-        try:
-            while not self._background_stopping:
-                interval_hours = max(1.0 / 60.0, float(self._cfg("memory.base_decay_interval_hours", 1.0) or 1.0))
+        while not self._background_stopping:
+            interval_hours = max(1.0 / 60.0, float(self._cfg("memory.base_decay_interval_hours", 1.0)))
+            try:
                 await asyncio.sleep(max(60.0, interval_hours * 3600.0))
                 if self._background_stopping:
                     break
                 if not bool(self._cfg("memory.enabled", True)):
                     continue
                 await self._run_memory_maintenance_cycle(interval_hours=interval_hours)
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            logger.warning(f"memory_maintenance loop 异常: {exc}")
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(f"memory_maintenance cycle 异常，将在下一周期重试: {exc}")
 
     async def _run_memory_maintenance_cycle(self, *, interval_hours: float) -> None:
         assert self.graph_store is not None
         assert self.metadata_store is not None
-        half_life = float(self._cfg("memory.half_life_hours", 24.0) or 24.0)
+        half_life = float(self._cfg("memory.half_life_hours", 24.0))
         if half_life > 0:
             factor = 0.5 ** (float(interval_hours) / half_life)
             self.graph_store.decay(factor)
@@ -44,8 +44,8 @@ class MemoryMaintenanceService(KernelServiceBase):
     async def _process_freeze_and_prune(self) -> None:
         assert self.metadata_store is not None
         assert self.graph_store is not None
-        prune_threshold = max(0.0, float(self._cfg("memory.prune_threshold", 0.1) or 0.1))
-        freeze_duration = max(0.0, float(self._cfg("memory.freeze_duration_hours", 24.0) or 24.0)) * 3600.0
+        prune_threshold = max(0.0, float(self._cfg("memory.prune_threshold", 0.1)))
+        freeze_duration = max(0.0, float(self._cfg("memory.freeze_duration_hours", 24.0))) * 3600.0
         now = time.time()
 
         low_edges = self.graph_store.get_low_weight_edges(prune_threshold)
@@ -91,9 +91,9 @@ class MemoryMaintenanceService(KernelServiceBase):
         orphan_cfg = self._cfg("memory.orphan", {}) or {}
         if not bool(orphan_cfg.get("enable_soft_delete", True)):
             return
-        entity_retention = max(0.0, float(orphan_cfg.get("entity_retention_days", 7.0) or 7.0)) * 86400.0
-        paragraph_retention = max(0.0, float(orphan_cfg.get("paragraph_retention_days", 7.0) or 7.0)) * 86400.0
-        grace_period = max(0.0, float(orphan_cfg.get("sweep_grace_hours", 24.0) or 24.0)) * 3600.0
+        entity_retention = max(0.0, float(orphan_cfg.get("entity_retention_days", 7.0))) * 86400.0
+        paragraph_retention = max(0.0, float(orphan_cfg.get("paragraph_retention_days", 7.0))) * 86400.0
+        grace_period = max(0.0, float(orphan_cfg.get("sweep_grace_hours", 24.0))) * 3600.0
 
         isolated = self.graph_store.get_isolated_nodes(include_inactive=True)
         if isolated:

--- a/src/A_memorix/core/runtime/services/memory_maintenance_service.py
+++ b/src/A_memorix/core/runtime/services/memory_maintenance_service.py
@@ -15,7 +15,8 @@ logger = get_logger("A_Memorix.SDKMemoryKernel")
 class MemoryMaintenanceService(KernelServiceBase):
     async def _memory_maintenance_loop(self) -> None:
         while not self._background_stopping:
-            interval_hours = max(1.0 / 60.0, float(self._cfg("memory.base_decay_interval_hours", 1.0)))
+            interval_value = self._cfg("memory.base_decay_interval_hours", 1.0)
+            interval_hours = max(1.0 / 60.0, float(1.0 if interval_value is None else interval_value))
             try:
                 await asyncio.sleep(max(60.0, interval_hours * 3600.0))
                 if self._background_stopping:

--- a/src/A_memorix/core/runtime/services/request_dedup_service.py
+++ b/src/A_memorix/core/runtime/services/request_dedup_service.py
@@ -19,14 +19,16 @@ class MemoryRequestDedupService(KernelServiceBase):
 
         existing = self._request_dedup_tasks.get(token)
         if existing is not None:
-            return True, await existing
+            return True, await asyncio.shield(existing)
 
         task = asyncio.create_task(executor())
         self._request_dedup_tasks[token] = task
-        try:
-            payload = await task
-            return False, payload
-        finally:
+
+        def _remove_completed_task(completed: asyncio.Task) -> None:
             current = self._request_dedup_tasks.get(token)
-            if current is task:
+            if current is completed:
                 self._request_dedup_tasks.pop(token, None)
+
+        task.add_done_callback(_remove_completed_task)
+        payload = await asyncio.shield(task)
+        return False, payload

--- a/src/A_memorix/core/runtime/services/runtime_config_service.py
+++ b/src/A_memorix/core/runtime/services/runtime_config_service.py
@@ -74,7 +74,7 @@ class MemoryRuntimeConfigService(KernelServiceBase):
             self._runtime_bundle = runtime_bundle
             self.retriever = runtime_bundle.retriever
             self.threshold_filter = runtime_bundle.threshold_filter
-            self.sparse_index = runtime_bundle.sparse_index or self.sparse_index
+            self.sparse_index = runtime_bundle.sparse_index
             self._refresh_runtime_dependents(preserve_managers=True)
             self._apply_runtime_sparse_mode()
             return {

--- a/src/A_memorix/core/runtime/services/runtime_lifecycle_service.py
+++ b/src/A_memorix/core/runtime/services/runtime_lifecycle_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import List
+
 from src.common.logger import get_logger
 
 from .base import KernelServiceBase
@@ -138,7 +140,7 @@ class MemoryRuntimeLifecycleService(KernelServiceBase):
     async def shutdown(self) -> None:
         """先等待后台工作和任务管理器退出，再持久化并释放底层存储。"""
         await self._stop_background_tasks()
-        shutdown_errors: list[BaseException] = []
+        shutdown_errors: List[Exception] = []
         if self.import_task_manager is not None:
             try:
                 await self.import_task_manager.shutdown()

--- a/src/A_memorix/core/runtime/services/runtime_lifecycle_service.py
+++ b/src/A_memorix/core/runtime/services/runtime_lifecycle_service.py
@@ -138,16 +138,21 @@ class MemoryRuntimeLifecycleService(KernelServiceBase):
     async def shutdown(self) -> None:
         """先等待后台工作和任务管理器退出，再持久化并释放底层存储。"""
         await self._stop_background_tasks()
+        shutdown_errors: list[BaseException] = []
         if self.import_task_manager is not None:
             try:
                 await self.import_task_manager.shutdown()
             except Exception as exc:
-                logger.warning(f"关闭导入任务管理器失败: {exc}")
+                shutdown_errors.append(exc)
+                logger.exception(f"关闭导入任务管理器失败: {exc}")
         if self.retrieval_tuning_manager is not None:
             try:
                 await self.retrieval_tuning_manager.shutdown()
             except Exception as exc:
-                logger.warning(f"关闭调优任务管理器失败: {exc}")
+                shutdown_errors.append(exc)
+                logger.exception(f"关闭调优任务管理器失败: {exc}")
+        if shutdown_errors:
+            raise RuntimeError("A_Memorix 任务管理器未能安全退出，底层存储保持打开") from shutdown_errors[0]
         self._close_runtime()
 
     def close(self) -> None:

--- a/src/A_memorix/core/runtime/services/search_hit_processing_service.py
+++ b/src/A_memorix/core/runtime/services/search_hit_processing_service.py
@@ -665,11 +665,12 @@ class MemorySearchHitProcessingService(KernelServiceBase):
             linked_hashes: List[str] = []
             for relation in linked_relations:
                 linked_hash = str(relation.get("hash", "") or "").strip()
-                if not linked_hash or linked_hash in seen_relation_hashes:
+                if not linked_hash:
                     continue
-                seen_relation_hashes.add(linked_hash)
-                relation_hashes.append(linked_hash)
                 linked_hashes.append(linked_hash)
+                if linked_hash not in seen_relation_hashes:
+                    seen_relation_hashes.add(linked_hash)
+                    relation_hashes.append(linked_hash)
             if linked_hashes:
                 paragraph_relation_cache[item_hash] = linked_hashes
 

--- a/src/A_memorix/core/runtime/services/v5_admin_service.py
+++ b/src/A_memorix/core/runtime/services/v5_admin_service.py
@@ -107,7 +107,7 @@ class MemoryV5AdminService(KernelServiceBase):
         if not token:
             return []
         if len(token) == 64 and all(ch in "0123456789abcdef" for ch in token.lower()):
-            return [token]
+            return [token] if self.metadata_store.get_relation(token) is not None else []
         hashes = self.metadata_store.search_relation_hashes_by_text(token, limit=10)
         if hashes:
             return hashes
@@ -123,7 +123,7 @@ class MemoryV5AdminService(KernelServiceBase):
         if not token:
             return []
         if len(token) == 64 and all(ch in "0123456789abcdef" for ch in token.lower()):
-            return [token]
+            return [token] if self.metadata_store.get_deleted_relation(token) is not None else []
         return self.metadata_store.search_deleted_relation_hashes_by_text(token, limit=10)
 
     def _memory_v5_status(self, *, target: str = "", limit: int = 50) -> Dict[str, Any]:

--- a/src/A_memorix/core/runtime/services/vector_runtime_service.py
+++ b/src/A_memorix/core/runtime/services/vector_runtime_service.py
@@ -841,6 +841,7 @@ class MemoryVectorRuntimeService(KernelServiceBase):
                     self._activate_dual_vector_build_dirs(dual_build_root)
                     self._update_dual_vector_auto_migration_stage("write_manifest")
                     self._write_dual_vector_ready_manifest(stats=stats, migration_stats=migration_stats)
+                    self._cleanup_stale_dual_vector_build_dirs()
                     self._update_dual_vector_auto_migration_stage("reload_dual_stores")
                     activation_ok = self._reload_dual_vector_stores_from_disk()
                     if not activation_ok:

--- a/src/A_memorix/core/storage/format_migration.py
+++ b/src/A_memorix/core/storage/format_migration.py
@@ -488,19 +488,8 @@ def run_startup_format_migration(data_dir: Path) -> Dict[str, Any]:
             _ensure_migration_table(conn)
             if _migration_record_exists(conn) and not _legacy_pickle_exists(data_dir):
                 summary["sqlite"] = {"updated": 0, "reason": "already_applied"}
-                summary["vectors"] = [
-                    {"migrated": False, "reason": "legacy_missing", "path": str(path.parent)}
-                    for path in _legacy_pickle_paths(data_dir)[:3]
-                ]
-                summary["graph"] = {"migrated": False, "reason": "legacy_missing"}
-                conn.commit()
-                summary["finished_at"] = time.time()
-                logger.info(
-                    "A_Memorix 存储格式迁移快速跳过: "
-                    f"duration={summary['finished_at'] - started_at:.2f}s"
-                )
-                return summary
-            summary["sqlite"] = _migrate_sqlite_metadata(conn)
+            else:
+                summary["sqlite"] = _migrate_sqlite_metadata(conn)
         else:
             summary["sqlite"] = {"updated": 0, "reason": "metadata_db_missing"}
         for relative in ("vectors", "vectors/paragraph", "vectors/graph"):

--- a/src/A_memorix/core/storage/graph_store.py
+++ b/src/A_memorix/core/storage/graph_store.py
@@ -1366,7 +1366,10 @@ class GraphStore:
         logger.debug(f"保存元数据: {metadata_path}")
 
         self._activate_snapshot(data_dir, generation)
-        self._cleanup_old_snapshots(data_dir, generation)
+        try:
+            self._cleanup_old_snapshots(data_dir, generation)
+        except OSError as exc:
+            logger.warning(f"清理旧图快照失败，当前快照已成功激活: {exc}")
 
         logger.info(f"图存储已保存到: {data_dir}")
 

--- a/src/A_memorix/core/storage/graph_store.py
+++ b/src/A_memorix/core/storage/graph_store.py
@@ -11,7 +11,9 @@ from typing import Optional, Union, Tuple, List, Dict, Set, Any
 import asyncio
 import contextlib
 import json
+import shutil
 import sqlite3
+import uuid
 
 import numpy as np
 
@@ -193,6 +195,73 @@ class GraphStore:
             conn.close()
         return edge_hash_map
 
+    def _prepare_snapshot(
+        self,
+        data_dir: Path,
+        metadata: Dict[str, Any],
+    ) -> str:
+        """写入不可变图快照，返回尚未激活的 generation。"""
+        snapshots_root = data_dir / "graph_snapshots"
+        snapshots_root.mkdir(parents=True, exist_ok=True)
+        generation = f"graph-{uuid.uuid4().hex}"
+        temporary_dir = snapshots_root / f".{generation}.tmp"
+        snapshot_dir = snapshots_root / generation
+        temporary_dir.mkdir(parents=True)
+        snapshot_metadata = {
+            **metadata,
+            "snapshot_generation": generation,
+            "has_adjacency": self._adjacency is not None,
+            "edge_hash_map": self._serialize_edge_hash_map(),
+        }
+        if self._adjacency is not None:
+            with (temporary_dir / "graph_adjacency.npz").open("wb") as handle:
+                save_npz(handle, self._adjacency)
+        _write_json_object(temporary_dir / "graph_metadata.json", snapshot_metadata)
+        temporary_dir.replace(snapshot_dir)
+        return generation
+
+    @staticmethod
+    def _activate_snapshot(data_dir: Path, generation: str) -> None:
+        _write_json_object(
+            data_dir / "graph_snapshot.json",
+            {"generation": generation, "schema_version": 1},
+        )
+
+    @staticmethod
+    def _cleanup_old_snapshots(data_dir: Path, active_generation: str) -> None:
+        snapshots_root = data_dir / "graph_snapshots"
+        if not snapshots_root.exists():
+            return
+        generations = sorted(
+            (
+                path
+                for path in snapshots_root.iterdir()
+                if path.is_dir() and not path.name.startswith(".")
+            ),
+            key=lambda path: path.stat().st_mtime,
+            reverse=True,
+        )
+        keep = {active_generation}
+        keep.update(path.name for path in generations[:2])
+        for path in generations:
+            if path.name not in keep:
+                shutil.rmtree(path)
+
+    @staticmethod
+    def _resolve_snapshot_paths(data_dir: Path) -> Tuple[Path, Path, bool]:
+        pointer_path = data_dir / "graph_snapshot.json"
+        if not pointer_path.exists():
+            return data_dir / "graph_metadata.json", data_dir / "graph_adjacency.npz", False
+        pointer = _read_json_object(pointer_path)
+        generation = str(pointer.get("generation", "") or "").strip()
+        if not generation or Path(generation).name != generation or not generation.startswith("graph-"):
+            raise RuntimeError("图快照指针包含非法 generation")
+        snapshot_dir = data_dir / "graph_snapshots" / generation
+        metadata_path = snapshot_dir / "graph_metadata.json"
+        if not metadata_path.exists():
+            raise FileNotFoundError(f"图快照元数据不存在: {metadata_path}")
+        return metadata_path, snapshot_dir / "graph_adjacency.npz", True
+
     def _canonicalize(self, node: str) -> str:
         """规范化节点名称 (用于去重和内部索引)"""
         if not node:
@@ -309,6 +378,13 @@ class GraphStore:
         if not edges:
             return 0
 
+        if weights is not None and len(weights) != len(edges):
+            raise ValueError(f"边数量与权重数量不匹配: {len(edges)} vs {len(weights)}")
+        if relation_hashes is not None and len(relation_hashes) != len(edges):
+            raise ValueError(
+                f"边数量与关系哈希数量不匹配: {len(edges)} vs {len(relation_hashes)}"
+            )
+
         # 确保所有节点存在
         nodes_to_add = set()
         for src, tgt in edges:
@@ -325,9 +401,6 @@ class GraphStore:
         # 处理权重
         if weights is None:
             weights = [1.0] * len(edges)
-
-        if len(weights) != len(edges):
-            raise ValueError(f"边数量与权重数量不匹配: {len(edges)} vs {len(weights)}")
 
         # 如果仅仅是添加边且处于增量模式 (LIL)，直接更新
         if self._modification_mode == GraphModificationMode.INCREMENTAL:
@@ -348,10 +421,12 @@ class GraphStore:
                  self._adjacency[rows, cols] = weights
                  
                  self._total_edges_added += len(edges)
+                 self._adjacency_dirty = True
+                 self._saliency_cache = None
                  
                  # V5：更新边哈希映射
                  if relation_hashes:
-                     for (src, tgt), r_hash in zip(edges, relation_hashes, strict=False):
+                     for (src, tgt), r_hash in zip(edges, relation_hashes, strict=True):
                          if r_hash:
                              s_idx = self._node_to_idx[self._canonicalize(src)]
                              t_idx = self._node_to_idx[self._canonicalize(tgt)]
@@ -398,10 +473,11 @@ class GraphStore:
 
         self._total_edges_added += len(edges)
         self._adjacency_dirty = True  # 标记脏位
+        self._saliency_cache = None
         
         # V5: 更新边哈希映射 (Edge Hash Map)
         if relation_hashes:
-            for (src, tgt), r_hash in zip(edges, relation_hashes, strict=False):
+            for (src, tgt), r_hash in zip(edges, relation_hashes, strict=True):
                 if r_hash:
                     try:
                         s_idx = self._node_to_idx[self._canonicalize(src)]
@@ -1160,16 +1236,12 @@ class GraphStore:
         if self._adjacency is None:
             return []
             
-        # 获取所有非零元素
-        rows, cols = self._adjacency.nonzero()
-        data = self._adjacency.data
-        
-        low_weight_indices = np.where(data < threshold)[0]
-        
+        # COO 的 row、col、data 始终逐项对齐，CSR、CSC 与显式零值都不会错位。
+        coordinates = self._adjacency.tocoo(copy=False)
         results = []
-        for idx in low_weight_indices:
-            r = rows[idx]
-            c = cols[idx]
+        for r, c, weight in zip(coordinates.row, coordinates.col, coordinates.data, strict=True):
+            if weight >= threshold:
+                continue
             src = self._nodes[r]
             tgt = self._nodes[c]
             results.append((src, tgt))
@@ -1237,6 +1309,7 @@ class GraphStore:
         self._edge_hash_map.clear()
         self._adjacency_T = None
         self._adjacency_dirty = True
+        self._saliency_cache = None
         self._total_nodes_added = 0
         self._total_edges_added = 0
         self._total_nodes_deleted = 0
@@ -1259,17 +1332,6 @@ class GraphStore:
         data_dir = Path(data_dir)
         data_dir.mkdir(parents=True, exist_ok=True)
 
-        # 保存邻接矩阵
-        matrix_path = data_dir / "graph_adjacency.npz"
-        if self._adjacency is not None:
-            with atomic_write(matrix_path, "wb") as f:
-                save_npz(f, self._adjacency)
-            logger.debug(f"保存邻接矩阵: {matrix_path}")
-        elif matrix_path.exists():
-            matrix_path.unlink()
-            logger.debug(f"删除陈旧邻接矩阵: {matrix_path}")
-
-        # 保存元数据
         metadata = {
             "nodes": self._nodes,
             "node_to_idx": self._node_to_idx,
@@ -1281,12 +1343,30 @@ class GraphStore:
             "total_edges_deleted": self._total_edges_deleted,
             "schema_version": 1,
         }
+
+        # 快照目录先完整落盘，兼容文件与 SQLite 镜像写完后再原子切换指针。
+        generation = self._prepare_snapshot(data_dir, metadata)
+
+        # 保存兼容邻接矩阵镜像
+        matrix_path = data_dir / "graph_adjacency.npz"
+        if self._adjacency is not None:
+            with atomic_write(matrix_path, "wb") as f:
+                save_npz(f, self._adjacency)
+            logger.debug(f"保存邻接矩阵: {matrix_path}")
+        elif matrix_path.exists():
+            matrix_path.unlink()
+            logger.debug(f"删除陈旧邻接矩阵: {matrix_path}")
+
+        # 保存兼容元数据与 SQLite 边映射镜像
         if not self._save_edge_hash_map(data_dir):
             metadata["edge_hash_map"] = self._serialize_edge_hash_map()
 
         metadata_path = data_dir / "graph_metadata.json"
         _write_json_object(metadata_path, metadata)
         logger.debug(f"保存元数据: {metadata_path}")
+
+        self._activate_snapshot(data_dir, generation)
+        self._cleanup_old_snapshots(data_dir, generation)
 
         logger.info(f"图存储已保存到: {data_dir}")
 
@@ -1307,8 +1387,8 @@ class GraphStore:
         if not data_dir.exists():
             raise FileNotFoundError(f"数据目录不存在: {data_dir}")
 
-        # 加载元数据
-        metadata_path = data_dir / "graph_metadata.json"
+        # 优先加载原子快照；旧数据目录没有指针时继续读取兼容文件。
+        metadata_path, matrix_path, snapshot_active = self._resolve_snapshot_paths(data_dir)
         if not metadata_path.exists():
             raise FileNotFoundError(f"元数据文件不存在: {metadata_path}")
 
@@ -1337,7 +1417,11 @@ class GraphStore:
         self._total_edges_deleted = metadata["total_edges_deleted"]
         
         # 恢复 V5 边哈希映射 (Restore V5 edge hash map)
-        self._edge_hash_map = defaultdict(set, self._load_edge_hash_map(data_dir))
+        self._edge_hash_map = (
+            defaultdict(set)
+            if snapshot_active
+            else defaultdict(set, self._load_edge_hash_map(data_dir))
+        )
         edge_map_data = metadata.get("edge_hash_map", {})
         if not self._edge_hash_map and isinstance(edge_map_data, dict):
             for k, v in edge_map_data.items():
@@ -1351,7 +1435,6 @@ class GraphStore:
                 self._edge_hash_map[key] = set(v if isinstance(v, (list, tuple, set)) else [v])
 
         # 加载邻接矩阵
-        matrix_path = data_dir / "graph_adjacency.npz"
         if matrix_path.exists():
             self._adjacency = load_npz(str(matrix_path))
 
@@ -1362,6 +1445,10 @@ class GraphStore:
                 self._adjacency = self._adjacency.tocsr()
 
             logger.debug(f"加载邻接矩阵: {matrix_path}, shape={self._adjacency.shape}")
+        elif snapshot_active and bool(metadata.get("has_adjacency", False)):
+            raise FileNotFoundError(f"图快照邻接矩阵不存在: {matrix_path}")
+        else:
+            self._adjacency = None
 
         # 检查维度不匹配并修复
         if self._adjacency is not None:

--- a/src/A_memorix/core/storage/metadata_episode.py
+++ b/src/A_memorix/core/storage/metadata_episode.py
@@ -72,6 +72,7 @@ class MetadataEpisodeMixin:
             ) VALUES (?, 'pending', 0, NULL, ?, ?, ?)
             ON CONFLICT(source) DO UPDATE SET
                 status = 'pending',
+                retry_count = 0,
                 last_error = NULL,
                 reason = excluded.reason,
                 requested_at = excluded.requested_at,

--- a/src/A_memorix/core/storage/metadata_feedback.py
+++ b/src/A_memorix/core/storage/metadata_feedback.py
@@ -197,6 +197,7 @@ class MetadataFeedbackMixin:
         *,
         limit: int = 20,
         now: Optional[float] = None,
+        lease_seconds: float = 300.0,
     ) -> List[Dict[str, Any]]:
         safe_limit = max(1, int(limit))
         now_ts = optional_float(now)
@@ -209,15 +210,23 @@ class MetadataFeedbackMixin:
             SELECT *
             FROM memory_feedback_tasks
             WHERE due_at <= ?
-              AND status IN ('pending', 'running')
+              AND (
+                    status = 'pending'
+                    OR (status = 'running' AND updated_at <= ?)
+                  )
             ORDER BY due_at ASC, id ASC
             LIMIT ?
             """,
-            (now_ts, safe_limit),
+            (now_ts, now_ts - max(1.0, float(lease_seconds)), safe_limit),
         )
         return [self._feedback_task_row_to_dict(row) for row in cursor.fetchall()]
 
-    def mark_feedback_task_running(self, task_id: int) -> Optional[Dict[str, Any]]:
+    def mark_feedback_task_running(
+        self,
+        task_id: int,
+        *,
+        lease_seconds: float = 300.0,
+    ) -> Optional[Dict[str, Any]]:
         if int(task_id or 0) <= 0:
             return None
         now = datetime.now().timestamp()
@@ -229,11 +238,16 @@ class MetadataFeedbackMixin:
                 attempt_count = COALESCE(attempt_count, 0) + 1,
                 updated_at = ?
             WHERE id = ?
-              AND status IN ('pending', 'running')
+              AND (
+                    status = 'pending'
+                    OR (status = 'running' AND updated_at <= ?)
+                  )
             """,
-            (now, int(task_id)),
+            (now, int(task_id), now - max(1.0, float(lease_seconds))),
         )
         self._conn.commit()
+        if int(cursor.rowcount or 0) <= 0:
+            return None
         cursor.execute(
             """
             SELECT *
@@ -298,6 +312,7 @@ class MetadataFeedbackMixin:
         task_id: int,
         requested_by: str = "",
         reason: str = "",
+        lease_seconds: float = 300.0,
     ) -> Optional[Dict[str, Any]]:
         if int(task_id or 0) <= 0:
             return None
@@ -314,7 +329,13 @@ class MetadataFeedbackMixin:
                 updated_at = ?
             WHERE id = ?
               AND LOWER(COALESCE(status, '')) = 'applied'
-              AND LOWER(COALESCE(rollback_status, 'none')) IN ('none', 'error')
+              AND (
+                    LOWER(COALESCE(rollback_status, 'none')) IN ('none', 'error')
+                    OR (
+                        LOWER(COALESCE(rollback_status, 'none')) = 'running'
+                        AND updated_at <= ?
+                    )
+                  )
             """,
             (
                 str(requested_by or "").strip() or None,
@@ -322,6 +343,7 @@ class MetadataFeedbackMixin:
                 now,
                 now,
                 int(task_id),
+                now - max(1.0, float(lease_seconds)),
             ),
         )
         self._conn.commit()

--- a/src/A_memorix/core/storage/metadata_fts.py
+++ b/src/A_memorix/core/storage/metadata_fts.py
@@ -664,6 +664,7 @@ class MetadataFTSMixin:
         """
         将段落写入（或覆盖）到 FTS 索引。
         """
+        owns_transaction = conn is None
         c = self._resolve_conn(conn)
         cur = c.cursor()
         try:
@@ -680,11 +681,13 @@ class MetadataFTSMixin:
                 "INSERT OR REPLACE INTO paragraphs_fts(rowid, content) VALUES (?, ?)",
                 (rowid, content),
             )
-            c.commit()
+            if owns_transaction:
+                c.commit()
             return True
         except sqlite3.OperationalError as e:
             logger.warning(f"FTS upsert 失败: {e}")
-            c.rollback()
+            if owns_transaction:
+                c.rollback()
             return False
 
     def fts_delete_paragraph(
@@ -695,6 +698,7 @@ class MetadataFTSMixin:
         """
         从 FTS 索引删除段落。
         """
+        owns_transaction = conn is None
         c = self._resolve_conn(conn)
         cur = c.cursor()
         try:
@@ -711,11 +715,13 @@ class MetadataFTSMixin:
                 "INSERT INTO paragraphs_fts(paragraphs_fts, rowid, content) VALUES ('delete', ?, ?)",
                 (rowid, content),
             )
-            c.commit()
+            if owns_transaction:
+                c.commit()
             return True
         except sqlite3.OperationalError as e:
             logger.warning(f"FTS delete 失败: {e}")
-            c.rollback()
+            if owns_transaction:
+                c.rollback()
             return False
 
     def fts_search_bm25(

--- a/src/A_memorix/core/storage/metadata_fts.py
+++ b/src/A_memorix/core/storage/metadata_fts.py
@@ -664,8 +664,8 @@ class MetadataFTSMixin:
         """
         将段落写入（或覆盖）到 FTS 索引。
         """
-        owns_transaction = conn is None
         c = self._resolve_conn(conn)
+        owns_transaction = not c.in_transaction
         cur = c.cursor()
         try:
             cur.execute(
@@ -698,8 +698,8 @@ class MetadataFTSMixin:
         """
         从 FTS 索引删除段落。
         """
-        owns_transaction = conn is None
         c = self._resolve_conn(conn)
+        owns_transaction = not c.in_transaction
         cur = c.cursor()
         try:
             cur.execute(

--- a/src/A_memorix/core/storage/metadata_schema.py
+++ b/src/A_memorix/core/storage/metadata_schema.py
@@ -84,7 +84,12 @@ class MetadataSchemaMixin:
                 try:
                     cursor.execute(sql)
                 except sqlite3.OperationalError as e:
-                    logger.warning(f"Schema迁移失败 (memory_feedback_tasks.{col}): {e}")
+                    cursor.execute("PRAGMA table_info(memory_feedback_tasks)")
+                    current_columns = {row[1] for row in cursor.fetchall()}
+                    if col not in current_columns:
+                        raise RuntimeError(
+                            f"Schema迁移失败 (memory_feedback_tasks.{col})"
+                        ) from e
 
     def _ensure_paragraph_stale_relation_mark_columns(self, cursor: sqlite3.Cursor) -> None:
         """补齐段落陈旧关系标记的来源追踪列。"""
@@ -100,7 +105,12 @@ class MetadataSchemaMixin:
                 try:
                     cursor.execute(sql)
                 except sqlite3.OperationalError as e:
-                    logger.warning(f"Schema迁移失败 (paragraph_stale_relation_marks.{col}): {e}")
+                    cursor.execute("PRAGMA table_info(paragraph_stale_relation_marks)")
+                    current_columns = {row[1] for row in cursor.fetchall()}
+                    if col not in current_columns:
+                        raise RuntimeError(
+                            f"Schema迁移失败 (paragraph_stale_relation_marks.{col})"
+                        ) from e
 
     def _ensure_fuzzy_modify_plan_tables(self, cursor: sqlite3.Cursor) -> None:
         """补齐模糊修改计划表，用于预览、确认、执行和追溯。"""

--- a/src/A_memorix/core/storage/metadata_store.py
+++ b/src/A_memorix/core/storage/metadata_store.py
@@ -1245,7 +1245,8 @@ class MetadataStore(
             # 2. 查找相关关系 (Subject 或 Object 为该实体)
             cursor.execute("""
                 SELECT hash FROM relations
-                WHERE subject = ? OR object = ?
+                WHERE LOWER(TRIM(subject)) = LOWER(TRIM(?))
+                   OR LOWER(TRIM(object)) = LOWER(TRIM(?))
             """, (entity_name, entity_name))
 
             relation_hashes = [r[0] for r in cursor.fetchall()]
@@ -1957,6 +1958,37 @@ class MetadataStore(
         )
         self._conn.commit()
         if cursor.rowcount <= 0:
+            return None
+        return self.get_fuzzy_modify_plan(token)
+
+    def claim_fuzzy_modify_plan(
+        self,
+        plan_id: str,
+        *,
+        stale_after_seconds: float = 300.0,
+    ) -> Optional[Dict[str, Any]]:
+        """原子领取待执行计划，并只回收超过租约的 executing 计划。"""
+        token = str(plan_id or "").strip()
+        if not token:
+            return None
+        now = datetime.now().timestamp()
+        stale_before = now - max(1.0, float(stale_after_seconds))
+        cursor = self._conn.cursor()
+        cursor.execute(
+            """
+            UPDATE memory_fuzzy_modify_plans
+            SET status = 'executing',
+                updated_at = ?
+            WHERE plan_id = ?
+              AND (
+                    status IN ('awaiting_confirmation', 'failed')
+                    OR (status = 'executing' AND updated_at <= ?)
+                  )
+            """,
+            (now, token, stale_before),
+        )
+        self._conn.commit()
+        if int(cursor.rowcount or 0) <= 0:
             return None
         return self.get_fuzzy_modify_plan(token)
 
@@ -3074,16 +3106,26 @@ class MetadataStore(
             cols_str = ",".join(columns)
             values = list(data.values())
 
-            cursor.execute(f"""
-                INSERT OR REPLACE INTO relations ({cols_str})
+            update_columns = [column for column in columns if column != "hash"]
+            update_sql = ", ".join(
+                f"{column} = excluded.{column}"
+                for column in update_columns
+            )
+            cursor.execute(
+                f"""
+                INSERT INTO relations ({cols_str})
                 VALUES ({placeholders})
-            """, values)
+                ON CONFLICT(hash) DO UPDATE SET {update_sql}
+                """,
+                values,
+            )
 
             # 3. 从备份表删除
             cursor.execute("DELETE FROM deleted_relations WHERE hash = ?", (hash_value,))
 
             self._conn.commit()
-            return self._row_to_dict(row, "relation") # 使用助手函数将原始行转换为字典
+            restored = self.get_relation(hash_value)
+            return restored
 
         except Exception as e:
             logger.error(f"恢复关系失败: {hash_value} - {e}")

--- a/src/A_memorix/core/storage/sqlite_connection.py
+++ b/src/A_memorix/core/storage/sqlite_connection.py
@@ -96,7 +96,7 @@ class SQLiteConnectionManager:
         scope_depth = connection.begin_managed_scope()
         try:
             yield connection
-        except Exception:
+        except BaseException:
             self._rollback_scope(connection, savepoint_name, scope_depth)
             raise
         else:

--- a/src/A_memorix/core/storage/transaction.py
+++ b/src/A_memorix/core/storage/transaction.py
@@ -2,11 +2,17 @@ from typing import Optional, Type
 
 import sqlite3
 
+from .sqlite_connection import ManagedSQLiteConnection
+
 
 class ConnectionTransaction:
     """为外部注入的 SQLite 连接提供统一事务语义。"""
 
     def __init__(self, connection: sqlite3.Connection, *, immediate: bool = False) -> None:
+        if not isinstance(connection, ManagedSQLiteConnection):
+            raise TypeError(
+                "外部 SQLite 连接不支持受管事务；请注入 ManagedSQLiteConnection"
+            )
         self.connection = connection
         self.immediate = immediate
         self._savepoint_name: Optional[str] = None

--- a/src/A_memorix/core/storage/vector_store.py
+++ b/src/A_memorix/core/storage/vector_store.py
@@ -6,12 +6,13 @@
 
 import hashlib
 import json
+import os
+import random
 import shutil
+import threading  # 线程同步
 import time
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple, Union
-import random
-import threading  # 线程同步
 
 import numpy as np
 
@@ -107,6 +108,9 @@ class VectorStore:
 
         self._known_hashes: Set[str] = set()
         self._deleted_ids: Set[int] = set()
+        self._known_hashes_revision = 0
+        self._cached_map_revision = -1
+        self._cached_map: Dict[int, str] = {}
 
         self._reservoir_buffer: List[np.ndarray] = []
         self._seen_count_for_reservoir = 0
@@ -155,13 +159,61 @@ class VectorStore:
         return self.data_dir / "vectors_ids.bin"
 
     @property
+    def _compaction_journal_path(self) -> Path:
+        return self.data_dir / "vectors_compaction.json"
+
+    @property
+    def _bin_backup_path(self) -> Path:
+        return self.data_dir / "vectors.bin.compaction.bak"
+
+    @property
+    def _ids_backup_path(self) -> Path:
+        return self.data_dir / "vectors_ids.bin.compaction.bak"
+
+    def _invalidate_id_map(self) -> None:
+        self._known_hashes_revision += 1
+
+    def _vector_pair_matches(self, bin_path: Path, ids_path: Path, *, expected_count: Optional[int] = None) -> bool:
+        if not bin_path.exists() or not ids_path.exists():
+            return False
+        vector_item_size = self.dimension * 2
+        bin_size = bin_path.stat().st_size
+        ids_size = ids_path.stat().st_size
+        if bin_size % vector_item_size != 0 or ids_size % 8 != 0:
+            return False
+        vector_count = bin_size // vector_item_size
+        id_count = ids_size // 8
+        return vector_count == id_count and (expected_count is None or vector_count == expected_count)
+
+    def _recover_interrupted_compaction_unlocked(self) -> None:
+        """根据持久化日志完成或回滚被中断的双文件切换。"""
+        journal_path = self._compaction_journal_path
+        if not journal_path.exists():
+            return
+
+        journal = _read_json_object(journal_path)
+        expected_count = int(journal["expected_count"])
+        if self._vector_pair_matches(self._bin_path, self._ids_bin_path, expected_count=expected_count):
+            self._bin_backup_path.unlink(missing_ok=True)
+            self._ids_backup_path.unlink(missing_ok=True)
+            journal_path.unlink()
+            return
+
+        if not self._vector_pair_matches(self._bin_backup_path, self._ids_backup_path):
+            raise RuntimeError("向量压缩被中断，且找不到可恢复的一致备份")
+        os.replace(self._bin_backup_path, self._bin_path)
+        os.replace(self._ids_backup_path, self._ids_bin_path)
+        journal_path.unlink()
+
+    @property
     def _int_to_str_map(self) -> Dict[int, str]:
         """按需从已知哈希构建易失的 ID 反查表。"""
-        # 反查表读取频繁，且依赖可变的 _known_hashes；缓存重建必须在锁内完成。
-        # 长度检查只用于发现缓存失效，实际重建仍由锁保护。
-        if not hasattr(self, "_cached_map") or len(self._cached_map) != len(self._known_hashes):
+        # 反查表读取频繁，且依赖可变的 _known_hashes；版本号可以识别等量替换。
+        if self._cached_map_revision != self._known_hashes_revision:
             with self._lock: # 在锁内重建缓存
-                 self._cached_map = {self._generate_id(k): k for k in self._known_hashes}
+                if self._cached_map_revision != self._known_hashes_revision:
+                    self._cached_map = {self._generate_id(k): k for k in self._known_hashes}
+                    self._cached_map_revision = self._known_hashes_revision
         return self._cached_map
 
     def add(self, vectors: np.ndarray, ids: List[str]) -> int:
@@ -187,6 +239,8 @@ class VectorStore:
 
             if not processed_vecs:
                 return 0
+
+            self._invalidate_id_map()
 
             batch_vecs = np.array(processed_vecs, dtype=np.float32)
             batch_ids = np.array(processed_int_ids, dtype=np.int64)
@@ -689,6 +743,9 @@ class VectorStore:
         """实际 GC 重建逻辑。"""
         logger.info("Starting Compaction (GC)...")
 
+        self._recover_interrupted_compaction_unlocked()
+        self._flush_write_buffer_unlocked()
+
         tmp_bin = self.data_dir / "vectors.bin.tmp"
         tmp_ids = self.data_dir / "vectors_ids.bin.tmp"
 
@@ -720,7 +777,24 @@ class VectorStore:
                     w_id.write(keep_ids.astype('>i8').tobytes())
                     new_count += len(keep_ids)
 
-        # 2. 重置状态并原子切换文件
+        if not self._vector_pair_matches(tmp_bin, tmp_ids, expected_count=new_count):
+            raise RuntimeError("向量压缩临时文件不一致，已拒绝切换")
+
+        # 2. 通过日志和成对备份切换文件；进程中断后会整体完成或整体回滚。
+        self._bin_backup_path.unlink(missing_ok=True)
+        self._ids_backup_path.unlink(missing_ok=True)
+        shutil.copy2(self._bin_path, self._bin_backup_path)
+        shutil.copy2(self._ids_bin_path, self._ids_backup_path)
+        _write_json_object(self._compaction_journal_path, {"expected_count": new_count})
+        os.replace(tmp_bin, self._bin_path)
+        os.replace(tmp_ids, self._ids_bin_path)
+        if not self._vector_pair_matches(self._bin_path, self._ids_bin_path, expected_count=new_count):
+            self._recover_interrupted_compaction_unlocked()
+            raise RuntimeError("向量压缩文件切换失败，已恢复原始文件")
+
+        self._bin_backup_path.unlink(missing_ok=True)
+        self._ids_backup_path.unlink(missing_ok=True)
+        self._compaction_journal_path.unlink()
         self._bin_count = new_count
 
         # 关闭当前索引
@@ -729,12 +803,16 @@ class VectorStore:
             self._fallback_index.reset() # 同时清空回退索引
         self._is_trained = False
 
-        # 切换数据文件
-        shutil.move(str(tmp_bin), str(self._bin_path))
-        shutil.move(str(tmp_ids), str(self._ids_bin_path))
-
-        # 清空删除标记，这是重建正确性的关键步骤。
+        # 已删除哈希必须同时移出成员集合，之后才能重新写入同名向量。
+        deleted_hashes = {
+            hash_value
+            for hash_value in self._known_hashes
+            if self._generate_id(hash_value) in self._deleted_ids
+        }
+        self._known_hashes.difference_update(deleted_hashes)
         self._deleted_ids.clear()
+        if deleted_hashes:
+            self._invalidate_id_map()
 
         # 3. 重新加载并训练索引
         # 删除后的数据分布可能明显变化，因此必须重新训练。
@@ -822,6 +900,7 @@ class VectorStore:
             # 重置内存状态，避免继续向旧运行时缓冲区追加数据。
             self._known_hashes.clear()
             self._deleted_ids.clear()
+            self._invalidate_id_map()
             self._write_buffer_vecs.clear()
             self._write_buffer_ids.clear()
             self._init_index()
@@ -838,6 +917,7 @@ class VectorStore:
             if not data_dir:
                 data_dir = self.data_dir
             data_dir = Path(data_dir)
+            self._recover_interrupted_compaction_unlocked()
 
             npy_path = data_dir / "vectors.npy"
             idx_path = data_dir / "vectors.index"
@@ -860,6 +940,7 @@ class VectorStore:
                 logger.warning("Index IDMap2 version mismatch (L2 Norm), forcing rebuild...")
                 self._known_hashes = set(meta.get("ids", [])) | set(meta.get("known_hashes", []))
                 self._deleted_ids = set(meta.get("deleted_ids", []))
+                self._invalidate_id_map()
                 self._init_index()
                 self._force_train_small_data()
                 return
@@ -868,6 +949,7 @@ class VectorStore:
             self._vector_norm = meta.get("vector_norm", "l2")
             self._deleted_ids = set(meta.get("deleted_ids", []))
             self._known_hashes = set(meta.get("known_hashes", []))
+            self._invalidate_id_map()
 
             if self._is_trained:
                 if idx_path.exists():
@@ -933,6 +1015,7 @@ class VectorStore:
             self._init_index()
             self._known_hashes.clear()
             self._deleted_ids.clear()
+            self._invalidate_id_map()
             self._bin_count = 0
             logger.info("VectorStore cleared.")
 

--- a/src/A_memorix/core/utils/feedback_policy.py
+++ b/src/A_memorix/core/utils/feedback_policy.py
@@ -73,7 +73,7 @@ def feedback_cfg_batch_size() -> int:
 
 
 def feedback_cfg_auto_apply_threshold() -> float:
-    value = float(getattr(_integration_config(), "feedback_correction_auto_apply_threshold", 0.85) or 0.85)
+    value = float(getattr(_integration_config(), "feedback_correction_auto_apply_threshold", 0.85))
     return min(1.0, max(0.0, value))
 
 
@@ -134,7 +134,7 @@ def fuzzy_modify_cfg_auto_execute_enabled() -> bool:
 
 
 def fuzzy_modify_cfg_confirm_threshold() -> float:
-    return float(getattr(_integration_config(), "fuzzy_modify_confirm_threshold", 0.85) or 0.85)
+    return float(getattr(_integration_config(), "fuzzy_modify_confirm_threshold", 0.85))
 
 
 def fuzzy_modify_cfg_candidate_limit() -> int:

--- a/src/A_memorix/core/utils/relation_write_service.py
+++ b/src/A_memorix/core/utils/relation_write_service.py
@@ -161,7 +161,6 @@ class RelationWriteService:
         self.graph_store.add_edges([(subject, obj)], relation_hashes=[rel_hash])
 
         if not write_vector:
-            self.metadata_store.set_relation_vector_state(rel_hash, "none")
             return RelationWriteResult(
                 hash_value=rel_hash,
                 vector_written=False,

--- a/src/A_memorix/core/utils/runtime_payloads.py
+++ b/src/A_memorix/core/utils/runtime_payloads.py
@@ -39,6 +39,8 @@ def safe_json_loads(raw: Any) -> Dict[str, Any]:
 
 
 def tokens(values: Optional[Iterable[Any]]) -> List[str]:
+    if isinstance(values, str):
+        values = [values]
     result: List[str] = []
     seen = set()
     for item in values or []:

--- a/src/A_memorix/core/utils/summary_importer.py
+++ b/src/A_memorix/core/utils/summary_importer.py
@@ -336,14 +336,16 @@ class SummaryImporter:
                     logger.warning(f"总结模型选择器 '{selector}' 的任务 '{task_name}' 不存在，已跳过")
                     continue
 
-                if base_cfg is None:
-                    base_cfg = task_cfg
-                    base_task_name = task_name
-
                 if not model_name or model_name.lower() == "auto":
+                    if base_cfg is None:
+                        base_cfg = task_cfg
+                        base_task_name = task_name
                     continue
 
                 if model_name in task_cfg.model_list:
+                    if base_cfg is None:
+                        base_cfg = task_cfg
+                        base_task_name = task_name
                     logger.info(
                         f"总结模型选择器 '{selector}' 已定位到任务 '{task_name}'；"
                         "当前 LLM 服务按任务候选列表执行，不单独覆盖具体模型。"
@@ -738,7 +740,6 @@ class SummaryImporter:
                     )
                     # 写入图数据库（写入 relation_hashes，确保后续可按关系精确修剪）
                     self.graph_store.add_edges([(s, o)], relation_hashes=[rel_hash])
-                    self.metadata_store.set_relation_vector_state(rel_hash, "none")
 
         logger.info(f"总结导入完成: hash={hash_value[:8]}")
         return hash_value

--- a/src/A_memorix/core/utils/web_import_manager.py
+++ b/src/A_memorix/core/utils/web_import_manager.py
@@ -2784,6 +2784,7 @@ class ImportTaskManager:
         switched = False
         rollback_info: Dict[str, Any] = {"attempted": True, "restored": False, "error": ""}
         moved_items: List[Tuple[Path, Path]] = []
+        installed_items: List[Path] = []
         try:
             for name in ("vectors", "graph", "metadata"):
                 src_current = target_dir / name
@@ -2795,19 +2796,33 @@ class ImportTaskManager:
                     shutil.move(str(src_current), str(dst_backup))
                     moved_items.append((dst_backup, src_current))
                 shutil.move(str(src_new), str(src_current))
+                installed_items.append(src_current)
             switched = True
         except Exception as switch_err:
             rollback_info["error"] = str(switch_err)
-            # 尝试回滚
-            for src_backup, dst_original in moved_items:
-                if src_backup.exists() and not dst_original.exists():
+            restore_errors: List[str] = []
+            # 先移走已安装的新目录，再逐项恢复旧目录，避免新旧内容混合。
+            for installed_path in reversed(installed_items):
+                if not installed_path.exists():
+                    continue
+                failed_new_path = backup_dir / f"{installed_path.name}.failed_new"
+                try:
+                    shutil.move(str(installed_path), str(failed_new_path))
+                except OSError as restore_exc:
+                    restore_errors.append(str(restore_exc))
+                    logger.error(f"隔离切换失败目录失败: path={installed_path}, error={restore_exc}")
+            for src_backup, dst_original in reversed(moved_items):
+                if src_backup.exists():
                     try:
                         shutil.move(str(src_backup), str(dst_original))
                     except OSError as restore_exc:
+                        restore_errors.append(str(restore_exc))
                         logger.error(
                             f"恢复转换备份失败: source={src_backup}, target={dst_original}, error={restore_exc}"
                         )
-            rollback_info["restored"] = True
+            rollback_info["restored"] = not restore_errors
+            if restore_errors:
+                rollback_info["error"] = f"{switch_err}; rollback: {'; '.join(restore_errors)}"
             async with self._lock:
                 t = self._tasks.get(task_id)
                 if t:
@@ -3657,7 +3672,6 @@ class ImportTaskManager:
             )
             self.plugin.graph_store.add_edges([(subject_token, object_token)], relation_hashes=[rel_hash])
             if not write_vector:
-                self.plugin.metadata_store.set_relation_vector_state(rel_hash, "none")
                 return rel_hash
             target_store = self._graph_vector_store()
             vector_id = self._graph_vector_id("relation", rel_hash)

--- a/src/A_memorix/host_service.py
+++ b/src/A_memorix/host_service.py
@@ -85,6 +85,8 @@ class AMemorixHostService:
         self._startup_error_stage = ""
         self._startup_started_at: Optional[float] = None
         self._startup_finished_at: Optional[float] = None
+        self._startup_queue_pending_count = 0
+        self._startup_queue_cache_loaded = False
         self._config_cache: Dict[str, Any] | None = None
         self._reload_callback_registered = False
 
@@ -238,42 +240,8 @@ class AMemorixHostService:
                 else {},
             )
 
-        if component_name == "ingest_summary":
-            return await kernel.ingest_summary(
-                external_id=str(payload.get("external_id", "") or ""),
-                chat_id=str(payload.get("chat_id", "") or ""),
-                text=str(payload.get("text", "") or ""),
-                participants=list(payload.get("participants") or []),
-                time_start=payload.get("time_start"),
-                time_end=payload.get("time_end"),
-                tags=list(payload.get("tags") or []),
-                metadata=payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {},
-                respect_filter=bool(payload.get("respect_filter", True)),
-                user_id=str(payload.get("user_id", "") or "").strip(),
-                group_id=str(payload.get("group_id", "") or "").strip(),
-            )
-
-        if component_name == "ingest_text":
-            relations = payload.get("relations") if isinstance(payload.get("relations"), list) else []
-            entities = payload.get("entities") if isinstance(payload.get("entities"), list) else []
-            return await kernel.ingest_text(
-                external_id=str(payload.get("external_id", "") or ""),
-                source_type=str(payload.get("source_type", "") or ""),
-                text=str(payload.get("text", "") or ""),
-                chat_id=str(payload.get("chat_id", "") or ""),
-                person_ids=list(payload.get("person_ids") or []),
-                participants=list(payload.get("participants") or []),
-                timestamp=payload.get("timestamp"),
-                time_start=payload.get("time_start"),
-                time_end=payload.get("time_end"),
-                tags=list(payload.get("tags") or []),
-                metadata=payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {},
-                entities=entities,
-                relations=relations,
-                respect_filter=bool(payload.get("respect_filter", True)),
-                user_id=str(payload.get("user_id", "") or "").strip(),
-                group_id=str(payload.get("group_id", "") or "").strip(),
-            )
+        if component_name in {"ingest_summary", "ingest_text"}:
+            return await self._dispatch_ingest_write(kernel, component_name, payload)
 
         if component_name == "get_person_profile":
             return await kernel.get_person_profile(
@@ -325,6 +293,7 @@ class AMemorixHostService:
             return self._kernel
 
     async def _ensure_startup_task(self) -> None:
+        await self._ensure_startup_queue_cache()
         async with self._lock:
             if self._kernel is not None and self._runtime_state == "ready":
                 return
@@ -439,15 +408,18 @@ class AMemorixHostService:
             handle.flush()
             os.fsync(handle.fileno())
 
+    def _append_jsonl_sync(self, path: Path, payload: Dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        self._ensure_jsonl_append_boundary(path)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+
     async def _append_jsonl(self, path: Path, payload: Dict[str, Any]) -> None:
         async with self._queue_lock:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            line = json.dumps(payload, ensure_ascii=False, sort_keys=True)
-            self._ensure_jsonl_append_boundary(path)
-            with path.open("a", encoding="utf-8") as handle:
-                handle.write(line + "\n")
-                handle.flush()
-                os.fsync(handle.fileno())
+            await asyncio.to_thread(self._append_jsonl_sync, path, payload)
 
     def _read_jsonl(self, path: Path) -> list[Dict[str, Any]]:
         if not path.exists():
@@ -487,8 +459,17 @@ class AMemorixHostService:
         records.sort(key=lambda item: float(item.get("created_at", 0.0) or 0.0))
         return records
 
+    async def _ensure_startup_queue_cache(self) -> None:
+        if self._startup_queue_cache_loaded:
+            return
+        async with self._queue_lock:
+            if self._startup_queue_cache_loaded:
+                return
+            records = await asyncio.to_thread(self._startup_queue_pending_records)
+            self._startup_queue_pending_count = len(records)
+            self._startup_queue_cache_loaded = True
+
     def _startup_status_payload(self) -> Dict[str, Any]:
-        pending_count = len(self._startup_queue_pending_records())
         return {
             "enabled": self.is_enabled(),
             "runtime_ready": self._runtime_state == "ready",
@@ -499,7 +480,7 @@ class AMemorixHostService:
             "error": self._startup_error,
             "startup_started_at": self._startup_started_at,
             "startup_finished_at": self._startup_finished_at,
-            "startup_queue_pending": pending_count,
+            "startup_queue_pending": self._startup_queue_pending_count,
             "data_dir": str(self._runtime_data_dir()),
         }
 
@@ -511,6 +492,7 @@ class AMemorixHostService:
             "created_at": time.time(),
         }
         await self._append_jsonl(self._startup_queue_path(), record)
+        self._startup_queue_pending_count += 1
         return {
             "success": True,
             "queued": True,
@@ -559,7 +541,7 @@ class AMemorixHostService:
             return {**base, "queued": False}
         return {**base, "success": False, "error": message}
 
-    async def _dispatch_queued_write(self, kernel: SDKMemoryKernel, component_name: str, payload: Dict[str, Any]) -> Any:
+    async def _dispatch_ingest_write(self, kernel: SDKMemoryKernel, component_name: str, payload: Dict[str, Any]) -> Any:
         if component_name == "ingest_summary":
             return await kernel.ingest_summary(
                 external_id=str(payload.get("external_id", "") or ""),
@@ -596,7 +578,9 @@ class AMemorixHostService:
         raise ValueError(f"不支持的启动队列写入类型: {component_name}")
 
     async def _replay_startup_write_queue(self, kernel: SDKMemoryKernel) -> None:
-        records = self._startup_queue_pending_records()
+        records = await asyncio.to_thread(self._startup_queue_pending_records)
+        self._startup_queue_pending_count = len(records)
+        self._startup_queue_cache_loaded = True
         if not records:
             return
         logger.info(f"A_Memorix 开始回放启动写入队列: pending={len(records)}")
@@ -605,7 +589,7 @@ class AMemorixHostService:
             component_name = str(record.get("component_name", "") or "").strip()
             payload = record.get("payload") if isinstance(record.get("payload"), dict) else {}
             try:
-                result = await self._dispatch_queued_write(kernel, component_name, payload)
+                result = await self._dispatch_ingest_write(kernel, component_name, payload)
                 if isinstance(result, dict) and result.get("success") is False:
                     raise RuntimeError(str(result.get("detail") or result.get("error") or result))
                 await self._append_jsonl(
@@ -617,6 +601,7 @@ class AMemorixHostService:
                         "result": result if isinstance(result, dict) else {},
                     },
                 )
+                self._startup_queue_pending_count = max(0, self._startup_queue_pending_count - 1)
             except Exception as exc:
                 await self._append_jsonl(
                     self._startup_queue_failed_path(),

--- a/src/A_memorix/plugin.py
+++ b/src/A_memorix/plugin.py
@@ -31,6 +31,7 @@ class AMemorixPlugin(MaiBotPlugin):
         self._plugin_root = repo_root()
         self._plugin_config: Dict[str, Any] = {}
         self._kernel: Optional[SDKMemoryKernel] = None
+        self._kernel_shutdown_error = ""
 
     def set_plugin_config(self, config: Dict[str, Any]) -> None:
         """更新下一次内核初始化使用的配置，不在同步入口关闭活动内核。"""
@@ -40,8 +41,14 @@ class AMemorixPlugin(MaiBotPlugin):
         """等待内核后台任务退出并释放资源，成功后再清除实例引用。"""
         if self._kernel is None:
             return
-        await self._kernel.shutdown()
-        self._kernel = None
+        try:
+            await self._kernel.shutdown()
+        except Exception as exc:
+            self._kernel_shutdown_error = str(exc)
+            raise
+        else:
+            self._kernel = None
+            self._kernel_shutdown_error = ""
 
     async def on_load(self):
         await self._get_kernel()
@@ -60,9 +67,14 @@ class AMemorixPlugin(MaiBotPlugin):
             await self._shutdown_kernel()
 
     async def _get_kernel(self) -> SDKMemoryKernel:
+        if self._kernel_shutdown_error:
+            raise RuntimeError(
+                f"A_Memorix 上次停机未完成，拒绝复用旧内核: {self._kernel_shutdown_error}"
+            )
         if self._kernel is None:
-            self._kernel = SDKMemoryKernel(plugin_root=self._plugin_root, config=self._plugin_config)
-            await self._kernel.initialize()
+            kernel = SDKMemoryKernel(plugin_root=self._plugin_root, config=self._plugin_config)
+            await kernel.initialize()
+            self._kernel = kernel
         return self._kernel
 
     async def _dispatch_admin_tool(self, method_name: str, action: str, **kwargs):

--- a/src/A_memorix/plugin.py
+++ b/src/A_memorix/plugin.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, List, Optional
 from maibot_sdk import MaiBotPlugin, Tool
 from maibot_sdk.types import ToolParameterInfo, ToolParamType
 
+import asyncio
+
 from A_memorix.core.runtime.sdk_memory_kernel import KernelSearchRequest, SDKMemoryKernel
 from A_memorix.paths import repo_root
 
@@ -31,6 +33,7 @@ class AMemorixPlugin(MaiBotPlugin):
         self._plugin_root = repo_root()
         self._plugin_config: Dict[str, Any] = {}
         self._kernel: Optional[SDKMemoryKernel] = None
+        self._kernel_lock = asyncio.Lock()
         self._kernel_shutdown_error = ""
 
     def set_plugin_config(self, config: Dict[str, Any]) -> None:
@@ -39,16 +42,17 @@ class AMemorixPlugin(MaiBotPlugin):
 
     async def _shutdown_kernel(self) -> None:
         """等待内核后台任务退出并释放资源，成功后再清除实例引用。"""
-        if self._kernel is None:
-            return
-        try:
-            await self._kernel.shutdown()
-        except Exception as exc:
-            self._kernel_shutdown_error = str(exc)
-            raise
-        else:
-            self._kernel = None
-            self._kernel_shutdown_error = ""
+        async with self._kernel_lock:
+            if self._kernel is None:
+                return
+            try:
+                await self._kernel.shutdown()
+            except Exception as exc:
+                self._kernel_shutdown_error = str(exc)
+                raise
+            else:
+                self._kernel = None
+                self._kernel_shutdown_error = ""
 
     async def on_load(self):
         await self._get_kernel()
@@ -67,15 +71,16 @@ class AMemorixPlugin(MaiBotPlugin):
             await self._shutdown_kernel()
 
     async def _get_kernel(self) -> SDKMemoryKernel:
-        if self._kernel_shutdown_error:
-            raise RuntimeError(
-                f"A_Memorix 上次停机未完成，拒绝复用旧内核: {self._kernel_shutdown_error}"
-            )
-        if self._kernel is None:
-            kernel = SDKMemoryKernel(plugin_root=self._plugin_root, config=self._plugin_config)
-            await kernel.initialize()
-            self._kernel = kernel
-        return self._kernel
+        async with self._kernel_lock:
+            if self._kernel_shutdown_error:
+                raise RuntimeError(
+                    f"A_Memorix 上次停机未完成，拒绝复用旧内核: {self._kernel_shutdown_error}"
+                )
+            if self._kernel is None:
+                kernel = SDKMemoryKernel(plugin_root=self._plugin_root, config=self._plugin_config)
+                await kernel.initialize()
+                self._kernel = kernel
+            return self._kernel
 
     async def _dispatch_admin_tool(self, method_name: str, action: str, **kwargs):
         kernel = await self._get_kernel()

--- a/src/A_memorix/scripts/process_knowledge.py
+++ b/src/A_memorix/scripts/process_knowledge.py
@@ -728,7 +728,8 @@ Chat paragraph:
                     await self._add_entity_with_vector(s, source_paragraph=h_val)
                     await self._add_entity_with_vector(o, source_paragraph=h_val)
 
-                    confidence = float(rel.get("confidence", 1.0) or 1.0) if isinstance(rel, dict) else 1.0
+                    confidence_value = rel.get("confidence", 1.0) if isinstance(rel, dict) else 1.0
+                    confidence = float(1.0 if confidence_value is None else confidence_value)
                     rel_meta = rel.get("metadata", {}) if isinstance(rel, dict) else {}
                     write_vector = self._should_write_relation_vectors()
                     if self.relation_write_service is not None:
@@ -751,7 +752,6 @@ Chat paragraph:
                             metadata=rel_meta if isinstance(rel_meta, dict) else {},
                         )
                         self.graph_store.add_edges([(s, o)], relation_hashes=[rel_hash])
-                        self.metadata_store.set_relation_vector_state(rel_hash, "none")
 
                 if progress_callback:
                     progress_callback(1)
@@ -775,11 +775,8 @@ Chat paragraph:
                 await self._add_entity_with_vector(subject)
                 await self._add_entity_with_vector(obj)
 
-                confidence = (
-                    float(raw_relation.get("confidence", 1.0) or 1.0)
-                    if isinstance(raw_relation, dict)
-                    else 1.0
-                )
+                confidence_value = raw_relation.get("confidence", 1.0) if isinstance(raw_relation, dict) else 1.0
+                confidence = float(1.0 if confidence_value is None else confidence_value)
                 rel_meta = raw_relation.get("metadata", {}) if isinstance(raw_relation, dict) else {}
                 write_vector = self._should_write_relation_vectors()
                 if self.relation_write_service is not None:
@@ -802,7 +799,6 @@ Chat paragraph:
                         metadata=rel_meta if isinstance(rel_meta, dict) else {},
                     )
                     self.graph_store.add_edges([(subject, obj)], relation_hashes=[rel_hash])
-                    self.metadata_store.set_relation_vector_state(rel_hash, "none")
 
         if warning_count > 0:
             logger.warning(f"脚本导入完成，跳过异常项 {warning_count} 条")

--- a/src/A_memorix/scripts/release_vnext_migrate.py
+++ b/src/A_memorix/scripts/release_vnext_migrate.py
@@ -191,7 +191,9 @@ def _graph_edge_hash_map_size(data_dir: Path) -> int:
         try:
             if _sqlite_table_exists(conn, "graph_edge_relation_map"):
                 row = conn.execute("SELECT COUNT(*) FROM graph_edge_relation_map").fetchone()
-                return int(row[0] or 0) if row else 0
+                sqlite_count = int(row[0] or 0) if row else 0
+                if sqlite_count > 0:
+                    return sqlite_count
         finally:
             conn.close()
 

--- a/src/learners/behavior_learner.py
+++ b/src/learners/behavior_learner.py
@@ -960,7 +960,11 @@ class BehaviorLearner:
                 for candidate, matched_segment, candidate_scene_start in write_plans
             ],
         )
-        for (candidate, matched_segment, candidate_scene_start), write_result in zip(write_plans, write_results):
+        for (candidate, matched_segment, candidate_scene_start), write_result in zip(
+            write_plans,
+            write_results,
+            strict=True,
+        ):
             if write_result.path is None:
                 skipped_reason = write_result.skipped_reason or "未知原因"
                 if write_result.skipped_reason:

--- a/src/learners/behavior_learner.py
+++ b/src/learners/behavior_learner.py
@@ -963,7 +963,7 @@ class BehaviorLearner:
         for (candidate, matched_segment, candidate_scene_start), write_result in zip(
             write_plans,
             write_results,
-            strict=True,
+            strict=False,
         ):
             if write_result.path is None:
                 skipped_reason = write_result.skipped_reason or "未知原因"

--- a/src/maisaka/chat_loop_service.py
+++ b/src/maisaka/chat_loop_service.py
@@ -31,7 +31,6 @@ from src.plugin_runtime.hook_schema_utils import build_object_schema
 from src.plugin_runtime.host.hook_spec_registry import HookSpec, HookSpecRegistry
 from src.services.llm_service import LLMServiceClient
 
-from src.maisaka.attention_drift import build_attention_drift_prompt_block
 from src.maisaka.builtin_tool import get_builtin_tools
 from src.maisaka.context.history import normalize_tool_call_result_pairs
 from src.maisaka.context.messages import (


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [x] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:
7. 请简要说明本次更新的内容和目的：
图存储改为通过不可变快照和原子指针发布，修正增量缓存失效、边哈希长度不一致及 CSC 边坐标错配。
向量压缩增加双文件切换日志和中断恢复，避免向量文件与 ID 文件只完成一半切换，并允许已删除哈希重新写入。
收紧 SQLite 事务边界，确保 BaseException 也会回滚，避免 FTS 操作提交调用方持有的事务。
删除操作会先记录恢复快照；关系恢复不再使用可能触发级联删除的 INSERT OR REPLACE。
反馈任务、模糊修改和回滚操作使用带租约的原子领取，避免并发重复执行及进程中断后永久停留在 running 状态。
共享请求不再被任一等待者的取消操作连带终止；任务管理器停机失败时不会继续关闭底层存储。
修正实体重命名后的关系哈希、向量状态和段落关联，以及 Episode 异常状态、显式零值、字符串状态过滤和导入回滚结果。
将启动迁移、启动写入队列的磁盘扫描和 fsync 移出事件循环。
# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 反馈纠错/模糊修改的计划租约领取：支持在执行/回滚租约过期后自动重新领取并继续流程。
  * 图存储与向量压缩的快照式持久化与一致性校验，提升中断后的可恢复能力。
* **问题修复**
  * 强化事务与外部事务边界，避免 FTS 写入误提交/误接管；升级停机与并发初始化的可靠性。
  * 改进置信度等关键字段解析的健壮性，并修复搜索命中相关逻辑细节。
* **测试**
  * 新增并扩展租约、快照/压缩恢复、图与向量一致性、事务边界等回归用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->