### PR TITLE
fix(plugin): build_readable 兼容 get_recent 返回的 dict

### DIFF
--- a/src/plugin_runtime/capabilities/data.py
+++ b/src/plugin_runtime/capabilities/data.py
@@ -523,7 +523,8 @@ class RuntimeDataCapabilityMixin:
             return {"success": False, "error": str(e)}
 
     async def _cap_message_build_readable(self, plugin_id: str, capability: str, args: Dict[str, Any]) -> Any:
-        from src.services import message_service 
+        from src.plugin_runtime.host.message_utils import PluginMessageUtils
+        from src.services import message_service
 
         try:
             messages = args.get("messages")
@@ -537,8 +538,16 @@ class RuntimeDataCapabilityMixin:
                     limit=args.get("limit", 0),
                 )
 
+            # get_recent 等能力返回的是序列化 dict；build_readable_messages 需要 SessionMessage。
+            normalized_messages = []
+            for item in messages or []:
+                if isinstance(item, dict):
+                    normalized_messages.append(PluginMessageUtils._build_session_message_from_dict(item))
+                else:
+                    normalized_messages.append(item)
+
             readable = message_service.build_readable_messages(
-                messages=messages,
+                messages=normalized_messages,
                 replace_bot_name=args.get("replace_bot_name", True),
                 timestamp_mode=args.get("timestamp_mode", "relative"),
                 truncate=args.get("truncate", False),


### PR DESCRIPTION
## Summary
- 修复插件 `message.build_readable` 不能直接消费 `message.get_recent` 返回的 dict 列表的问题（#1910）
- 传入 dict 时先经 `PluginMessageUtils._build_session_message_from_dict` 还原为 `SessionMessage`

## Test plan
- [ ] `get_recent` → 将 `messages` 传入 `build_readable`，不再报 `processed_plain_text` AttributeError
- [ ] 直接传 `SessionMessage` 列表或 `chat_id` 查询路径仍正常

Fixes #1910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化消息内容展示：支持将已序列化的消息数据转换为可读文本。
  * 改善近期消息等场景下的消息格式兼容性，确保内容能够正常显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->