### PR TITLE
fix(plugin): 兼容嵌套 metadata 中的 core_tool 可见性

### DIFF
--- a/src/plugin_runtime/component_query.py
+++ b/src/plugin_runtime/component_query.py
@@ -267,13 +267,29 @@ class ComponentQueryService:
         )
 
     @staticmethod
+    def _read_tool_metadata_value(entry: "ToolEntry", key: str, default: Any = None) -> Any:
+        """读取工具元数据字段，兼容 SDK model_dump 后的嵌套 ``metadata``。
+
+        ``@Tool(core_tool=True)`` 经 SDK ``collect_components()`` 序列化后常为
+        ``{"metadata": {"core_tool": true}, ...}``，顶层没有 ``core_tool``。
+        """
+
+        metadata = entry.metadata or {}
+        if key in metadata and metadata.get(key) is not None:
+            return metadata.get(key)
+        nested = metadata.get("metadata")
+        if isinstance(nested, dict) and key in nested and nested.get(key) is not None:
+            return nested.get(key)
+        return default
+
+    @staticmethod
     def _get_tool_visibility(entry: "ToolEntry") -> str:
         """读取插件工具面向 LLM 的可见性声明。"""
 
-        raw_visibility = str(entry.metadata.get("visibility") or "").strip().lower()
+        raw_visibility = str(ComponentQueryService._read_tool_metadata_value(entry, "visibility") or "").strip().lower()
         if raw_visibility in {"visible", "deferred", "hidden"}:
             return raw_visibility
-        if bool(entry.metadata.get("core_tool", False)):
+        if bool(ComponentQueryService._read_tool_metadata_value(entry, "core_tool", False)):
             return "visible"
         return "deferred"
 


### PR DESCRIPTION
## Summary
- 修复 `@Tool(core_tool=True)` 因 SDK `model_dump` 嵌套在 `metadata.metadata` 下，导致 `_get_tool_visibility()` 读不到、工具被当成 `deferred` 的问题（#1901）
- 读取 `core_tool` / `visibility` 时同时兼容顶层与嵌套路径

## Test plan
- [ ] 注册 `@Tool(core_tool=True)` 的插件工具，确认 planner 初始可见（无需先 `tool_search`）
- [ ] 顶层已扁平写入 `core_tool` 的旧数据仍正常
- [ ] `visibility=hidden/deferred/visible` 嵌套与顶层均可生效

Fixes #1901

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复工具元数据序列化后字段嵌套时的读取问题。
  * 改进工具可见性判断，确保 `visibility` 和核心工具标识能够被正确识别，并应用相应的默认可见性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->