### PR TITLE
fix: 将 is_at/is_mentioned 标志位传入 Planner Prompt，修复 @消息 无法识别

### DIFF
--- a/prompts/zh-CN/maisaka_chat.prompt
+++ b/prompts/zh-CN/maisaka_chat.prompt
@@ -14,6 +14,10 @@
 
 {group_chat_attention_block}
 
+在消息格式中，<message> 标签可能包含以下属性：
+- is_at="true" 表示这条消息 @ 了 {bot_name}
+- is_mentioned="true" 表示这条消息提及了 {bot_name}
+
 # Using your tools
 - 当你判断{bot_name}现在应该正式对用户发出一条可见回复时调用reply。调用后生成一条真正展示给用户的回复。你可以针对某个用户回复，也可以对所有用户回复。发言必须通过reply工具，不然用户无法看见如果要回复，把上下文关键信息加入。
 {query_memory_rule}

--- a/prompts/zh-CN/maisaka_chat_focus.prompt
+++ b/prompts/zh-CN/maisaka_chat_focus.prompt
@@ -12,6 +12,10 @@
 
 {group_chat_attention_block}
 
+在消息格式中，<message> 标签可能包含以下属性：
+- is_at="true" 表示这条消息 @ 了 {bot_name}
+- is_mentioned="true" 表示这条消息提及了 {bot_name}
+
 # Focus 模式
 当前启用了 Focus 模式。同一时间只有一个聊天处于活跃关注状态，你只在这个聊天中进行决策；请求末尾可能收到多条独立的 `<focus_chat_event>` user message，它们列出当前运行中已创建聊天触发的跨聊天事件。
 - `<focus_chat_event current_chat_id="...">` 是单个跨聊天事件；标签上的 `chat_id`、`platform`、`id`、`type` 是目标聊天的元信息。

--- a/pytests/maisaka/test_planner_messages.py
+++ b/pytests/maisaka/test_planner_messages.py
@@ -1,0 +1,90 @@
+"""Planner 消息构造工具测试。"""
+
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from src.maisaka.context.planner_messages import (
+    build_planner_prefix,
+    build_planner_user_prefix_from_session_message,
+)
+
+
+def _make_prefix(
+    *,
+    is_at: bool = False,
+    is_mentioned: bool = False,
+) -> str:
+    return build_planner_prefix(
+        timestamp=datetime(2026, 8, 5, 12, 0, 0),
+        user_name="test_user",
+        is_at=is_at,
+        is_mentioned=is_mentioned,
+        include_message_id=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("is_at", "is_mentioned", "expect_at", "expect_mentioned"),
+    [
+        (False, False, False, False),
+        (True, False, True, False),
+        (False, True, False, True),
+        (True, True, True, True),
+    ],
+)
+def test_build_planner_prefix_is_at_mentioned(
+    is_at: bool,
+    is_mentioned: bool,
+    expect_at: bool,
+    expect_mentioned: bool,
+) -> None:
+    prefix = _make_prefix(is_at=is_at, is_mentioned=is_mentioned)
+
+    assert (expect_at and 'is_at="true"' in prefix) or (not expect_at and 'is_at="true"' not in prefix)
+    assert (expect_mentioned and 'is_mentioned="true"' in prefix) or (
+        not expect_mentioned and 'is_mentioned="true"' not in prefix
+    )
+
+
+def test_build_planner_user_prefix_from_session_message_passthrough() -> None:
+    """验证 build_planner_user_prefix_from_session_message 正确透传 is_at/is_mentioned。"""
+
+    def _make_msg(is_at: bool, is_mentioned: bool) -> SimpleNamespace:
+        return SimpleNamespace(
+            timestamp=datetime(2026, 8, 5, 12, 0, 0),
+            message_id="msg_001",
+            session_id="session_001",
+            is_notify=False,
+            is_at=is_at,
+            is_mentioned=is_mentioned,
+            message_info=SimpleNamespace(
+                user_info=SimpleNamespace(
+                    user_id="user_001",
+                    user_nickname="test_user",
+                    user_cardname="",
+                ),
+            ),
+            raw_message=SimpleNamespace(components=[]),
+        )
+
+    msg_both = _make_msg(is_at=True, is_mentioned=True)
+    prefix = build_planner_user_prefix_from_session_message(msg_both)
+    assert 'is_at="true"' in prefix
+    assert 'is_mentioned="true"' in prefix
+
+    msg_neither = _make_msg(is_at=False, is_mentioned=False)
+    prefix = build_planner_user_prefix_from_session_message(msg_neither)
+    assert 'is_at="true"' not in prefix
+    assert 'is_mentioned="true"' not in prefix
+
+    msg_at_only = _make_msg(is_at=True, is_mentioned=False)
+    prefix = build_planner_user_prefix_from_session_message(msg_at_only)
+    assert 'is_at="true"' in prefix
+    assert 'is_mentioned="true"' not in prefix
+
+    msg_mentioned_only = _make_msg(is_at=False, is_mentioned=True)
+    prefix = build_planner_user_prefix_from_session_message(msg_mentioned_only)
+    assert 'is_at="true"' not in prefix
+    assert 'is_mentioned="true"' in prefix

