### PR TITLE
fix: Planner 人格提示词遇到第二人称 personality 会重复「是」

### DIFF
--- a/src/maisaka/chat_loop_service.py
+++ b/src/maisaka/chat_loop_service.py
@@ -626,6 +626,12 @@ class MaisakaChatLoopService:
             if not prompt_personality:
                 prompt_personality = "是人类。"
 
+            # personality 默认值与官方文档均建议使用第二人称（如「你是一个大二女大学生」），
+            # 而下方会在昵称后接「是」，直接拼接会得到「{bot_name}是你是…」这类重复「是」。
+            # 拼接前去掉开头的「你」，避免这种情况；Replyer 侧独立成行使用，不受影响。
+            if prompt_personality.startswith("你是"):
+                prompt_personality = prompt_personality[1:]
+
             if prompt_personality.startswith("是"):
                 identity_line = f"{bot_name}{prompt_personality}"
             else:


### PR DESCRIPTION
很小的一个 minor，随手提一下，改不改都行 🙂

默认 personality 是第二人称（文档也建议第二人称、示例就是「你是一个大二女大学生…」）。但 Planner 侧 `_build_personality_prompt`（src/maisaka/chat_loop_service.py）拼的是 `{昵称}是{personality}`，于是默认开箱就变成：

> 麦麦是你是一个大二女大学生…

多了个「是」，第三人称还撞第二人称。（Replyer 那边是独立成行，没这问题。）

拼接前把开头的「你」去掉就好：

    if prompt_personality.startswith("你是"):
        prompt_personality = prompt_personality[1:]

→「麦麦是一个大二女大学生…」

或者更宽泛点，直接 strip 掉开头的「你」也行，看你们取舍。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复个性化提示词生成时可能出现重复“是”的问题。
  * 优化身份描述文本拼接，避免生成不自然或重复的表达。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->