### PR TITLE
fix: 展平插件工具嵌套 metadata，使 core_tool 生效

### DIFF
--- a/pytests/plugin_runtime/test_tool_metadata_visibility.py
+++ b/pytests/plugin_runtime/test_tool_metadata_visibility.py
@@ -1,0 +1,47 @@
+"""覆盖插件工具 metadata 嵌套导致 core_tool 失效的问题。"""
+
+from src.plugin_runtime.component_query import ComponentQueryService
+from src.plugin_runtime.host.component_registry import _flatten_extension_metadata
+
+
+class _FakeToolEntry:
+    def __init__(self, metadata: dict) -> None:
+        self.metadata = metadata
+
+
+def test_flatten_extension_metadata_promotes_nested_core_tool() -> None:
+    flattened = _flatten_extension_metadata(
+        {
+            "description": "demo",
+            "handler_name": "demo_tool",
+            "metadata": {"core_tool": True},
+        }
+    )
+    assert flattened["core_tool"] is True
+    assert flattened["description"] == "demo"
+    assert "metadata" not in flattened
+
+
+def test_flatten_extension_metadata_keeps_top_level_priority() -> None:
+    flattened = _flatten_extension_metadata(
+        {
+            "core_tool": False,
+            "metadata": {"core_tool": True},
+        }
+    )
+    assert flattened["core_tool"] is False
+
+
+def test_get_tool_visibility_reads_nested_core_tool() -> None:
+    entry = _FakeToolEntry({"metadata": {"core_tool": True}})
+    assert ComponentQueryService._get_tool_visibility(entry) == "visible"
+
+
+def test_get_tool_visibility_reads_top_level_core_tool() -> None:
+    entry = _FakeToolEntry({"core_tool": True})
+    assert ComponentQueryService._get_tool_visibility(entry) == "visible"
+
+
+def test_get_tool_visibility_defaults_to_deferred() -> None:
+    entry = _FakeToolEntry({})
+    assert ComponentQueryService._get_tool_visibility(entry) == "deferred"

--- a/src/plugin_runtime/component_query.py
+++ b/src/plugin_runtime/component_query.py
@@ -267,13 +267,26 @@ class ComponentQueryService:
         )
 
     @staticmethod
+    def _read_tool_metadata_value(entry: "ToolEntry", key: str) -> Any:
+        """读取工具元数据，兼容 SDK 嵌套在 `metadata.metadata` 下的扩展字段。"""
+
+        if key in entry.metadata:
+            return entry.metadata.get(key)
+        nested = entry.metadata.get("metadata")
+        if isinstance(nested, dict) and key in nested:
+            return nested.get(key)
+        return None
+
+    @staticmethod
     def _get_tool_visibility(entry: "ToolEntry") -> str:
         """读取插件工具面向 LLM 的可见性声明。"""
 
-        raw_visibility = str(entry.metadata.get("visibility") or "").strip().lower()
+        raw_visibility = str(
+            ComponentQueryService._read_tool_metadata_value(entry, "visibility") or ""
+        ).strip().lower()
         if raw_visibility in {"visible", "deferred", "hidden"}:
             return raw_visibility
-        if bool(entry.metadata.get("core_tool", False)):
+        if bool(ComponentQueryService._read_tool_metadata_value(entry, "core_tool")):
             return "visible"
         return "deferred"
 

--- a/src/plugin_runtime/host/component_registry.py
+++ b/src/plugin_runtime/host/component_registry.py
@@ -72,6 +72,23 @@ def _normalize_chat_scope(raw_value: Any) -> ComponentChatScope:
     return "all"
 
 
+def _flatten_extension_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """将 SDK `model_dump` 产生的嵌套 `metadata` 提升到顶层。
+
+    maibot-plugin-sdk 序列化组件信息时，会把 `core_tool` 等扩展字段放在
+    `metadata["metadata"]` 下。若不展平，宿主只读顶层时这些声明会失效。
+    """
+
+    normalized = dict(metadata)
+    nested = normalized.pop("metadata", None)
+    if not isinstance(nested, dict):
+        return normalized
+    for key, value in nested.items():
+        if key not in normalized:
+            normalized[key] = value
+    return normalized
+
+
 class StatusDict(TypedDict):
     total: int
     action: int
@@ -669,7 +686,7 @@ class ComponentRegistry:
 
         try:
             normalized_type = self._normalize_component_type(component_type)
-            normalized_metadata = dict(metadata)
+            normalized_metadata = _flatten_extension_metadata(dict(metadata))
             if normalized_type == ComponentTypes.ACTION:
                 normalized_metadata = self._convert_action_metadata_to_tool_metadata(name, normalized_metadata)
                 component = ToolEntry(


### PR DESCRIPTION
## Summary
- 修复 SDK `model_dump` 把 `core_tool` 嵌套在 `metadata.metadata` 下导致宿主读取失败的问题
- 组件注册时展平扩展 metadata；查询可见性时兼容嵌套路径
- 补充针对 #1901 的单元测试

## Test plan
- [ ] 注册带 `@Tool(core_tool=True)` 的插件工具
- [ ] 确认该工具在 Planner 中可见性为 `visible`，无需先 `tool_search`
- [ ] 运行 `pytests/plugin_runtime/test_tool_metadata_visibility.py`

Closes #1901