--- a/src/maisaka/context/planner_messages.py
+++ b/src/maisaka/context/planner_messages.py
@@ -26,6 +26,8 @@ def build_planner_prefix(
     include_message_id: bool = True,
     include_chat_id: bool = False,
     is_self_message: bool = False,
+    is_at: bool = False,
+    is_mentioned: bool = False,
 ) -> str:
     """构造 Maisaka 规划器使用的统一消息前缀。
 
@@ -36,9 +38,11 @@ def build_planner_prefix(
         message_id: 消息 ID。
         chat_id: 聊天流 ID。
         quote_ids: 被引用消息 ID 列表。
-        include_message_id: 是否输出 `msg_id` 段。
-        include_chat_id: 是否输出 `chat_id` 段。
+        include_message_id: 是否输出 ``msg_id`` 段。
+        include_chat_id: 是否输出 ``chat_id`` 段。
         is_self_message: 是否显式标注这条消息是 bot 自己发送的。
+        is_at: 是否显式标注这条消息 @ 了 bot。
+        is_mentioned: 是否显式标注这条消息提及了 bot。
 
     Returns:
         str: 拼接完成的规划器前缀。
@@ -69,6 +73,10 @@ def build_planner_prefix(
         message_attrs.append(f'group_card="{escape(normalized_group_card, quote=True)}"')
     if is_self_message:
         message_attrs.append('is_self_message="true"')
+    if is_at:
+        message_attrs.append('is_at="true"')
+    if is_mentioned:
+        message_attrs.append('is_mentioned="true"')
     return f"<message {' '.join(message_attrs)}>\n"
 
 
@@ -117,8 +125,8 @@ def build_planner_user_prefix_from_session_message(
 
     Args:
         message: 原始会话消息。
-        include_message_id: 是否输出 `msg_id` 段。
-        include_chat_id: 是否输出 `chat_id` 段。
+        include_message_id: 是否输出 ``msg_id`` 段。
+        include_chat_id: 是否输出 ``chat_id`` 段。
         is_self_message: 是否显式标注这条消息是 bot 自己发送的。
 
     Returns:
@@ -137,6 +145,8 @@ def build_planner_user_prefix_from_session_message(
         include_message_id=include_message_id and not message.is_notify and bool(message.message_id),
         include_chat_id=include_chat_id,
         is_self_message=is_self_message,
+        is_at=message.is_at,
+        is_mentioned=message.is_mentioned,
     )
 
 

--- a/src/maisaka/context/planner_messages.py
+++ b/src/maisaka/context/planner_messages.py
@@ -74,9 +74,9 @@ def build_planner_prefix(
     if is_self_message:
         message_attrs.append('is_self_message="true"')
     if is_at:
-        message_attrs.append('is_at="true"')
+        message_attrs.append("is_at=\"true\"")
     if is_mentioned:
-        message_attrs.append('is_mentioned="true"')
+        message_attrs.append("is_mentioned=\"true\"")
     return f"<message {' '.join(message_attrs)}>\n"
 
 


### PR DESCRIPTION
在 build_planner_prefix 新增 is_at/is_mentioned 参数并写入 <message> 标签，同步更新 zh-CN prompt 模板的属性说明；en-US/ja-JP 等待 Crowdin 回流。

<!-- 提交前必读 -->
- ✅ 接受：与main直接相关的Bug修复：提交到dev分支
- 新增功能类pr需要经过issue提前讨论，否则不会被合并
- 🌐 i18n 提醒：除 bootstrap 或紧急修复外，请不要把非 `zh-CN` 目标翻译作为常规 GitHub 编辑面；常规翻译以 Crowdin -> `l10n_*` PR 回流为准，详见 `docs/i18n.md`
    
# 请填写以下内容
（删除掉中括号内的空格，并替换为**小写的x**）
1. - [x] `main` 分支 **禁止修改**，请确认本次提交的分支 **不是 `main` 分支**
2. - [x] 我确认我阅读了贡献指南
3. - [x] 本次更新类型为：BUG修复
   - [ ] 本次更新类型为：功能新增
4. - [ ] 本次更新是否经过测试
    （说明：AST 级逻辑验证通过，未跑完整 pytest 及部署测试）
5. - [ ] 如果本次修改涉及 `src/A_memorix`，我确认已阅读 `src/A_memorix/MODIFICATION_POLICY.md`，不涉及则无需勾选
6. 请填写破坏性更新的具体内容（如有）:
7. 请简要说明本次更新的内容和目的：

    适配器已正确检测 @ 消息（is_at=True），但该标志位未传入 LLM Prompt，
    导致 Planner 只能靠文本推理判断是否被 @，群名片/昵称与系统 bot 名称不一致时会误判"未被提及"从而不回复。
    
    本次在 build_planner_prefix 新增 is_at/is_mentioned 参数，写入 <message> 标签，
    并同步更新 zh-CN prompt 模板说明；en-US/ja-JP 由 Crowdin 回流，不在此 PR 中修改。

# 其他信息
- **关联 Issue**：Close #1969
- **截图/GIF**：
- **附加信息**：

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 聊天分析现可识别消息是否 @ 机器人或提及机器人。
  * 相关互动状态会被准确传递，帮助分析结果更完整地理解消息关系。
  * 更新消息格式说明，提升对 @ 和提及场景的识别准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->