### PR TITLE
fix: 新版 streamable_http 客户端注入 Accept 头

### DIFF
--- a/src/mcp_module/connection.py
+++ b/src/mcp_module/connection.py
@@ -219,7 +219,13 @@ class MCPConnection:
                 )
             )
         else:
-            self._http_client = await self._exit_stack.enter_async_context(self._build_http_client())
+            # 新版 streamable_http_client 不再接收 headers 参数，必须通过 httpx 客户端注入。
+            # ModelScope 等服务要求 Accept 同时包含 application/json 与 text/event-stream。
+            self._http_client = await self._exit_stack.enter_async_context(
+                self._build_http_client(
+                    headers={"Accept": "application/json, text/event-stream"},
+                )
+            )
             read_stream, write_stream, session_id_getter = await self._exit_stack.enter_async_context(
                 streamable_http_client(
                     url=self.config.url,


### PR DESCRIPTION
## Summary
- 新版 `streamable_http_client` 不再接收 `headers` 参数，改为通过 `httpx.AsyncClient` 注入
- 为 ModelScope 等服务补齐 `Accept: application/json, text/event-stream`，避免 406

## Test plan
- [ ] 使用 `streamable_http` 连接 ModelScope 托管 MCP
- [ ] 确认不再出现 Accept/Content-Type 相关 406
- [ ] 确认配置中的 Authorization 等自定义头仍生效

Closes #1894