### PR TITLE
fix: 将插件传入的序列化 dict 反序列化为 SessionMessage

### DIFF
--- a/src/plugin_runtime/capabilities/data.py
+++ b/src/plugin_runtime/capabilities/data.py
@@ -537,6 +537,17 @@ class RuntimeDataCapabilityMixin:
                     limit=args.get("limit", 0),
                 )
 
+            # 插件通过 get_recent 拿到的消息是序列化 dict，需要反序列化为 SessionMessage
+            if isinstance(messages, list):
+                from src.plugin_runtime.host.message_utils import PluginMessageUtils
+
+                messages = [
+                    PluginMessageUtils._build_session_message_from_dict(message)
+                    if isinstance(message, dict)
+                    else message
+                    for message in messages
+                ]
+
             readable = message_service.build_readable_messages(
                 messages=messages,
                 replace_bot_name=args.get("replace_bot_name", True),


### PR DESCRIPTION
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:
7. 请简要说明本次更新的内容和目的：_clap_message_build_readable 中，plugins 通过 get_recent 获取的 消息列表为序列化 dict，直接传入 build_readable_messages 导致 'AttributeError: dict has no attribute processed_plain_text'。 在此处增加反序列化归一化，复用已有 helper PluginMessageUtils._build_session_message_from_dict。
# 其他信息
- **关联 Issue**：Close #1910 
- **截图/GIF**：
- **附加信息**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复处理序列化消息列表时无法正确生成可读文本的问题。
  * 支持将插件获取的消息数据转换为可读消息，同时保持现有返回结构不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->