### PR TITLE
fix: 避免 embedding 探针浮动触发表达向量全量回填

### DIFF
--- a/pytests/test_expression_embedding_profile.py
+++ b/pytests/test_expression_embedding_profile.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+
+import pytest
+
+from src.chat.replyer.expression_vector_index import (
+    ExpressionVectorIndex,
+    build_embedding_profile_from_probe_results,
+)
+
+
+def _result(
+    vector: list[float],
+    *,
+    name: str = "embedding",
+    identifier: str = "vendor/model",
+    provider: str = "provider",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        embedding=list(vector),
+        model_name=name,
+        model_identifier=identifier,
+        api_provider=provider,
+    )
+
+
+def test_profile_marker_ignores_numeric_jitter() -> None:
+    baseline = [_result([0.1, 0.2]), _result([0.2, 0.3]), _result([0.3, 0.4])]
+    jittered = [
+        _result([0.1014, 0.1991]),
+        _result([0.1989, 0.3012]),
+        _result([0.2992, 0.4011]),
+    ]
+
+    baseline_profile = build_embedding_profile_from_probe_results(baseline)
+    jittered_profile = build_embedding_profile_from_probe_results(jittered)
+
+    assert baseline_profile.marker == jittered_profile.marker
+    assert baseline_profile.model_name == "embedding"
+    assert baseline_profile.model_identifier == "vendor/model"
+    assert baseline_profile.api_provider == "provider"
+    assert baseline_profile.dimension == 2
+
+
+@pytest.mark.parametrize(
+    "changed_results",
+    [
+        [_result([0.1, 0.2], name="other-name")] * 3,
+        [_result([0.1, 0.2], identifier="vendor/other")] * 3,
+        [_result([0.1, 0.2], provider="other-provider")] * 3,
+        [_result([0.1, 0.2, 0.3])] * 3,
+    ],
+)
+def test_profile_marker_changes_with_backend_identity(changed_results: list[SimpleNamespace]) -> None:
+    baseline = [_result([0.1, 0.2])] * 3
+
+    baseline_profile = build_embedding_profile_from_probe_results(baseline)
+    changed_profile = build_embedding_profile_from_probe_results(changed_results)
+
+    assert baseline_profile.marker != changed_profile.marker
+
+
+@pytest.mark.parametrize(
+    ("results", "message"),
+    [
+        (
+            [_result([0.1, 0.2]), _result([0.1, 0.2], name="other-name"), _result([0.1, 0.2])],
+            "模型不一致",
+        ),
+        (
+            [_result([0.1, 0.2]), _result([0.1, 0.2], identifier="vendor/other"), _result([0.1, 0.2])],
+            "模型标识不一致",
+        ),
+        (
+            [_result([0.1, 0.2]), _result([0.1, 0.2], provider="other-provider"), _result([0.1, 0.2])],
+            "Provider 不一致",
+        ),
+        (
+            [_result([0.1, 0.2]), _result([0.1, 0.2, 0.3]), _result([0.1, 0.2])],
+            "维度不一致",
+        ),
+    ],
+)
+def test_profile_rejects_mixed_probe_results(results: list[SimpleNamespace], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        build_embedding_profile_from_probe_results(results)
+
+
+@pytest.mark.parametrize(
+    ("attribute", "message"),
+    [
+        ("model_name", "模型不一致"),
+        ("model_identifier", "模型标识不一致"),
+        ("api_provider", "Provider 不一致"),
+    ],
+)
+def test_profile_rejects_blank_backend_identity(attribute: str, message: str) -> None:
+    results = [_result([0.1, 0.2]) for _ in range(3)]
+    setattr(results[1], attribute, "")
+
+    with pytest.raises(ValueError, match=message):
+        build_embedding_profile_from_probe_results(results)
+
+
+@pytest.mark.parametrize(
+    ("attribute", "changed_value"),
+    [
+        ("model_name", "other-name"),
+        ("model_identifier", "vendor/other"),
+        ("api_provider", "other-provider"),
+        ("embedding", [0.1, 0.2, 0.3]),
+    ],
+)
+def test_embedding_result_must_match_current_profile(attribute: str, changed_value: object) -> None:
+    profile = build_embedding_profile_from_probe_results([_result([0.1, 0.2])] * 3)
+    result = _result([0.1, 0.2])
+    setattr(result, attribute, changed_value)
+
+    with pytest.raises(ValueError, match="embedding profile 与当前标定不一致"):
+        ExpressionVectorIndex._validate_embedding_result_profile(result, profile, usage="test")

--- a/src/chat/replyer/expression_vector_index.py
+++ b/src/chat/replyer/expression_vector_index.py
@@ -25,7 +25,7 @@ VECTOR_CLUSTER_WEIGHT = 0.1
 VECTOR_LEXICAL_WEIGHT = 0.2
 VECTOR_DIVERSITY_LAMBDA = 0.85
 EMBEDDING_PROFILE_CACHE_SECONDS = 600.0
-EMBEDDING_PROFILE_VERSION = 1
+EMBEDDING_PROFILE_VERSION = 2
 LEGACY_EMBEDDING_PROFILE_MARKER = "__legacy_unmarked__"
 HISTORY_BACKFILL_BATCH_SIZE = 200
 HISTORY_BACKFILL_MIN_INTERVAL_SECONDS = 10.0
@@ -45,6 +45,8 @@ class ExpressionEmbeddingProfile:
 
     marker: str
     model_name: str
+    model_identifier: str
+    api_provider: str
     dimension: int
 
 
@@ -108,12 +110,6 @@ def expression_embedding_text(situation: str, style: str) -> str:
     return f"情景：{normalize_text(situation)}\n风格：{normalize_text(style)}"
 
 
-def _quantize_embedding_for_profile(embedding: Sequence[float]) -> List[float]:
-    """把探针向量压成稳定可 hash 的小数表示。"""
-
-    return [round(float(value), 6) for value in embedding]
-
-
 def build_embedding_profile_from_probe_results(results: Sequence[Any]) -> ExpressionEmbeddingProfile:
     """根据固定探针 embedding 结果生成当前 embedding profile。"""
 
@@ -122,10 +118,20 @@ def build_embedding_profile_from_probe_results(results: Sequence[Any]) -> Expres
             f"embedding profile 探针数量异常: results={len(results)}, probes={len(EMBEDDING_PROFILE_PROBE_TEXTS)}"
         )
 
