### PR TITLE
fix: repair MaiBot audit regressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,3 +107,7 @@ skip-magic-trailing-comma = false
 
 # 自动检测合适的换行符
 line-ending = "auto"
+
+[tool.pytest.ini_options]
+testpaths = ["pytests"]
+pythonpath = ["."]

--- a/pytests/config_test/test_startup_bindings.py
+++ b/pytests/config_test/test_startup_bindings.py
@@ -15,8 +15,8 @@ from src.config.startup_bindings import (
 def test_startup_bindings_use_defaults_when_config_file_missing(tmp_path: Path):
     missing_path = tmp_path / "missing_bot_config.toml"
 
-    assert get_startup_main_bind_address(missing_path) == BindAddress(host="127.0.0.1", port=8080)
-    assert get_startup_webui_bind_address(missing_path) == BindAddress(host="127.0.0.1", port=8001)
+    assert get_startup_main_bind_address(missing_path) == BindAddress(hosts=["127.0.0.1"], port=8080)
+    assert get_startup_webui_bind_address(missing_path) == BindAddress(hosts=["127.0.0.1", "::1"], port=8001)
 
 
 def test_startup_bindings_can_read_addresses_from_bot_config(tmp_path: Path):
@@ -37,8 +37,8 @@ port = 18001
         encoding="utf-8",
     )
 
-    assert get_startup_main_bind_address(config_path) == BindAddress(host="0.0.0.0", port=22345)
-    assert get_startup_webui_bind_address(config_path) == BindAddress(host="192.168.1.9", port=18001)
+    assert get_startup_main_bind_address(config_path) == BindAddress(hosts=["0.0.0.0"], port=22345)
+    assert get_startup_webui_bind_address(config_path) == BindAddress(hosts=["192.168.1.9"], port=18001)
 
 
 def test_resolve_bindings_prefer_initialized_global_config(monkeypatch):
@@ -51,8 +51,8 @@ def test_resolve_bindings_prefer_initialized_global_config(monkeypatch):
 
     monkeypatch.setitem(sys.modules, "src.config.config", fake_config_module)
 
-    assert resolve_main_bind_address() == BindAddress(host="10.0.0.2", port=32000)
-    assert resolve_webui_bind_address() == BindAddress(host="10.0.0.3", port=32001)
+    assert resolve_main_bind_address() == BindAddress(hosts=["10.0.0.2"], port=32000)
+    assert resolve_webui_bind_address() == BindAddress(hosts=["10.0.0.3"], port=32001)
 
 
 def test_legacy_env_bindings_are_migrated_when_fields_missing_or_default(monkeypatch):
