### PR TITLE
fix(gemini): 修复空 contents/parts 与并行工具回复合并

### DIFF
--- a/src/llm_models/model_client/gemini_client.py
+++ b/src/llm_models/model_client/gemini_client.py
@@ -278,6 +278,14 @@ def _extract_response_json_schema(response_format: RespFormat) -> Dict[str, obje
     return cast(Dict[str, object], schema_payload)
 
 
+def _append_content_if_non_empty(contents: List[ContentUnion], content: Content) -> None:
+    """仅在 Content 含有有效 parts 时追加，避免 Gemini 因空 parts 报错。"""
+    if content.parts:
+        contents.append(content)
+    else:
+        logger.debug("跳过 parts 为空的 Gemini Content（role=%s）", content.role)
+
+
 def _convert_messages(messages: List[Message]) -> Tuple[ContentListUnion, str | None]:
     """将内部统一消息列表转换为 Gemini 内容结构。
 
@@ -288,7 +296,7 @@ def _convert_messages(messages: List[Message]) -> Tuple[ContentListUnion, str | 
         Tuple[ContentListUnion, str | None]: `contents` 与可选的 `system_instruction`。
 
     Raises:
-        ValueError: 当消息结构无法映射到 Gemini 内容模型时抛出。
+        ValueError: 当消息结构无法映射到 Gemini 内容模型，或有效对话内容为空时抛出。
     """
     contents: List[ContentUnion] = []
     system_instruction_chunks: List[str] = []
@@ -303,7 +311,10 @@ def _convert_messages(messages: List[Message]) -> Tuple[ContentListUnion, str | 
             continue
 
         if message.role == RoleType.User:
-            contents.append(Content(role="user", parts=_build_non_tool_parts(message)))
+            _append_content_if_non_empty(
+                contents,
+                Content(role="user", parts=_build_non_tool_parts(message)),
+            )
             continue
 
         if message.role == RoleType.Assistant:
@@ -317,7 +328,10 @@ def _convert_messages(messages: List[Message]) -> Tuple[ContentListUnion, str | 
                         )
                     )
                     tool_name_by_call_id[tool_call.call_id] = tool_call.func_name
-            contents.append(Content(role="model", parts=assistant_parts))
+            _append_content_if_non_empty(
+                contents,
+                Content(role="model", parts=assistant_parts),
+            )
             continue
 
         if message.role == RoleType.Tool:
@@ -337,12 +351,25 @@ def _convert_messages(messages: List[Message]) -> Tuple[ContentListUnion, str | 
                     response=_normalize_function_response_payload(message),
                 )
             )
-            contents.append(Content(role="tool", parts=[function_response_part]))
+            _append_content_if_non_empty(
+                contents,
+                Content(role="tool", parts=[function_response_part]),
+            )
             continue
 
         raise ValueError(f"不支持的消息角色: {message.role}")
 
     system_instruction = "\n\n".join(chunk for chunk in system_instruction_chunks if chunk.strip()) or None
+
+    # Gemini 要求 contents 至少包含一条带 parts 的消息；仅有 system_instruction 时 API 会直接报错。
+    # 在仅有 system 消息的场景下，补一条最小 user 占位，保证请求可提交。
+    if not contents:
+        if system_instruction:
+            logger.debug("仅有 system 消息，补充最小 user 内容以满足 Gemini contents 非空要求")
+            contents.append(Content(role="user", parts=[Part.from_text(text="请根据系统指令继续。")]))
+        else:
+            raise ValueError("Gemini 请求的 contents 不能为空，至少需要一条 user/assistant/tool 消息")
+
     return contents, system_instruction
 
 

--- a/src/llm_models/model_client/gemini_client.py
+++ b/src/llm_models/model_client/gemini_client.py
@@ -301,9 +301,23 @@ def _convert_messages(messages: List[Message]) -> Tuple[ContentListUnion, str | 
     contents: List[ContentUnion] = []
     system_instruction_chunks: List[str] = []
     tool_name_by_call_id: Dict[str, str] = {}
+    # Gemini 要求同一轮并行 function call 的全部 function response 放在同一条 Content 的 parts 中；
+    # 若拆成多条 Content，会报 “number of function response parts is equal to ...”。
+    pending_tool_response_parts: List[Part] = []
+
+    def flush_pending_tool_responses() -> None:
+        nonlocal pending_tool_response_parts
+        if not pending_tool_response_parts:
+            return
+        _append_content_if_non_empty(
+            contents,
+            Content(role="tool", parts=list(pending_tool_response_parts)),
+        )
+        pending_tool_response_parts = []
 
     for message in messages:
         if message.role == RoleType.System:
+            flush_pending_tool_responses()
             system_text = message.get_text_content().strip()
             if not system_text:
                 raise ValueError("Gemini 的 system message 必须为非空文本")
@@ -311,6 +325,7 @@ def _convert_messages(messages: List[Message]) -> Tuple[ContentListUnion, str | 
             continue
 
         if message.role == RoleType.User:
+            flush_pending_tool_responses()
             _append_content_if_non_empty(
                 contents,
                 Content(role="user", parts=_build_non_tool_parts(message)),
@@ -318,6 +333,7 @@ def _convert_messages(messages: List[Message]) -> Tuple[ContentListUnion, str | 
             continue
 
         if message.role == RoleType.Assistant:
+            flush_pending_tool_responses()
             assistant_parts = _build_non_tool_parts(message)
             if message.tool_calls:
                 for tool_call_index, tool_call in enumerate(message.tool_calls):
@@ -344,21 +360,20 @@ def _convert_messages(messages: List[Message]) -> Tuple[ContentListUnion, str | 
                     "且消息中未携带 tool_name"
                 )
             tool_name_by_call_id[message.tool_call_id] = tool_name
-            function_response_part = Part(
-                function_response=FunctionResponse(
-                    id=message.tool_call_id,
-                    name=tool_name,
-                    response=_normalize_function_response_payload(message),
+            pending_tool_response_parts.append(
+                Part(
+                    function_response=FunctionResponse(
+                        id=message.tool_call_id,
+                        name=tool_name,
+                        response=_normalize_function_response_payload(message),
+                    )
                 )
-            )
-            _append_content_if_non_empty(
-                contents,
-                Content(role="tool", parts=[function_response_part]),
             )
             continue
 
         raise ValueError(f"不支持的消息角色: {message.role}")
 
+    flush_pending_tool_responses()
     system_instruction = "\n\n".join(chunk for chunk in system_instruction_chunks if chunk.strip()) or None
 
     # Gemini 要求 contents 至少包含一条带 parts 的消息；仅有 system_instruction 时 API 会直接报错。


### PR DESCRIPTION
## Summary
- 修复 Gemini _convert_messages 在仅有 system 消息时 `contents` 为空的问题（#1494）
- 跳过 `parts` 为空的 Content，避免空 parts 请求
- 将连续的 tool 结果合并为单条 Content 的多个 `functionResponse` parts，修复并行工具调用时报 `number of function response parts is equal to...`（#1617）

## Test plan
- [ ] 仅构造一条 system 消息调用 Gemini，确认不再出现 `must include at least one parts field`
- [ ] system + user 正常对话，system 仍走 `system_instruction`
- [ ] 单工具调用往返正常
- [ ] 同一轮并行调用多个工具后回传结果，确认不再 400

Fixes #1494
Fixes #1617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进 Gemini 请求内容转换，避免生成空内容片段。
  * 优化仅包含系统指令的对话处理，确保请求符合 Gemini 要求。
  * 完善无有效对话内容时的错误提示与处理逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->