-    model_names = {normalize_text(result.model_name) for result in results if normalize_text(result.model_name)}
-    if len(model_names) != 1:
+    model_names = {normalize_text(result.model_name) for result in results}
+    if len(model_names) != 1 or not all(model_names):
         raise ValueError(f"embedding profile 探针命中模型不一致: {sorted(model_names)}")
     model_name = next(iter(model_names))
+
+    model_identifiers = {normalize_text(result.model_identifier) for result in results}
+    if len(model_identifiers) != 1 or not all(model_identifiers):
+        raise ValueError(f"embedding profile 探针命中模型标识不一致: {sorted(model_identifiers)}")
+    model_identifier = next(iter(model_identifiers))
+
+    api_providers = {normalize_text(result.api_provider) for result in results}
+    if len(api_providers) != 1 or not all(api_providers):
+        raise ValueError(f"embedding profile 探针命中 Provider 不一致: {sorted(api_providers)}")
+    api_provider = next(iter(api_providers))
 
     dimensions = {len(result.embedding) for result in results}
     if len(dimensions) != 1:
@@ -137,17 +143,18 @@ def build_embedding_profile_from_probe_results(results: Sequence[Any]) -> Expres
     payload = {
         "version": EMBEDDING_PROFILE_VERSION,
         "model_name": model_name,
+        "model_identifier": model_identifier,
+        "api_provider": api_provider,
         "dimension": dimension,
-        "probes": [
-            {
-                "text": probe_text,
-                "embedding": _quantize_embedding_for_profile(result.embedding),
-            }
-            for probe_text, result in zip(EMBEDDING_PROFILE_PROBE_TEXTS, results, strict=True)
-        ],
     }
     marker = sha256(json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")).hexdigest()
-    return ExpressionEmbeddingProfile(marker=marker, model_name=model_name, dimension=dimension)
+    return ExpressionEmbeddingProfile(
+        marker=marker,
+        model_name=model_name,
+        model_identifier=model_identifier,
+        api_provider=api_provider,
+        dimension=dimension,
+    )
 
 
 def resolve_project_path(raw_path: str) -> Path:
@@ -269,7 +276,8 @@ class ExpressionVectorIndex:
             self._profile_cache = (time.monotonic(), profile)
             logger.info(
                 f"表达向量 embedding profile 已标定: marker={profile.marker[:12]} "
-                f"model={profile.model_name} dimension={profile.dimension}"
+                f"model={profile.model_name} identifier={profile.model_identifier} "
+                f"provider={profile.api_provider} dimension={profile.dimension}"
             )
             return profile
 
@@ -281,11 +289,21 @@ class ExpressionVectorIndex:
         usage: str,
     ) -> None:
         result_model_name = normalize_text(result.model_name)