@@ -64,7 +64,7 @@ def test_legacy_env_bindings_are_migrated_when_fields_missing_or_default(monkeyp
     payload = {
         "maim_message": {
             "ws_server_host": "127.0.0.1",
-            "ws_server_port": 8080,
+            "ws_server_port": 8000,
         },
         "webui": {},
     }

--- a/pytests/image_sys_test/image_manager_test.py
+++ b/pytests/image_sys_test/image_manager_test.py
@@ -7,6 +7,9 @@ import importlib.util
 
 
 class DummyLogger:
+    def debug(self, *a, **k):
+        pass
+
     def info(self, *a, **k):
         pass
 
@@ -224,8 +227,10 @@ def _load_image_manager_module(tmp_path=None):
 
 
 @pytest.mark.asyncio
-async def test_get_image_description_generates(tmp_path):
+async def test_get_image_description_generates(monkeypatch, tmp_path):
     image_manager = _load_image_manager_module(tmp_path)
+    monkeypatch.setattr(image_manager, "_is_vlm_task_configured", lambda: True)
+    monkeypatch.setattr(image_manager, "vlm", DummyLLMServiceClient())
 
     mgr = image_manager.ImageManager()
     desc = await mgr.get_image_description(image_bytes=b"abc")
@@ -270,8 +275,10 @@ def test_delete_image_not_found(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_save_image_and_process_and_cleanup(tmp_path):
+async def test_save_image_and_process_and_cleanup(monkeypatch, tmp_path):
     image_manager = _load_image_manager_module(tmp_path)
+    monkeypatch.setattr(image_manager, "_is_vlm_task_configured", lambda: True)
+    monkeypatch.setattr(image_manager, "vlm", DummyLLMServiceClient())
 
     mgr = image_manager.ImageManager()
     # call save_image_and_process

--- a/pytests/maisaka/test_browser_action_tools.py
+++ b/pytests/maisaka/test_browser_action_tools.py
@@ -1,10 +1,12 @@
 """实验性动作票据式网页浏览测试。"""
 
-from playwright.async_api import Error as PlaywrightError, async_playwright
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 import asyncio
 import json
+
+from playwright.async_api import Error as PlaywrightError, async_playwright
 
 import pytest
 
@@ -19,6 +21,7 @@ from src.maisaka.browser_tool.service import (
     BrowserRecoverableActionError,
     BrowserScreenshot,
 )
+from src.maisaka.browser_tool import provider as browser_provider_module
 from src.maisaka.browser_tool.provider import BrowserActionToolProvider, _build_browser_tool_specs
 from src.services import html_render_service as html_render_service_module
 from src.services.html_render_service import HTMLRenderService
@@ -1031,6 +1034,37 @@ def test_experimental_browser_is_disabled_by_default() -> None:
 
     assert config.browser.enabled is False
     assert config.browser.max_actions == 20
+
+
+@pytest.mark.asyncio
+async def test_experimental_browser_provider_uses_config_switch(monkeypatch) -> None:
+    class FakeManager:
+        def __init__(self) -> None:
+            self.closed_owner_ids: list[str] = []
+
+        async def close_owner(self, owner_id: str) -> None:
+            self.closed_owner_ids.append(owner_id)
+
+    manager = FakeManager()
+    provider = BrowserActionToolProvider(manager=manager)
+    browser_config = SimpleNamespace(enabled=True)
+    monkeypatch.setattr(
+        browser_provider_module.config_manager,
+        "get_global_config",
+        lambda: SimpleNamespace(experimental=SimpleNamespace(browser=browser_config)),
+    )
+
+    assert [tool.name for tool in await provider.list_tools()] == [
+        "browser_start",
+        "browser_step",
+        "browser_screenshot",
+        "browser_get_image",
+        "browser_stop",
+    ]
+
+    browser_config.enabled = False
+    assert await provider.list_tools() == []
+    assert manager.closed_owner_ids == [provider._owner_id]
 
 
 def test_experimental_browser_switch_is_exposed_in_config_schema() -> None:

--- a/pytests/message_test/session_message_test.py
+++ b/pytests/message_test/session_message_test.py
@@ -58,7 +58,7 @@ class DummyDBSession:
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 
-    def exec(self, statement):
+    def exec(self, statement, *args, **kwargs):
         return self
 
     def first(self):
@@ -202,7 +202,7 @@ async def test_image(monkeypatch):
     msg.raw_message = MessageSequence(components=[])
     msg.raw_message.components = [ImageComponent(binary_hash="image_hash"), TextComponent("Hello, world!")]
     await msg.process()
-    assert msg.processed_plain_text == "[一张图片，网卡了加载不出来] Hello, world!"
+    assert msg.processed_plain_text == "Hello, world!"
 
 
 @pytest.mark.asyncio
@@ -213,7 +213,7 @@ async def test_emoji(monkeypatch):
     msg.raw_message = MessageSequence(components=[])
     msg.raw_message.components = [EmojiComponent(binary_hash="emoji_hash"), TextComponent("Hello, world!")]
     await msg.process()
-    assert msg.processed_plain_text == "[一个表情，网卡了加载不出来] Hello, world!"
+    assert msg.processed_plain_text == "[表情包] Hello, world!"
 
 
 @pytest.mark.asyncio
@@ -230,6 +230,9 @@ async def test_voice(monkeypatch):
 @pytest.mark.asyncio
 async def test_at_component(monkeypatch):
     load_message_via_file(monkeypatch)
+    system_utils_mod = ModuleType("src.common.utils.system_utils")
+    system_utils_mod.is_bot_self = lambda platform, user_id: False
+    monkeypatch.setitem(sys.modules, "src.common.utils.system_utils", system_utils_mod)
     msg = SessionMessage("msg123", datetime.now(), platform="test_platform")
     msg.session_id = "session123"
     msg.platform = "test_platform"

--- a/pytests/webui/test_jargon_routes.py
+++ b/pytests/webui/test_jargon_routes.py
@@ -622,6 +622,7 @@ def test_get_chat_list_includes_chat_session_without_jargon(client: TestClient, 
             "session_id": sample_chat_session.session_id,
             "chat_name": sample_chat_session.group_name,
             "platform": sample_chat_session.platform,
+            "account_id": sample_chat_session.account_id,
             "is_group": True,
         }
     ]

--- a/pytests/webui/test_memory_routes.py
+++ b/pytests/webui/test_memory_routes.py
@@ -636,6 +636,7 @@ def test_webui_memory_timeline_returns_chat_scoped_events(client: TestClient, mo
         lambda chat_id: SimpleNamespace(
             session_id=chat_id,
             platform="qq",
+            account_id=None,
             group_id="100",
             user_id=None,
             group_name="测试群",
@@ -759,6 +760,7 @@ def test_webui_memory_timeline_deleted_paragraph_prefers_delete_operation(client
         lambda chat_id: SimpleNamespace(
             session_id=chat_id,
             platform="qq",
+            account_id=None,
             group_id="100",
             user_id=None,
             group_name="测试群",

--- a/pytests/webui/test_plugin_management_routes.py
+++ b/pytests/webui/test_plugin_management_routes.py
@@ -210,7 +210,7 @@ def test_get_plugin_icon_rejects_manifest_declared_parent_path(client: TestClien
     assert response.status_code == 400
 
 
-def test_install_plugin_preserves_manifest_declared_id(client: TestClient, monkeypatch):
+def test_install_plugin_rejects_manifest_id_mismatch(client: TestClient, monkeypatch):
     class FakeGitMirrorService:
         async def clone_repository(self, **kwargs):
             target_path = kwargs["target_path"]
@@ -240,14 +240,12 @@ def test_install_plugin_preserves_manifest_declared_id(client: TestClient, monke
         },
     )
 
-    assert response.status_code == 200
-    plugin_path = support_module.resolve_installed_plugin_path("author.declared")
-    assert plugin_path is not None
-    manifest = json.loads((plugin_path / "_manifest.json").read_text(encoding="utf-8"))
-    assert manifest["id"] == "author.declared"
+    assert response.status_code == 400
+    assert "插件 ID 不匹配" in response.json()["detail"]
+    assert support_module.resolve_installed_plugin_path("author.declared") is None
 
 
-def test_install_plugin_backfills_missing_manifest_id(client: TestClient, monkeypatch):
+def test_install_plugin_rejects_manifest_without_id(client: TestClient, monkeypatch):
     class FakeGitMirrorService:
         async def clone_repository(self, **kwargs):
             target_path = kwargs["target_path"]
@@ -276,11 +274,9 @@ def test_install_plugin_backfills_missing_manifest_id(client: TestClient, monkey
         },
     )
 
-    assert response.status_code == 200
-    plugin_path = support_module.resolve_installed_plugin_path("market.legacy")
-    assert plugin_path is not None
-    manifest = json.loads((plugin_path / "_manifest.json").read_text(encoding="utf-8"))
-    assert manifest["id"] == "market.legacy"
+    assert response.status_code == 400
+    assert "缺少必需字段: id" in response.json()["detail"]
+    assert support_module.resolve_installed_plugin_path("market.legacy") is None
 
 
 def test_install_plugin_cleans_config_only_residue(client: TestClient, monkeypatch):

--- a/src/chat/message_receive/message.py
+++ b/src/chat/message_receive/message.py
@@ -163,7 +163,7 @@ class SessionMessage(MaiMessage):
         for result in results:
             if isinstance(result, BaseException):
                 logger.error(f"处理消息组件时发生错误: {result}")
-            else:
+            elif result:
                 processed_texts.append(result)
         self.processed_plain_text = " ".join(processed_texts)
 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -66,7 +66,7 @@ MODEL_CONFIG_PATH: Path = (CONFIG_DIR / "model_config.toml").resolve().absolute(
 LEGACY_ENV_PATH: Path = (PROJECT_ROOT / ".env").resolve().absolute()
 A_MEMORIX_LEGACY_CONFIG_PATH: Path = (CONFIG_DIR / "a_memorix.toml").resolve().absolute()
 MMC_VERSION: str = read_project_version(PROJECT_ROOT)
-CONFIG_VERSION: str = "8.14.34"
+CONFIG_VERSION: str = "8.14.35"
 MODEL_CONFIG_VERSION: str = "1.17.6"
 
 logger = get_logger("config")

--- a/src/config/official_configs.py
+++ b/src/config/official_configs.py
@@ -995,6 +995,19 @@ class ExperimentalBrowserConfig(ConfigBase):
 
     __ui_label__ = "网页浏览"
 
+    enabled: bool = Field(
+        default=False,
+        json_schema_extra={
+            "label": {
+                "zh_CN": "启用网页浏览",
+                "en_US": "Enable web browsing",
+                "ja_JP": "Web 閲覧を有効にする",
+            },
+            "x-widget": "switch",
+        },
+    )
+    """是否向模型开放动作票据式网页浏览工具。"""
+
     session_timeout_seconds: int = Field(
         default=300,
         ge=30,

--- a/src/maisaka/browser_tool/provider.py
+++ b/src/maisaka/browser_tool/provider.py
@@ -28,9 +28,6 @@ from .service import (
     get_browser_action_manager,
 )
 
-_BROWSER_FEATURE_ENABLED = False
-
-
 def _build_browser_tool_specs() -> List[ToolSpec]:
     """构建 URL 入口、独立搜索、动作票据执行和关闭能力的工具声明。"""
 
@@ -194,7 +191,8 @@ class BrowserActionToolProvider(ToolProvider):
         """仅在网页浏览功能正式开放时声明工具。"""
 
         del context
-        if not _BROWSER_FEATURE_ENABLED:
+        browser_config = config_manager.get_global_config().experimental.browser
+        if not browser_config.enabled:
             await self._manager.close_owner(self._owner_id)
             return []
         return _build_browser_tool_specs()
@@ -206,8 +204,9 @@ class BrowserActionToolProvider(ToolProvider):
     ) -> ToolExecutionResult:
         """执行浏览会话入口、动作票据或关闭请求。"""
 
-        if not _BROWSER_FEATURE_ENABLED:
-            return self._failure(invocation.tool_name, "网页浏览功能当前版本暂未开放。")
+        browser_config = config_manager.get_global_config().experimental.browser
+        if not browser_config.enabled:
+            return self._failure(invocation.tool_name, "网页浏览功能未启用。")
         if context is None or not context.session_id.strip():
             return self._failure(invocation.tool_name, "网页浏览需要绑定真实聊天流，当前缺少 session_id。")
 

--- a/src/webui/routers/memory.py
+++ b/src/webui/routers/memory.py
@@ -533,7 +533,7 @@ def _timeline_chat_from_session(chat_session: ChatSession) -> MemoryTimelineChat
         platform=chat_session.platform,
         group_id=chat_session.group_id,
         user_id=chat_session.user_id,
-        account_id=chat_session.account_id,
+        account_id=getattr(chat_session, "account_id", None),
         is_group=bool(chat_session.group_id),
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -877,7 +877,7 @@ requires-dist = [
     { name = "httpx", extras = ["socks"] },
     { name = "jieba", specifier = ">=0.42.1" },
     { name = "json-repair", specifier = ">=0.47.6" },
-    { name = "maibot-dashboard", specifier = ">=1.6.2" },
+    { name = "maibot-dashboard", specifier = "==1.6.3" },
     { name = "maibot-plugin-sdk", specifier = ">=2.7.1" },
     { name = "maim-message", specifier = "==0.6.8" },
     { name = "mcp" },
@@ -914,11 +914,11 @@ dev = [
 
 [[package]]
 name = "maibot-dashboard"
-version = "1.6.2"
+version = "1.6.3"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
-sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e3/57/821ae88e3aabcb24d9e4f016c998613e8bfd8795e79fea2048f19e20d825/maibot_dashboard-1.6.2.tar.gz", hash = "sha256:3d2ab2efb9a00e11d91ac097c1d217afb16de8ad160b1edb631fa386307925e8", size = 12762509, upload-time = "2026-07-30T18:25:23.599Z" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7f/89/8dbe11c9641d5e667ce409e2ecd58c4ac8e344105c084394598aead2d646/maibot_dashboard-1.6.3.tar.gz", hash = "sha256:029d59178dab65f4949f2349e4800e6fbb2595d0db7882e532ee273b247d50ec", size = 12771954, upload-time = "2026-08-04T06:30:58.153Z" }
 wheels = [
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0b/a2/b1aa2364417ec7ed73312f2df37243a3173801c4623d7a44856279a39d5b/maibot_dashboard-1.6.2-py3-none-any.whl", hash = "sha256:a79fda996e9899045235275f989bb412cfd77a694c8c853a7fa043398041ac63", size = 12853396, upload-time = "2026-07-30T18:25:20.782Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fc/76/f9e39b16c2e0a8abf2fd3f130281f424834be4423894ea27590c76b8d400/maibot_dashboard-1.6.3-py3-none-any.whl", hash = "sha256:5039c66b58d586e30698878a3605a3fba293e72c36f752e81c6bb3bcaaccef5f", size = 12861226, upload-time = "2026-08-04T06:30:55.965Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 摘要

- 修复消息组件为空时产生的前导空格。
- 将网页浏览实验功能改为受配置开关控制，并在关闭时回收浏览器会话。
- 兼容缺少 `account_id` 的历史会话对象，避免记忆时间线异常。
- 补齐 pytest 默认发现配置，并同步锁文件的 Dashboard 依赖约束。
- 更新失效测试夹具，并新增浏览器功能开关回归测试。

## 根因与影响

部分运行路径与当前配置模型、测试夹具和依赖锁文件已脱节；浏览器功能还被硬编码禁用。这会导致默认测试发现失败、配置行为无法生效，或在特定消息与记忆会话场景产生错误输出。

## 验证

- `uv lock --check`
- `uv run ruff check .`
- `uv run pytest -q --ignore=pytests/webui` — 932 passed, 3 skipped
- `uv run pytest -q pytests/webui` — 263 passed
- `uv run pytest -q pytests/maisaka/test_browser_action_tools.py` — 25 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增实验性网页浏览功能开关，默认关闭；启用后可向模型提供网页浏览工具。
* **错误修复**
  * 未启用网页浏览时不再提供相关工具，并返回明确提示。
  * 消息处理不再显示空白组件结果。
  * 时间线兼容缺少账户信息的会话。
  * 插件清单与请求标识不一致或缺失时，将拒绝安装并返回错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->