### PR TITLE
fix(maisaka): 修复跨日时间提示打断工具调用链

### DIFF
--- a/pytests/maisaka/test_chat_loop_day_boundary.py
+++ b/pytests/maisaka/test_chat_loop_day_boundary.py
@@ -1,0 +1,111 @@
+"""Maisaka Planner 跨日时间提示测试。"""
+
+from datetime import datetime
+from typing import List
+
+from src.llm_models.payload_content.message import Message, RoleType
+from src.llm_models.payload_content.tool_option import ToolCall
+from src.maisaka.chat_loop_service import MaisakaChatLoopService
+from src.maisaka.context.messages import AssistantMessage, LLMContextMessage, ReferenceMessage, ToolResultMessage
+
+
+def _build_history_messages(history: List[LLMContextMessage]) -> List[Message]:
+    """构造请求并移除固定的 system 与末尾当前时间消息。"""
+
+    service = MaisakaChatLoopService(chat_system_prompt="system")
+    messages = service._build_request_messages(
+        history,
+        enable_visual_message=False,
+        include_day_boundary_time_messages=True,
+    )
+    return messages[1:-1]
+
+
+def test_day_boundary_is_deferred_until_after_tool_result() -> None:
+    history: List[LLMContextMessage] = [
+        AssistantMessage(
+            content="调用表情工具",
+            timestamp=datetime(2026, 7, 20, 23, 59, 59),
+            tool_calls=[ToolCall(call_id="call_emoji", func_name="send_emoji", args={})],
+        ),
+        ToolResultMessage(
+            content="表情包发送成功",
+            timestamp=datetime(2026, 7, 21, 0, 0, 1),
+            tool_call_id="call_emoji",
+            tool_name="send_emoji",
+        ),
+        ReferenceMessage(
+            content="工具后的普通消息",
+            timestamp=datetime(2026, 7, 21, 0, 0, 2),
+            remaining_uses_value=None,
+        ),
+    ]
+
+    messages = _build_history_messages(history)
+
+    assert [message.role for message in messages] == [
+        RoleType.Assistant,
+        RoleType.Tool,
+        RoleType.User,
+        RoleType.User,
+    ]
+    assert messages[1].tool_call_id == "call_emoji"
+    assert messages[2].get_text_content() == "时间：2026-07-21 00:00:01"
+    assert messages[3].get_text_content() == "[参考消息]\n工具后的普通消息"
+
+
+def test_day_boundary_is_deferred_until_after_all_tool_results() -> None:
+    history: List[LLMContextMessage] = [
+        AssistantMessage(
+            content="调用多个工具",
+            timestamp=datetime(2026, 7, 20, 23, 59, 59),
+            tool_calls=[
+                ToolCall(call_id="call_first", func_name="first_tool", args={}),
+                ToolCall(call_id="call_second", func_name="second_tool", args={}),
+            ],
+        ),
+        ToolResultMessage(
+            content="第一个工具执行成功",
+            timestamp=datetime(2026, 7, 20, 23, 59, 59, 500000),
+            tool_call_id="call_first",
+            tool_name="first_tool",
+        ),
+        ToolResultMessage(
+            content="第二个工具执行成功",
+            timestamp=datetime(2026, 7, 21, 0, 0, 1),
+            tool_call_id="call_second",
+            tool_name="second_tool",
+        ),
+    ]
+
+    messages = _build_history_messages(history)
+
+    assert [message.role for message in messages] == [
+        RoleType.Assistant,
+        RoleType.Tool,
+        RoleType.Tool,
+        RoleType.User,
+    ]
+    assert [message.tool_call_id for message in messages[1:3]] == ["call_first", "call_second"]
+    assert messages[3].get_text_content() == "时间：2026-07-21 00:00:01"
+
+
+def test_day_boundary_stays_before_regular_context_message() -> None:
+    history: List[LLMContextMessage] = [
+        ReferenceMessage(
+            content="跨日前消息",
+            timestamp=datetime(2026, 7, 20, 23, 59, 59),
+            remaining_uses_value=None,
+        ),
+        ReferenceMessage(
+            content="跨日后消息",
+            timestamp=datetime(2026, 7, 21, 0, 0, 1),
+            remaining_uses_value=None,
+        ),
+    ]
+
+    messages = _build_history_messages(history)
+
+    assert [message.role for message in messages] == [RoleType.User, RoleType.User, RoleType.User]
+    assert messages[1].get_text_content() == "时间：2026-07-21 00:00:01"
+    assert messages[2].get_text_content() == "[参考消息]\n跨日后消息"