+        result_model_identifier = normalize_text(result.model_identifier)
+        result_api_provider = normalize_text(result.api_provider)
         result_dimension = len(result.embedding)
-        if result_model_name != profile.model_name or result_dimension != profile.dimension:
+        if (
+            result_model_name != profile.model_name
+            or result_model_identifier != profile.model_identifier
+            or result_api_provider != profile.api_provider
+            or result_dimension != profile.dimension
+        ):
             raise ValueError(
                 f"{usage} embedding profile 与当前标定不一致: "
                 f"result_model={result_model_name!r}, profile_model={profile.model_name!r}, "
+                f"result_identifier={result_model_identifier!r}, "
+                f"profile_identifier={profile.model_identifier!r}, "
+                f"result_provider={result_api_provider!r}, profile_provider={profile.api_provider!r}, "
                 f"result_dimension={result_dimension}, profile_dimension={profile.dimension}"
             )
 

--- a/src/common/data_models/embedding_service_data_models.py
+++ b/src/common/data_models/embedding_service_data_models.py
@@ -12,6 +12,8 @@ class EmbeddingResult(BaseDataModel):
 
     embedding: List[float] = field(default_factory=list)
     model_name: str = field(default_factory=str)
+    model_identifier: str = field(default_factory=str)
+    api_provider: str = field(default_factory=str)
 
 
 __all__ = [

--- a/src/common/data_models/llm_service_data_models.py
+++ b/src/common/data_models/llm_service_data_models.py
@@ -185,6 +185,8 @@ class LLMEmbeddingResult(BaseDataModel):
 
     embedding: List[float] = field(default_factory=list)
     model_name: str = field(default_factory=str)
+    model_identifier: str = field(default_factory=str)
+    api_provider: str = field(default_factory=str)
 
 
 __all__ = [

--- a/src/llm_models/utils_model.py
+++ b/src/llm_models/utils_model.py
@@ -560,7 +560,12 @@ class LLMOrchestrator:
             )
         if not embedding:
             raise RuntimeError("获取embedding失败")
-        return LLMEmbeddingResult(embedding=embedding, model_name=model_info.name)
+        return LLMEmbeddingResult(
+            embedding=embedding,
+            model_name=model_info.name,
+            model_identifier=model_info.model_identifier,
+            api_provider=model_info.api_provider,
+        )
 
     def _resolve_effective_temperature(
         self,

--- a/src/services/embedding_service.py
+++ b/src/services/embedding_service.py
@@ -61,6 +61,8 @@ class EmbeddingServiceClient:
         return EmbeddingResult(
             embedding=list(raw_result.embedding),
             model_name=raw_result.model_name,
+            model_identifier=raw_result.model_identifier,
+            api_provider=raw_result.api_provider,
         )
 
     async def embed_texts(


### PR DESCRIPTION
<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`

# 请填写以下内容

1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:

   无数据库或配置结构破坏。`EMBEDDING_PROFILE_VERSION` 从 1 升至 2，升级后的首次运行会对表达向量索引执行一次受控全量重建；完成后，同一 embedding 后端的非 bit-exact 浮点输出不会再次触发重建。

7. 请简要说明本次更新的内容和目的：

   当前表达向量 profile marker 会哈希三个探针的完整浮点向量。部分托管 embedding 后端对同一输入会返回语义等价但数值略有差异的向量，导致 marker 改变，并把全部历史表达误判为需要重新生成向量。

   本次修改：

   - 将 marker 改为由 profile 版本、模型名称、实际模型标识、API Provider 和向量维度组成的稳定身份哈希；
   - 从实际执行结果向 embedding 服务层传递 `model_identifier` 和 `api_provider`；
   - 探针继续验证模型身份和维度一致性，但不再将浮点向量作为精确哈希输入；
   - 批量写入前同时校验模型名称、模型标识、Provider 和维度，避免混用不同后端；
   - 增加 16 个回归测试场景，覆盖浮点抖动、后端身份变化、混合/空身份和写入时 profile 不匹配。

# 其他信息

- **关联 Issue**：Closes #1923
- **截图/GIF**：不适用
- **附加信息**：

  验证结果：

  - `uv run --frozen pytest -q pytests/test_expression_embedding_profile.py`：16 passed；
  - 修改文件的 `ruff check`：通过；
  - Python `compileall`：通过；
  - `git diff --check`：通过；
  - 真实托管 API 重复探针 12 轮：旧算法产生 5 个 marker，本方案保持为 1 个 marker。

  本 PR 仅修复 marker 稳定性，不包含批量 embedding 请求或聚类/落盘性能优化。
