### PR TITLE
fix(llm): 模型级 temperature/max_tokens 应覆盖任务配置

### DIFF
--- a/src/llm_models/utils_model.py
+++ b/src/llm_models/utils_model.py
@@ -569,6 +569,9 @@ class LLMOrchestrator:
     ) -> Optional[float]:
         """解析响应请求最终使用的温度参数。
 
+        优先级与配置说明一致：模型级 ``temperature`` / ``extra_params.temperature``
+        覆盖任务或调用方显式传入的温度；都未设置时回退到任务默认温度。
+
         Args:
             model_info: 当前模型信息。
             temperature: 调用方显式传入的温度。
@@ -576,12 +579,12 @@ class LLMOrchestrator:
         Returns:
             Optional[float]: 最终生效的温度参数。
         """
-        if temperature is not None:
-            return temperature
         if model_info.temperature is not None:
             return model_info.temperature
         if "temperature" in model_info.extra_params:
             return model_info.extra_params["temperature"]
+        if temperature is not None:
+            return temperature
         return self.model_for_task.temperature
 
     def _resolve_effective_max_tokens(
@@ -591,6 +594,9 @@ class LLMOrchestrator:
     ) -> Optional[int]:
         """解析响应请求最终使用的最大输出 token 数。
 
+        优先级与配置说明一致：模型级 ``max_tokens`` / ``extra_params.max_tokens``
+        覆盖任务或调用方显式传入的值；都未设置时回退到任务默认值。
+
         Args:
             model_info: 当前模型信息。
             max_tokens: 调用方显式传入的最大 token 数。
@@ -598,12 +604,12 @@ class LLMOrchestrator:
         Returns:
             Optional[int]: 最终生效的最大 token 数。
         """
-        if max_tokens is not None:
-            return max_tokens
         if model_info.max_tokens is not None:
             return model_info.max_tokens
         if "max_tokens" in model_info.extra_params:
             return model_info.extra_params["max_tokens"]
+        if max_tokens is not None:
+            return max_tokens
         return self.model_for_task.max_tokens
 
     def _build_response_request(


### PR DESCRIPTION
## Summary
- 修正 `_resolve_effective_temperature` / `_resolve_effective_max_tokens` 优先级，使模型级配置按文档覆盖任务/调用方参数（#1833）
- 例如 Kimi-K2.6 仅允许 `temperature=0.6`：在模型列表设置后，即使任务配置了其他温度也会使用模型级值

## Test plan
- [ ] 模型配置 `temperature=0.6`，任务侧显式传入其他温度，实际请求应为 `0.6`
- [ ] 未配置模型级温度时，仍使用调用方/任务默认温度
- [ ] `max_tokens` 同理：模型级覆盖任务级

Fixes #1833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能优化**
  * 调整模型参数的生效优先级：模型配置中的温度和最大输出长度设置将优先于调用时传入的参数。
  * 未配置模型级参数时，将依次使用扩展参数、调用方参数及任务默认值。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->