--- a/src/maisaka/chat_loop_service.py
+++ b/src/maisaka/chat_loop_service.py
@@ -667,6 +667,17 @@ class MaisakaChatLoopService:
 
         return MaisakaChatLoopService._build_time_user_message(datetime.now())
 
+    @staticmethod
+    def _append_time_user_message(messages: List[Message], timestamp: datetime) -> None:
+        """向请求消息列表追加一条时间提示。"""
+
+        messages.append(
+            MessageBuilder()
+            .set_role(RoleType.User)
+            .add_text_content(MaisakaChatLoopService._build_time_user_message(timestamp))
+            .build()
+        )
+
     def _build_group_chat_attention_block(self) -> str:
         """构建当前聊天场景下的额外注意事项块。"""
 
@@ -784,6 +795,7 @@ class MaisakaChatLoopService:
         messages.append(system_msg.build())
 
         previous_context_timestamp: datetime | None = None
+        deferred_boundary_timestamps: List[datetime] = []
         for msg in selected_history:
             llm_message = build_llm_message_from_context(
                 msg,
@@ -792,21 +804,27 @@ class MaisakaChatLoopService:
             if llm_message is None:
                 continue
 
+            # assistant tool_calls 与其连续 tool 结果是协议原子段，跨日时间提示必须延后到整个结果段之后。
+            if llm_message.role != RoleType.Tool and deferred_boundary_timestamps:
+                for boundary_timestamp in deferred_boundary_timestamps:
+                    self._append_time_user_message(messages, boundary_timestamp)
+                deferred_boundary_timestamps.clear()
+
             if (
                 include_day_boundary_time_messages
                 and previous_context_timestamp is not None
                 and previous_context_timestamp.date() != msg.timestamp.date()
             ):
-                boundary_message = self._build_time_user_message(msg.timestamp)
-                messages.append(
-                    MessageBuilder()
-                    .set_role(RoleType.User)
-                    .add_text_content(boundary_message)
-                    .build()
-                )
+                if llm_message.role == RoleType.Tool:
+                    deferred_boundary_timestamps.append(msg.timestamp)
+                else:
+                    self._append_time_user_message(messages, msg.timestamp)
 
             messages.append(llm_message)
             previous_context_timestamp = msg.timestamp
+
+        for boundary_timestamp in deferred_boundary_timestamps:
+            self._append_time_user_message(messages, boundary_timestamp)
 
         normalized_injected_messages: List[Message] = []
         current_chat_attention = self._build_current_chat_attention_tail_message()


### PR DESCRIPTION
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
    - [ ] 本次更新类型为：功能新增
4. - [x] 本次更新是否经过测试
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:
7. 请简要说明本次更新的内容和目的：
    - 在工具调用响应跨日时，跨日提示词注入会破坏工具调用链导致请求异常，具体报错表现为: HTTP400 {'error': {'message': "An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. (insufficient tool messages following tool_calls message)", 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_request_error'}}

# 其他信息
- **关联 Issue**：Close #
- **截图/GIF**：
- **附加信息**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 优化跨日时间提示的显示时机，避免插入工具调用及结果处理流程中。
  - 当存在多个工具结果时，时间提示会在全部相关结果之后显示。
  - 对普通消息，时间提示会出现在跨日后的第一条消息之前。

- **测试**
  - 新增跨日场景测试，覆盖工具结果、多个工具结果及普通消息等情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->