### PR TITLE
fix(maisaka): 恢复频率触发的线性消息阈值

### DIFF
--- a/src/maisaka/runtime.py
+++ b/src/maisaka/runtime.py
@@ -44,7 +44,6 @@ from src.maisaka.context.messages import (
 from src.maisaka.display.runtime_mixin import MaisakaRuntimeDisplayMixin
 from src.maisaka.display.stage_status_board import remove_stage_status, update_stage_status
 from src.maisaka.focus import MaisakaFocusRuntimeMixin, focus_mode_manager
-from src.maisaka.mode_policy import is_reply_necessity_trigger_enabled
 from src.maisaka.monitor.events import emit_message_ingested, emit_message_sent, emit_message_updated, emit_session_start
 from src.maisaka.monitor.message_payload import (
     build_monitor_message_content,
@@ -1028,12 +1027,14 @@ class MaisakaHeartFlowChatting(MaisakaFocusRuntimeMixin, MaisakaRuntimeDisplayMi
         return snapshot
 
     def _get_message_trigger_threshold(self) -> int:
-        """根据回复触发模式和频率折算出触发一轮循环所需的消息数。"""
+        """根据回复频率折算出触发一轮循环所需的消息数。
+
+        使用线性关系 ``ceil(1 / frequency)``：例如 frequency=0.1 约需 10 条消息。
+        切勿再对 frequency 做平方，否则低频率配置会被放大到几乎不触发。
+        """
         effective_frequency = min(1.0, self._get_effective_reply_frequency())
         if effective_frequency <= 0:
             return 0
-        if is_reply_necessity_trigger_enabled():
-            return max(1, int(ceil(1.0 / (effective_frequency * effective_frequency))))
         return max(1, int(ceil(1.0 / effective_frequency)))
 
     def _get_pending_message_count(self) -> int:


### PR DESCRIPTION
## Summary
- 恢复回复频率与触发消息数的线性关系 `ceil(1/frequency)`（#1892）
- 去掉必要性触发模式下对 frequency 平方导致 `0.1 → ~100 条` 的放大

## Test plan
- [ ] `talk_value=0.1` 时触发阈值约为 10 条消息
- [ ] `talk_value=1.0` 时仍约为 1 条
- [ ] 频率触发 / 必要性触发两种模式均按线性阈值计消息数

Fixes #1892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 调整消息触发阈值计算方式，使其按回复频率线性计算。
  * 当回复频率为非正数时，不再触发消息处理。
  * 提升不同回复频率设置下消息触发行为的可预测性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->